### PR TITLE
Removed result<0 gives error for [cv bias abf1 bin]

### DIFF
--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -290,10 +290,6 @@ int colvarscript::proc_bias(int argc, char const *argv[]) {
   // Subcommands for MW ABF
   if (subcmd == "bin") {
     int r = b->current_bin();
-    if (r < 0) {
-      result = "Error: calling current_bin() for bias " + b->name;
-      return COLVARSCRIPT_ERROR;
-    }
     result = cvm::to_str(r);
     return COLVARSCRIPT_OK;
   }


### PR DESCRIPTION
When the boundaries on the ABF colvar are not hard, it is common for the colvar to wander outside of the ABF bins, especially when lowerWallConstant is weak. For this reason, [cv bias abf1 bin] can return values less than one. Previously this was assumed to indicate an error.
