### PR TITLE
Allow colvarscript to process object pointers

### DIFF
--- a/namd/src/ScriptTcl.C
+++ b/namd/src/ScriptTcl.C
@@ -1380,29 +1380,32 @@ int ScriptTcl::Tcl_colvarfreq(ClientData clientData,
 }
 
 int ScriptTcl::Tcl_colvars(ClientData clientData,
-        Tcl_Interp *interp, int argc, char *argv[]) {
-  ScriptTcl *script = (ScriptTcl *)clientData;
+                           Tcl_Interp *interp,
+                           int objc,
+                           Tcl_Obj *const objv[])
+{
+  ScriptTcl *script = (ScriptTcl *) clientData;
   script->initcheck();
   colvarmodule *colvars = Node::Object()->colvars;
   if ( ! colvars ) {
     Tcl_SetResult(interp,"colvars module not active",TCL_VOLATILE);
     return TCL_ERROR;
   }
-  int retval = colvars->proxy->script->run(argc, (char const **) argv);
-  // use Tcl dynamic allocation to prevent having to copy the buffer
-  // *twice* just because Tcl is missing const qualifiers for strings
-  char *buf = Tcl_Alloc(colvars->proxy->script->result.length() + 1);
-  strncpy(buf, colvars->proxy->script->result.c_str(), colvars->proxy->script->result.length() + 1);
-  Tcl_SetResult(interp, buf, TCL_DYNAMIC);
-  // Note: sometimes Tcl 8.5 will segfault here
-  // (only on error conditions, apparently)
-  // http://sourceforge.net/p/tcl/bugs/4677/
-  // Fixed in Tcl 8.6
+  colvarscript *cvscript = colvars->proxy->script;
+  int retval = cvscript->run(objc, reinterpret_cast<unsigned char * const *>(objv));
 
-  if (retval == COLVARSCRIPT_OK && !cvm::get_error())
+  bool const no_errors = (retval == COLVARSCRIPT_OK) &&
+    (cvm::get_error() == COLVARS_OK);
+
+  Tcl_Obj *obj = Tcl_NewStringObj(cvscript->result.c_str(),
+                                  cvscript->result.length() + 1);
+  Tcl_SetObjResult(interp, obj);
+
+  if (no_errors) {
     return TCL_OK;
-  else
+  } else {
     return TCL_ERROR;
+  }
 }
 
 int ScriptTcl::Tcl_checkpoint(ClientData clientData,
@@ -2035,7 +2038,7 @@ ScriptTcl::ScriptTcl() : scriptBarrier(scriptBarrierTag) {
     (ClientData) this, (Tcl_CmdDeleteProc *) NULL);
   Tcl_CreateCommand(interp, "colvarvalue", Tcl_colvarvalue,
     (ClientData) this, (Tcl_CmdDeleteProc *) NULL);
-  Tcl_CreateCommand(interp, "cv", Tcl_colvars,
+  Tcl_CreateObjCommand(interp, "cv", Tcl_colvars,
     (ClientData) this, (Tcl_CmdDeleteProc *) NULL);
   Tcl_CreateCommand(interp, "colvarfreq", Tcl_colvarfreq,
     (ClientData) this, (Tcl_CmdDeleteProc *) NULL);

--- a/namd/src/ScriptTcl.h
+++ b/namd/src/ScriptTcl.h
@@ -95,7 +95,7 @@ private:
   static int Tcl_measure(ClientData, Tcl_Interp *, int, char **);
   static int Tcl_colvarbias(ClientData, Tcl_Interp *, int, char **);
   static int Tcl_colvarvalue(ClientData, Tcl_Interp *, int, char **);
-  static int Tcl_colvars(ClientData, Tcl_Interp *, int, char **);
+  static int Tcl_colvars(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
   static int Tcl_colvarfreq(ClientData, Tcl_Interp *, int, char **);
   static int Tcl_checkpoint(ClientData, Tcl_Interp *, int, char **);
   static int Tcl_revert(ClientData, Tcl_Interp *, int, char **);

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -955,6 +955,16 @@ int colvarproxy_namd::backup_file(char const *filename)
 }
 
 
+char const *colvarproxy_namd::script_obj_to_str(unsigned char const *obj)
+{
+#ifdef NAMD_TCL
+  return Tcl_GetString(reinterpret_cast<Tcl_Obj *>(const_cast<unsigned char *>(obj)));
+#else
+  // This is most likely not going to be executed
+  return colvarproxy::script_obj_to_str(obj);
+#endif
+}
+
 int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
 {
   if (cvm::debug())

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -955,10 +955,10 @@ int colvarproxy_namd::backup_file(char const *filename)
 }
 
 
-char const *colvarproxy_namd::script_obj_to_str(unsigned char const *obj)
+char *colvarproxy_namd::script_obj_to_str(unsigned char *obj)
 {
 #ifdef NAMD_TCL
-  return Tcl_GetString(reinterpret_cast<Tcl_Obj *>(const_cast<unsigned char *>(obj)));
+  return Tcl_GetString(reinterpret_cast<Tcl_Obj *>(obj));
 #else
   // This is most likely not going to be executed
   return colvarproxy::script_obj_to_str(obj);

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -16,7 +16,7 @@
 #include "colvarvalue.h"
 
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2017-01-09"
+#define COLVARPROXY_VERSION "2017-03-13"
 #endif
 
 // For replica exchange
@@ -214,6 +214,16 @@ public:
     return msg_len;
   }
 
+  int replica_comm_send()
+  {
+    return COLVARS_OK;
+  }
+
+  int replica_comm_async_send()
+  {
+    return COLVARS_OK;
+  }
+
   inline size_t restart_frequency()
   {
     return restart_frequency_s;
@@ -270,6 +280,8 @@ public:
   std::ostream * output_stream(std::string const &output_name);
   int close_output_stream(std::string const &output_name);
   int backup_file(char const *filename);
+
+  char const *script_obj_to_str(unsigned char const *obj);
 };
 
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -281,7 +281,7 @@ public:
   int close_output_stream(std::string const &output_name);
   int backup_file(char const *filename);
 
-  char const *script_obj_to_str(unsigned char const *obj);
+  char *script_obj_to_str(unsigned char *obj);
 };
 
 

--- a/namd/tests/interface/Common
+++ b/namd/tests/interface/Common
@@ -1,0 +1,1 @@
+../library/Common

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -134,6 +134,11 @@ protected:
 
 public:
 
+  virtual char const *script_obj_to_str(unsigned char const *obj)
+  {
+    return reinterpret_cast<char const *>(obj);
+  }
+
   // ***************** SHARED-MEMORY PARALLELIZATION *****************
 
   /// Whether threaded parallelization is available (TODO: make this a cvm::deps feature)

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -134,9 +134,9 @@ protected:
 
 public:
 
-  virtual char const *script_obj_to_str(unsigned char const *obj)
+  virtual char *script_obj_to_str(unsigned char *obj)
   {
-    return reinterpret_cast<char const *>(obj);
+    return reinterpret_cast<char *>(obj);
   }
 
   // ***************** SHARED-MEMORY PARALLELIZATION *****************

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "colvarscript.h"
+#include "colvarproxy.h"
 #include "colvardeps.h"
 
 
@@ -20,7 +21,7 @@ extern "C" {
 
   // Generic hooks; NAMD and VMD have Tcl-specific versions in the respective proxies
 
-  int run_colvarscript_command(int argc, const char **argv)
+  int run_colvarscript_command(int objc, unsigned char *const objv[])
   {
     colvarproxy *cvp = cvm::proxy;
     if (!cvp) {
@@ -30,7 +31,7 @@ extern "C" {
       cvm::error("Called run_colvarscript_command without a script object initialized.\n");
       return -1;
     }
-    return cvp->script->run(argc, argv);
+    return cvp->script->run(objc, objv);
   }
 
   const char * get_colvarscript_result()
@@ -46,30 +47,52 @@ extern "C" {
 
 
 /// Run method based on given arguments
-int colvarscript::run(int argc, char const *argv[]) {
-
-  result = "";
+int colvarscript::run(int objc, unsigned char *const objv[])
+{
+  result.clear();
 
   if (cvm::debug()) {
-    cvm::log("Called script run with " + cvm::to_str(argc) + " args");
-    for (int i = 0; i < argc; i++) { cvm::log(argv[i]); }
+    cvm::log("Called script run with " + cvm::to_str(objc) + " args:");
+    for (int i = 0; i < objc; i++) {
+      cvm::log(obj_to_str(objv[i]));
+    }
   }
 
-  if (argc < 2) {
+  if (objc < 2) {
     result = help_string();
     return COLVARS_OK;
   }
 
-  std::string cmd = argv[1];
+  std::string const cmd(obj_to_str(objv[1]));
 
   int error_code = COLVARS_OK;
 
   if (cmd == "colvar") {
-    return proc_colvar(argc-1, &(argv[1]));
+    if (objc < 3) {
+      result = "Missing parameters\n" + help_string();
+      return COLVARSCRIPT_ERROR;
+    }
+    std::string const name(obj_to_str(objv[2]));
+    colvar *cv = cvm::colvar_by_name(name);
+    if (cv == NULL) {
+      result = "Colvar not found: " + name;
+      return COLVARSCRIPT_ERROR;
+    }
+    return proc_colvar(cv, objc-1, &(objv[1]));
   }
 
   if (cmd == "bias") {
-    return proc_bias(argc-1, &(argv[1]));
+    if (objc < 3) {
+      result = "Missing parameters\n" + help_string();
+      return COLVARSCRIPT_ERROR;
+    }
+    std::string const name(obj_to_str(objv[2]));
+    colvarbias *b = cvm::bias_by_name(name);
+    if (b == NULL) {
+      result = "Bias not found: " + name;
+      return COLVARSCRIPT_ERROR;
+    }
+    return proc_bias(b, objc-1, &(objv[1]));
   }
 
   if (cmd == "version") {
@@ -95,20 +118,20 @@ int colvarscript::run(int argc, char const *argv[]) {
     error_code |= colvars->calc();
     error_code |= proxy->update_output();
     if (error_code) {
-      result += "Error updating the colvars module.\n";
+      result += "Error updating the Colvars module.\n";
     }
     return error_code;
   }
 
   if (cmd == "list") {
-    if (argc == 2) {
+    if (objc == 2) {
       for (std::vector<colvar *>::iterator cvi = colvars->colvars.begin();
            cvi != colvars->colvars.end();
            ++cvi) {
         result += (cvi == colvars->colvars.begin() ? "" : " ") + (*cvi)->name;
       }
       return COLVARS_OK;
-    } else if (argc == 3 && !strcmp(argv[2], "biases")) {
+    } else if (objc == 3 && !strcmp(obj_to_str(objv[2]), "biases")) {
       for (std::vector<colvarbias *>::iterator bi = colvars->biases.begin();
            bi != colvars->biases.end();
            ++bi) {
@@ -123,11 +146,11 @@ int colvarscript::run(int argc, char const *argv[]) {
 
   /// Parse config from file
   if (cmd == "configfile") {
-    if (argc < 3) {
+    if (objc < 3) {
       result = "Missing arguments\n" + help_string();
       return COLVARSCRIPT_ERROR;
     }
-    if (colvars->read_config_file(argv[2]) == COLVARS_OK) {
+    if (colvars->read_config_file(obj_to_str(objv[2])) == COLVARS_OK) {
       return COLVARS_OK;
     } else {
       result = "Error parsing configuration file";
@@ -137,11 +160,11 @@ int colvarscript::run(int argc, char const *argv[]) {
 
   /// Parse config from string
   if (cmd == "config") {
-    if (argc < 3) {
+    if (objc < 3) {
       result = "Missing arguments\n" + help_string();
       return COLVARSCRIPT_ERROR;
     }
-    std::string conf = argv[2];
+    std::string const conf(obj_to_str(objv[2]));
     if (colvars->read_config_string(conf) == COLVARS_OK) {
       return COLVARS_OK;
     } else {
@@ -152,11 +175,11 @@ int colvarscript::run(int argc, char const *argv[]) {
 
   /// Load an input state file
   if (cmd == "load") {
-    if (argc < 3) {
+    if (objc < 3) {
       result = "Missing arguments\n" + help_string();
       return COLVARSCRIPT_ERROR;
     }
-    proxy->input_prefix() = argv[2];
+    proxy->input_prefix() = obj_to_str(objv[2]);
     if (colvars->setup_input() == COLVARS_OK) {
       return COLVARS_OK;
     } else {
@@ -167,11 +190,11 @@ int colvarscript::run(int argc, char const *argv[]) {
 
   /// Save to an output state file
   if (cmd == "save") {
-    if (argc < 3) {
+    if (objc < 3) {
       result = "Missing arguments";
       return COLVARSCRIPT_ERROR;
     }
-    proxy->output_prefix_str = argv[2];
+    proxy->output_prefix_str = obj_to_str(objv[2]);
     int error = 0;
     error |= colvars->setup_output();
     error |= colvars->write_output_files();
@@ -193,7 +216,7 @@ int colvarscript::run(int argc, char const *argv[]) {
   }
 
   if (cmd == "frame") {
-    if (argc == 2) {
+    if (objc == 2) {
       long int f;
       int error = proxy->get_frame(f);
       if (error == COLVARS_OK) {
@@ -203,10 +226,10 @@ int colvarscript::run(int argc, char const *argv[]) {
         result = "Frame number is not available";
         return COLVARSCRIPT_ERROR;
       }
-    } else if (argc == 3) {
+    } else if (objc == 3) {
       // Failure of this function does not trigger an error, but
       // returns nonzero, to let scripts detect available frames
-      int error = proxy->set_frame(strtol(argv[2], NULL, 10));
+      int error = proxy->set_frame(strtol(obj_to_str(objv[2]), NULL, 10));
       result = cvm::to_str(error == COLVARS_OK ? 0 : -1);
       return COLVARS_OK;
     } else {
@@ -216,8 +239,8 @@ int colvarscript::run(int argc, char const *argv[]) {
   }
 
   if (cmd == "addenergy") {
-    if (argc == 3) {
-      colvars->total_bias_energy += strtod(argv[2], NULL);
+    if (objc == 3) {
+      colvars->total_bias_energy += strtod(obj_to_str(objv[2]), NULL);
       return COLVARS_OK;
     } else {
       result = "Wrong arguments to command \"addenergy\"\n" + help_string();
@@ -230,19 +253,9 @@ int colvarscript::run(int argc, char const *argv[]) {
 }
 
 
-int colvarscript::proc_colvar(int argc, char const *argv[]) {
-  if (argc < 3) {
-    result = "Missing parameters\n" + help_string();
-    return COLVARSCRIPT_ERROR;
-  }
+int colvarscript::proc_colvar(colvar *cv, int objc, unsigned char *const objv[]) {
 
-  std::string name = argv[1];
-  colvar *cv = cvm::colvar_by_name(name);
-  if (cv == NULL) {
-    result = "Colvar not found: " + name;
-    return COLVARSCRIPT_ERROR;
-  }
-  std::string subcmd = argv[2];
+  std::string const subcmd(obj_to_str(objv[2]));
 
   if (subcmd == "value") {
     result = (cv->value()).to_simple_string();
@@ -301,11 +314,11 @@ int colvarscript::proc_colvar(int argc, char const *argv[]) {
   }
 
   if (subcmd == "addforce") {
-    if (argc < 4) {
+    if (objc < 4) {
       result = "addforce: missing parameter: force value\n" + help_string();
       return COLVARSCRIPT_ERROR;
     }
-    std::string f_str = argv[3];
+    std::string const f_str(obj_to_str(objv[3]));
     std::istringstream is(f_str);
     is.width(cvm::cv_width);
     is.precision(cvm::cv_prec);
@@ -321,11 +334,11 @@ int colvarscript::proc_colvar(int argc, char const *argv[]) {
   }
 
   if (subcmd == "cvcflags") {
-    if (argc < 4) {
+    if (objc < 4) {
       result = "cvcflags: missing parameter: vector of flags";
       return COLVARSCRIPT_ERROR;
     }
-    std::string flags_str = argv[3];
+    std::string const flags_str(obj_to_str(objv[3]));
     std::istringstream is(flags_str);
     std::vector<bool> flags;
 
@@ -344,7 +357,7 @@ int colvarscript::proc_colvar(int argc, char const *argv[]) {
   }
 
   if ((subcmd == "get") || (subcmd == "set") || (subcmd == "state")) {
-    return proc_features(cv, argc, argv);
+    return proc_features(cv, objc, objv);
   }
 
   result = "Syntax error\n" + help_string();
@@ -352,20 +365,10 @@ int colvarscript::proc_colvar(int argc, char const *argv[]) {
 }
 
 
-int colvarscript::proc_bias(int argc, char const *argv[]) {
-  if (argc < 3) {
-    result = "Missing parameters\n" + help_string();
-    return COLVARSCRIPT_ERROR;
-  }
+int colvarscript::proc_bias(colvarbias *b, int objc, unsigned char *const objv[]) {
 
-  std::string name = argv[1];
-  colvarbias *b = cvm::bias_by_name(name);
-  if (b == NULL) {
-    result = "Bias not found: " + name;
-    return COLVARSCRIPT_ERROR;
-  }
-
-  std::string subcmd = argv[2];
+  std::string const key(obj_to_str(objv[0]));
+  std::string const subcmd(obj_to_str(objv[2]));
 
   if (subcmd == "energy") {
     result = cvm::to_str(b->get_energy());
@@ -420,11 +423,11 @@ int colvarscript::proc_bias(int argc, char const *argv[]) {
   }
 
   if ((subcmd == "get") || (subcmd == "set") || (subcmd == "state")) {
-    return proc_features(b, argc, argv);
+    return proc_features(b, objc, objv);
   }
 
-  if (argc >= 4) {
-    std::string param = argv[3];
+  if (objc >= 4) {
+    std::string const param(obj_to_str(objv[3]));
     if (subcmd == "count") {
       int index;
       if (!(std::istringstream(param) >> index)) {
@@ -445,11 +448,11 @@ int colvarscript::proc_bias(int argc, char const *argv[]) {
 
 
 int colvarscript::proc_features(colvardeps *obj,
-                                int argc, char const *argv[]) {
+                                int objc, unsigned char *const objv[]) {
   // size was already checked before calling
-  std::string subcmd = argv[2];
+  std::string const subcmd(obj_to_str(objv[2]));
 
-  if (argc == 3) {
+  if (objc == 3) {
     if (subcmd == "state") {
       // TODO make this returned as result?
       obj->print_state();
@@ -463,7 +466,7 @@ int colvarscript::proc_features(colvardeps *obj,
 
   if ((subcmd == "get") || (subcmd == "set")) {
     std::vector<colvardeps::feature *> &features = obj->features();
-    std::string const req_feature(argv[3]);
+    std::string const req_feature(obj_to_str(objv[3]));
     colvardeps::feature *f = NULL;
     int fid = 0;
     for (fid = 0; fid < int(features.size()); fid++) {
@@ -492,9 +495,9 @@ int colvarscript::proc_features(colvardeps *obj,
       }
 
       if (subcmd == "set") {
-        if (argc == 5) {
+        if (objc == 5) {
           std::string const yesno =
-            colvarparse::to_lower_cppstr(std::string(argv[4]));
+            colvarparse::to_lower_cppstr(std::string(obj_to_str(objv[4])));
           if ((yesno == std::string("yes")) ||
               (yesno == std::string("on")) ||
               (yesno == std::string("1"))) {
@@ -526,11 +529,11 @@ std::string colvarscript::help_string()
   std::string buf;
   buf = "Usage: cv <subcommand> [args...]\n\
 \n\
-Managing the colvars module:\n\
+Managing the Colvars module:\n\
   configfile <file name>      -- read configuration from a file\n\
   config <string>             -- read configuration from the given string\n\
   reset                       -- delete all internal configuration\n\
-  delete                      -- delete this colvars module instance\n\
+  delete                      -- delete this Colvars module instance\n\
   version                     -- return version of colvars code\n\
   \n\
 Input and output:\n\

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -34,22 +34,30 @@ public:
   /// If an error is returned by one of the methods, it should set this to the error message
   std::string result;
 
-  /// Run script command with given positional arguments
-  int run(int argc, char const *argv[]);
+  /// Run script command with given positional arguments (objects)
+  int run(int objc, unsigned char *const objv[]);
 
 private:
   /// Run subcommands on colvar
-  int proc_colvar(int argc, char const *argv[]);
+  int proc_colvar(colvar *cv, int argc, unsigned char *const argv[]);
 
   /// Run subcommands on bias
-  int proc_bias(int argc, char const *argv[]);
+  int proc_bias(colvarbias *b, int argc, unsigned char *const argv[]);
 
   /// Run subcommands on base colvardeps object (colvar, bias, ...)
   int proc_features(colvardeps *obj,
-                    int argc, char const *argv[]);
+                    int argc, unsigned char *const argv[]);
 
   /// Builds and return a short help
   std::string help_string(void);
+
+public:
+
+  inline char const *obj_to_str(unsigned char *const obj)
+  {
+    return cvm::proxy->script_obj_to_str(obj);
+  }
+
 };
 
 

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -377,10 +377,10 @@ void colvarproxy_vmd::add_energy(cvm::real energy)
 }
 
 
-char const *colvarproxy_vmd::script_obj_to_str(unsigned char const *obj)
+char *colvarproxy_vmd::script_obj_to_str(unsigned char *obj)
 {
-#ifdef VMDTCL // is it ever off?
-  return Tcl_GetString(reinterpret_cast<Tcl_Obj *>(const_cast<unsigned char *>(obj)));
+#ifdef VMDTCL // is TCL ever off?
+  return Tcl_GetString(reinterpret_cast<Tcl_Obj *>(obj));
 #else
   // This is most likely not going to be executed
   return colvarproxy::script_obj_to_str(obj);

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -15,12 +15,12 @@
 #include "colvaratoms.h"
 
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2017-03-14"
+#define COLVARPROXY_VERSION "2017-03-13"
 #endif
 
 
-int tcl_colvars(ClientData clientdata, Tcl_Interp *interp, int argc, const char *argv[]);
-
+int tcl_colvars(ClientData clientData, Tcl_Interp *interp,
+                int objc, Tcl_Obj *const objv[]);
 
 /// \brief Communication between colvars and VMD (implementation of
 /// \link colvarproxy \endlink)
@@ -108,6 +108,8 @@ public:
     return output_prefix_str;
   }
 
+  char *script_obj_to_str(unsigned char *obj);
+
   void add_energy(cvm::real energy);
 
 private:
@@ -136,7 +138,7 @@ public:
                           colvarvalue &value);
   int run_colvar_gradient_callback(std::string const &name,
                                    std::vector<const colvarvalue *> const &cvcs,
-                                   std::vector<cvm::matrix2d<cvm::real> > &gradient);
+                                   std::vector<colvarvalue> &gradient);
 
   int load_atoms(char const *filename,
                  cvm::atom_group &atoms,

--- a/vmd/src/tcl_commands.C
+++ b/vmd/src/tcl_commands.C
@@ -286,8 +286,8 @@ int Vmd_Init(Tcl_Interp *interp) {
 #endif
 
 #if defined(VMDCOLVARS)
-  Tcl_CreateCommand(interp, "colvars", tcl_colvars, (ClientData) app, (Tcl_CmdDeleteProc*) NULL);
-  Tcl_CreateCommand(interp, "cv", tcl_colvars, (ClientData) app, (Tcl_CmdDeleteProc*) NULL);
+  Tcl_CreateObjCommand(interp, "colvars", tcl_colvars, (ClientData) app, (Tcl_CmdDeleteProc*) NULL);
+  Tcl_CreateObjCommand(interp, "cv", tcl_colvars, (ClientData) app, (Tcl_CmdDeleteProc*) NULL);
   Tcl_PkgProvide(interp, "colvars", COLVARS_VERSION);
 #endif
 


### PR DESCRIPTION
This is partly to address potential implications of this commit (which implements part of #105), and partly to just test the Reviewer workflow of GitHub...

I changed the prototypes of the scripting API functions (and their calls from VMD and NAMD) so that they now handle pointers to byte arrays rather than C-style strings.  Immediate advantage: we don't need to const-cast the string argument `argv` any more when calling `colvarscript::run()`.

The `colvarscript` class does not return object pointers yet (only strings), but that could be allowed in the future (at least for a few uses, e.g. saving a pointer to a `colvar` object and calling `proc_colvar()` directly for that object).

Disadvantage: unless we begin tracking how the object arguments are converted to/from C strings (i.e., how the scripting API is called), this could introduce a dependency on the scripting language (at least for Tcl, where declarations of `Tcl_Obj` and related functions are needed).  Currently, I hid this dependency inside the usual "dumpster" class, `colvarproxy`: this is the simplest solution, but maybe not the most robust.