### PR TITLE
Clean up the colvarproxy API

### DIFF
--- a/doc/cv_version.tex
+++ b/doc/cv_version.tex
@@ -1,1 +1,1 @@
-\newcommand{\cvversion}{2017-06-23_proxy-streamline}
+\newcommand{\cvversion}{2017-06-26_proxy-streamline}

--- a/doc/cv_version.tex
+++ b/doc/cv_version.tex
@@ -1,1 +1,1 @@
-\newcommand{\cvversion}{2017-06-23}
+\newcommand{\cvversion}{2017-06-23_proxy-streamline}

--- a/doc/cv_version.tex
+++ b/doc/cv_version.tex
@@ -1,1 +1,1 @@
-\newcommand{\cvversion}{2017-06-26_proxy-streamline}
+\newcommand{\cvversion}{2017-06-26_proxy-cleanup}

--- a/lammps/lib/colvars/Makefile.g++
+++ b/lammps/lib/colvars/Makefile.g++
@@ -19,7 +19,7 @@ SRC = colvaratoms.cpp colvarbias_abf.cpp colvarbias_alb.cpp colvarbias.cpp  \
  colvarcomp_angles.cpp colvarcomp_coordnums.cpp colvarcomp.cpp              \
  colvarcomp_distances.cpp colvarcomp_protein.cpp colvarcomp_rotations.cpp   \
  colvardeps.cpp colvar.cpp colvargrid.cpp colvarmodule.cpp colvarparse.cpp  \
- colvarscript.cpp colvartypes.cpp colvarvalue.cpp
+ colvarproxy.cpp colvarscript.cpp colvartypes.cpp colvarvalue.cpp
 
 LIB = libcolvars.a
 OBJ = $(SRC:.cpp=.o)

--- a/lammps/lib/colvars/Makefile.mingw32-cross
+++ b/lammps/lib/colvars/Makefile.mingw32-cross
@@ -22,7 +22,7 @@ SRC = colvaratoms.cpp colvarbias_abf.cpp colvarbias_alb.cpp colvarbias.cpp  \
  colvarcomp_angles.cpp colvarcomp_coordnums.cpp colvarcomp.cpp              \
  colvarcomp_distances.cpp colvarcomp_protein.cpp colvarcomp_rotations.cpp   \
  colvardeps.cpp colvar.cpp colvargrid.cpp colvarmodule.cpp colvarparse.cpp  \
- colvarscript.cpp colvartypes.cpp colvarvalue.cpp
+ colvarproxy.cpp colvarscript.cpp colvartypes.cpp colvarvalue.cpp
 
 DIR = Obj_mingw32/
 LIB = $(DIR)libcolvars.a

--- a/lammps/lib/colvars/Makefile.mingw64-cross
+++ b/lammps/lib/colvars/Makefile.mingw64-cross
@@ -22,7 +22,7 @@ SRC = colvaratoms.cpp colvarbias_abf.cpp colvarbias_alb.cpp colvarbias.cpp  \
  colvarcomp_angles.cpp colvarcomp_coordnums.cpp colvarcomp.cpp              \
  colvarcomp_distances.cpp colvarcomp_protein.cpp colvarcomp_rotations.cpp   \
  colvardeps.cpp colvar.cpp colvargrid.cpp colvarmodule.cpp colvarparse.cpp  \
- colvarscript.cpp colvartypes.cpp colvarvalue.cpp
+ colvarproxy.cpp colvarscript.cpp colvartypes.cpp colvarvalue.cpp
 
 DIR = Obj_mingw64/
 LIB = $(DIR)libcolvars.a

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -301,10 +301,6 @@ void colvarproxy_lammps::error(std::string const &message)
 void colvarproxy_lammps::fatal_error(std::string const &message)
 {
   log(message);
-  // if (!cvm::debug())
-  //   log("If this error message is unclear, try recompiling the "
-  //        "colvars library and LAMMPS with -DCOLVARS_DEBUG.\n");
-
   _lmp->error->one(FLERR,
                    "Fatal error in the collective variables module.\n");
 }

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps_version.h
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2017-03-21"
+#define COLVARPROXY_VERSION "2017-06-26_proxy-cleanup"
 #endif

--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -5170,6 +5170,10 @@ obj/colvarparse.o: \
 	src/colvarvalue.h \
 	src/colvarparse.h
 	$(CXX) $(CXXCOLVARFLAGS) $(COPTO)obj/colvarparse.o $(COPTC) src/colvarparse.C
+obj/colvarproxy.o: \
+	obj/.exists \
+	src/colvarproxy.C
+	$(CXX) $(CXXCOLVARFLAGS) $(COPTO)obj/colvarproxy.o $(COPTC) src/colvarproxy.C
 obj/colvarproxy_namd.o: \
 	obj/.exists \
 	src/colvarproxy_namd.C \

--- a/namd/Makefile
+++ b/namd/Makefile
@@ -241,6 +241,7 @@ OBJS = \
 	$(DSTDIR)/colvargrid.o \
 	$(DSTDIR)/colvarmodule.o \
 	$(DSTDIR)/colvarparse.o \
+	$(DSTDIR)/colvarproxy.o \
 	$(DSTDIR)/colvarproxy_namd.o \
 	$(DSTDIR)/colvarscript.o \
 	$(DSTDIR)/colvartypes.o \

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -570,11 +570,8 @@ void colvarproxy_namd::error(std::string const &message)
 void colvarproxy_namd::fatal_error(std::string const &message)
 {
   log(message);
-  if (errno) log(strerror(errno));
-  // if (!cvm::debug())
-  //   log("If this error message is unclear, "
-  //       "try recompiling with -DCOLVARS_DEBUG.\n");
   if (errno) {
+    log(strerror(errno));
     NAMD_err("Error in the collective variables module");
   } else {
     NAMD_die("Error in the collective variables module: exiting.\n");

--- a/namd/src/colvarproxy_namd_version.h
+++ b/namd/src/colvarproxy_namd_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2017-06-11"
+#define COLVARPROXY_VERSION "2017-06-26_proxy-cleanup"
 #endif

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1591,12 +1591,6 @@ int colvarmodule::fatal_error(std::string const &message)
 }
 
 
-void cvm::exit(std::string const &message)
-{
-  proxy->exit(message);
-}
-
-
 int cvm::read_index_file(char const *filename)
 {
   std::ifstream is(filename, std::ios::binary);

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1583,8 +1583,6 @@ int colvarmodule::error(std::string const &message, int code)
 
 int colvarmodule::fatal_error(std::string const &message)
 {
-  // TODO once all non-fatal errors have been set to be handled by error(),
-  // set DELETE_COLVARS here for VMD to handle it
   set_error_bits(FATAL_ERROR);
   proxy->fatal_error(message);
   return get_error();

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -471,8 +471,7 @@ public:
   /// \brief Get the distance between two atomic positions with pbcs handled
   /// correctly
   static rvector position_distance(atom_pos const &pos1,
-                                    atom_pos const &pos2);
-
+                                   atom_pos const &pos2);
 
   /// \brief Get the square distance between two positions (with
   /// periodic boundary conditions handled transparently)
@@ -481,21 +480,7 @@ public:
   /// an analytical square distance (while taking the square of
   /// position_distance() would produce leads to a cusp)
   static real position_dist2(atom_pos const &pos1,
-                              atom_pos const &pos2);
-
-  /// \brief Get the closest periodic image to a reference position
-  /// \param pos The position to look for the closest periodic image
-  /// \param ref_pos (optional) The reference position
-  static void select_closest_image(atom_pos &pos,
-                                    atom_pos const &ref_pos);
-
-  /// \brief Perform select_closest_image() on a set of atomic positions
-  ///
-  /// After that, distance vectors can then be calculated directly,
-  /// without using position_distance()
-  static void select_closest_images(std::vector<atom_pos> &pos,
-                                     atom_pos const &ref_pos);
-
+                             atom_pos const &pos2);
 
   /// \brief Names of groups from a Gromacs .ndx file to be read at startup
   std::list<std::string> index_group_names;
@@ -702,18 +687,6 @@ inline int cvm::replica_comm_send(char* msg_data, int msg_len, int dest_rep) {
 inline void cvm::request_total_force()
 {
   proxy->request_total_force(true);
-}
-
-inline void cvm::select_closest_image(atom_pos &pos,
-                                       atom_pos const &ref_pos)
-{
-  proxy->select_closest_image(pos, ref_pos);
-}
-
-inline void cvm::select_closest_images(std::vector<atom_pos> &pos,
-                                        atom_pos const &ref_pos)
-{
-  proxy->select_closest_images(pos, ref_pos);
 }
 
 inline cvm::rvector cvm::position_distance(atom_pos const &pos1,

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -40,23 +40,6 @@ cvm::real colvarproxy_system::position_dist2(cvm::atom_pos const &pos1,
 }
 
 
-void colvarproxy_system::select_closest_image(cvm::atom_pos &pos,
-                                              cvm::atom_pos const &ref_pos)
-{
-  pos = position_distance(ref_pos, pos) + ref_pos;
-}
-
-
-void colvarproxy_system::select_closest_images(std::vector<cvm::atom_pos> &pos,
-                                               cvm::atom_pos const &ref_pos)
-{
-  for (std::vector<cvm::atom_pos>::iterator pi = pos.begin();
-       pi != pos.end(); ++pi) {
-    select_closest_image(*pi, ref_pos);
-  }
-}
-
-
 
 colvarproxy_atoms::colvarproxy_atoms() {}
 
@@ -67,7 +50,7 @@ colvarproxy_atoms::~colvarproxy_atoms()
 }
 
 
-int colvarproxy_atoms::reset()  
+int colvarproxy_atoms::reset()
 {
   atoms_ids.clear();
   atoms_ncopies.clear();
@@ -304,16 +287,16 @@ int colvarproxy_replicas::replica_num()
 void colvarproxy_replicas::replica_comm_barrier() {}
 
 
-int colvarproxy_replicas::replica_comm_recv(char* msg_data, 
-                                            int buf_len, 
+int colvarproxy_replicas::replica_comm_recv(char* msg_data,
+                                            int buf_len,
                                             int src_rep)
 {
   return COLVARS_NOT_IMPLEMENTED;
 }
 
 
-int colvarproxy_replicas::replica_comm_send(char* msg_data, 
-                                            int msg_len, 
+int colvarproxy_replicas::replica_comm_send(char* msg_data,
+                                            int msg_len,
                                             int dest_rep)
 {
   return COLVARS_NOT_IMPLEMENTED;
@@ -371,13 +354,13 @@ colvarproxy_io::~colvarproxy_io() {}
 
 int colvarproxy_io::get_frame(long int&)
 {
-  return COLVARS_NOT_IMPLEMENTED; 
+  return COLVARS_NOT_IMPLEMENTED;
 }
 
 
 int colvarproxy_io::set_frame(long int)
 {
-  return COLVARS_NOT_IMPLEMENTED; 
+  return COLVARS_NOT_IMPLEMENTED;
 }
 
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -1,0 +1,479 @@
+// -*- c++ -*-
+
+#include <sstream>
+#include <string.h>
+
+#include "colvarmodule.h"
+#include "colvarproxy.h"
+#include "colvarscript.h"
+#include "colvaratoms.h"
+
+
+
+colvarproxy_system::colvarproxy_system() {}
+
+
+colvarproxy_system::~colvarproxy_system() {}
+
+
+void colvarproxy_system::add_energy(cvm::real energy) {}
+
+
+void colvarproxy_system::request_total_force(bool yesno)
+{
+  if (yesno == true)
+    cvm::error("Error: total forces are currently not implemented.\n",
+               COLVARS_NOT_IMPLEMENTED);
+}
+
+
+bool colvarproxy_system::total_forces_enabled() const
+{
+  return false;
+}
+
+
+cvm::real colvarproxy_system::position_dist2(cvm::atom_pos const &pos1,
+                                             cvm::atom_pos const &pos2)
+{
+  return (position_distance(pos1, pos2)).norm2();
+}
+
+
+void colvarproxy_system::select_closest_image(cvm::atom_pos &pos,
+                                              cvm::atom_pos const &ref_pos)
+{
+  pos = position_distance(ref_pos, pos) + ref_pos;
+}
+
+
+void colvarproxy_system::select_closest_images(std::vector<cvm::atom_pos> &pos,
+                                               cvm::atom_pos const &ref_pos)
+{
+  for (std::vector<cvm::atom_pos>::iterator pi = pos.begin();
+       pi != pos.end(); ++pi) {
+    select_closest_image(*pi, ref_pos);
+  }
+}
+
+
+
+colvarproxy_atoms::colvarproxy_atoms() {}
+
+
+colvarproxy_atoms::~colvarproxy_atoms()
+{
+  reset();
+}
+
+
+int colvarproxy_atoms::reset()  
+{
+  atoms_ids.clear();
+  atoms_ncopies.clear();
+  atoms_masses.clear();
+  atoms_charges.clear();
+  atoms_positions.clear();
+  atoms_total_forces.clear();
+  atoms_new_colvar_forces.clear();
+  return COLVARS_OK;
+}
+
+
+int colvarproxy_atoms::add_atom_slot(int atom_id)
+{
+  atoms_ids.push_back(atom_id);
+  atoms_ncopies.push_back(1);
+  atoms_masses.push_back(1.0);
+  atoms_charges.push_back(0.0);
+  atoms_positions.push_back(cvm::rvector(0.0, 0.0, 0.0));
+  atoms_total_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+  atoms_new_colvar_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+  return (atoms_ids.size() - 1);
+}
+
+
+int colvarproxy_atoms::init_atom(cvm::residue_id const &residue,
+                                 std::string const     &atom_name,
+                                 std::string const     &segment_id)
+{
+  cvm::error("Error: initializing an atom by name and residue number is currently not supported.\n",
+             COLVARS_NOT_IMPLEMENTED);
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_atoms::check_atom_id(cvm::residue_id const &residue,
+                                     std::string const     &atom_name,
+                                     std::string const     &segment_id)
+{
+  colvarproxy_atoms::init_atom(residue, atom_name, segment_id);
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+void colvarproxy_atoms::clear_atom(int index)
+{
+  if (((size_t) index) >= atoms_ids.size()) {
+    cvm::error("Error: trying to disable an atom that was not previously requested.\n",
+               INPUT_ERROR);
+  }
+  if (atoms_ncopies[index] > 0) {
+    atoms_ncopies[index] -= 1;
+  }
+}
+
+
+int colvarproxy_atoms::load_atoms(char const *filename,
+                                  cvm::atom_group &atoms,
+                                  std::string const &pdb_field,
+                                  double const)
+{
+  return cvm::error("Error: loading atom identifiers from a file "
+                    "is currently not implemented.\n",
+                    COLVARS_NOT_IMPLEMENTED);
+}
+
+
+int colvarproxy_atoms::load_coords(char const *filename,
+                                   std::vector<cvm::atom_pos> &pos,
+                                   const std::vector<int> &indices,
+                                   std::string const &pdb_field,
+                                   double const)
+{
+  return cvm::error("Error: loading atomic coordinates from a file "
+                    "is currently not implemented.\n",
+                    COLVARS_NOT_IMPLEMENTED);
+}
+
+
+
+colvarproxy_atom_groups::colvarproxy_atom_groups() {}
+
+
+colvarproxy_atom_groups::~colvarproxy_atom_groups()
+{
+  reset();
+}
+
+
+int colvarproxy_atom_groups::reset()
+{
+  atom_groups_ids.clear();
+  atom_groups_ncopies.clear();
+  atom_groups_masses.clear();
+  atom_groups_charges.clear();
+  atom_groups_coms.clear();
+  atom_groups_total_forces.clear();
+  atom_groups_new_colvar_forces.clear();
+  return COLVARS_OK;
+}
+
+
+int colvarproxy_atom_groups::add_atom_group_slot(int atom_group_id)
+{
+  atom_groups_ids.push_back(atom_group_id);
+  atom_groups_ncopies.push_back(1);
+  atom_groups_masses.push_back(1.0);
+  atom_groups_charges.push_back(0.0);
+  atom_groups_coms.push_back(cvm::rvector(0.0, 0.0, 0.0));
+  atom_groups_total_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+  atom_groups_new_colvar_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+  return (atom_groups_ids.size() - 1);
+}
+
+
+int colvarproxy_atom_groups::scalable_group_coms()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_atom_groups::init_atom_group(std::vector<int> const &atoms_ids)
+{
+  cvm::error("Error: initializing a group outside of the Colvars module "
+             "is currently not supported.\n",
+             COLVARS_NOT_IMPLEMENTED);
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+void colvarproxy_atom_groups::clear_atom_group(int index)
+{
+  if (((size_t) index) >= atom_groups_ids.size()) {
+    cvm::error("Error: trying to disable an atom group "
+               "that was not previously requested.\n",
+               INPUT_ERROR);
+  }
+  if (atom_groups_ncopies[index] > 0) {
+    atom_groups_ncopies[index] -= 1;
+  }
+}
+
+
+
+colvarproxy_smp::colvarproxy_smp()
+{
+  b_smp_active = true;
+}
+
+
+colvarproxy_smp::~colvarproxy_smp() {}
+
+
+int colvarproxy_smp::smp_enabled()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_smp::smp_colvars_loop()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_smp::smp_biases_loop()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_smp::smp_biases_script_loop()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_smp::smp_thread_id()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_smp::smp_num_threads()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_smp::smp_lock()
+{
+  return COLVARS_OK;
+}
+
+
+int colvarproxy_smp::smp_trylock()
+{
+  return COLVARS_OK;
+}
+
+
+int colvarproxy_smp::smp_unlock()
+{
+  return COLVARS_OK;
+}
+
+
+
+
+colvarproxy_replicas::colvarproxy_replicas() {}
+
+
+colvarproxy_replicas::~colvarproxy_replicas() {}
+
+
+bool colvarproxy_replicas::replica_enabled()
+{
+  return false;
+}
+
+
+int colvarproxy_replicas::replica_index()
+{
+  return 0;
+}
+
+
+int colvarproxy_replicas::replica_num()
+{
+  return 1;
+}
+
+
+void colvarproxy_replicas::replica_comm_barrier() {}
+
+
+int colvarproxy_replicas::replica_comm_recv(char* msg_data, 
+                                            int buf_len, 
+                                            int src_rep)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_replicas::replica_comm_send(char* msg_data, 
+                                            int msg_len, 
+                                            int dest_rep)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+
+
+colvarproxy_script::colvarproxy_script()
+{
+  script = NULL;
+}
+
+
+colvarproxy_script::~colvarproxy_script() {}
+
+
+char *colvarproxy_script::script_obj_to_str(unsigned char *obj)
+{
+  return reinterpret_cast<char *>(obj);
+}
+
+
+int colvarproxy_script::run_force_callback()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_script::run_colvar_callback(
+      std::string const &name,
+      std::vector<const colvarvalue *> const &cvcs,
+      colvarvalue &value)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_script::run_colvar_gradient_callback(
+      std::string const &name,
+      std::vector<const colvarvalue *> const &cvcs,
+      std::vector<cvm::matrix2d<cvm::real> > &gradient)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+
+
+colvarproxy_io::colvarproxy_io() {}
+
+
+colvarproxy_io::~colvarproxy_io() {}
+
+
+int colvarproxy_io::get_frame(long int&)
+{
+  return COLVARS_NOT_IMPLEMENTED; 
+}
+
+
+int colvarproxy_io::set_frame(long int)
+{
+  return COLVARS_NOT_IMPLEMENTED; 
+}
+
+
+std::ostream * colvarproxy_io::output_stream(std::string const &output_name)
+{
+  std::list<std::ostream *>::iterator osi  = output_files.begin();
+  std::list<std::string>::iterator    osni = output_stream_names.begin();
+  for ( ; osi != output_files.end(); osi++, osni++) {
+    if (*osni == output_name) {
+      return *osi;
+    }
+  }
+  output_stream_names.push_back(output_name);
+  std::ofstream * os = new std::ofstream(output_name.c_str());
+  if (!os->is_open()) {
+    cvm::error("Error: cannot write to file/channel \""+output_name+"\".\n",
+               FILE_ERROR);
+  }
+  output_files.push_back(os);
+  return os;
+}
+
+
+int colvarproxy_io::close_output_stream(std::string const &output_name)
+{
+  std::list<std::ostream *>::iterator osi  = output_files.begin();
+  std::list<std::string>::iterator    osni = output_stream_names.begin();
+  for ( ; osi != output_files.end(); osi++, osni++) {
+    if (*osni == output_name) {
+      ((std::ofstream *) (*osi))->close();
+      output_files.erase(osi);
+      output_stream_names.erase(osni);
+      return COLVARS_OK;
+    }
+  }
+  return cvm::error("Error: trying to close an output file/channel "
+                    "that wasn't open.\n", BUG_ERROR);
+}
+
+
+int colvarproxy_io::backup_file(char const *filename)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+
+colvarproxy::colvarproxy()
+{
+  colvars = NULL;
+  b_simulation_running = true;
+}
+
+
+colvarproxy::~colvarproxy() {}
+
+
+int colvarproxy::reset()
+{
+  int error_code = COLVARS_OK;
+  error_code |= colvarproxy_atoms::reset();
+  error_code |= colvarproxy_atom_groups::reset();
+  return error_code;
+}
+
+
+int colvarproxy::setup()
+{
+  return COLVARS_OK;
+}
+
+
+int colvarproxy::update_input()
+{
+  return COLVARS_OK;
+}
+
+
+int colvarproxy::update_output()
+{
+  return COLVARS_OK;
+}
+
+
+size_t colvarproxy::restart_frequency()
+{
+  return 0;
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -29,6 +29,7 @@
 class colvarscript;
 
 
+/// Methods for accessing the simulation system (PBCs, integrator, etc)
 class colvarproxy_system {
 
 public:
@@ -39,14 +40,24 @@ public:
   /// Destructor
   virtual ~colvarproxy_system();
 
+  /// \brief Value of the unit for atomic coordinates with respect to
+  /// angstroms (used by some variables for hard-coded default values)
+  virtual cvm::real unit_angstrom() = 0;
+
+  /// \brief Boltzmann constant
+  virtual cvm::real boltzmann() = 0;
+
+  /// \brief Target temperature of the simulation (K units)
+  virtual cvm::real temperature() = 0;
+
+  /// \brief Time step of the simulation (fs)
+  virtual cvm::real dt() = 0;
+
+  /// \brief Pseudo-random number with Gaussian distribution
+  virtual cvm::real rand_gaussian(void) = 0;
+
   /// Pass restraint energy value for current timestep to MD engine
   virtual void add_energy(cvm::real energy) = 0;
-
-  /// Tell the proxy whether total forces are needed (may not always be available)
-  virtual void request_total_force(bool yesno);
-
-  /// Are total forces being used?
-  virtual bool total_forces_enabled() const;
 
   /// \brief Get the PBC-aware distance vector between two positions
   virtual cvm::rvector position_distance(cvm::atom_pos const &pos1,
@@ -57,22 +68,15 @@ public:
   virtual cvm::real position_dist2(cvm::atom_pos const &pos1,
                                    cvm::atom_pos const &pos2);
 
-  /// \brief Get the closest periodic image to a reference position
-  /// \param pos The position to look for the closest periodic image
-  /// \param ref_pos The reference position
-  virtual void select_closest_image(cvm::atom_pos &pos,
-                                    cvm::atom_pos const &ref_pos);
+  /// Tell the proxy whether total forces are needed (may not always be available)
+  virtual void request_total_force(bool yesno);
 
-  /// \brief Perform select_closest_image() on a set of atomic positions
-  ///
-  /// After that, distance vectors can then be calculated directly,
-  /// without using position_distance()
-  void select_closest_images(std::vector<cvm::atom_pos> &pos,
-                             cvm::atom_pos const &ref_pos);
+  /// Are total forces being used?
+  virtual bool total_forces_enabled() const;
 };
 
 
-/// \brief Container of atomic data for serial processing by Colvars
+/// \brief Container of atomic data for processing by Colvars
 class colvarproxy_atoms {
 
 public:
@@ -537,22 +541,6 @@ public:
 
   /// \brief Update data based from the results of a module update (e.g. send forces)
   virtual int update_output();
-
-  /// \brief Value of the unit for atomic coordinates with respect to
-  /// angstroms (used by some variables for hard-coded default values)
-  virtual cvm::real unit_angstrom() = 0;
-
-  /// \brief Boltzmann constant
-  virtual cvm::real boltzmann() = 0;
-
-  /// \brief Target temperature of the simulation (K units)
-  virtual cvm::real temperature() = 0;
-
-  /// \brief Time step of the simulation (fs)
-  virtual cvm::real dt() = 0;
-
-  /// \brief Pseudo-random number with Gaussian distribution
-  virtual cvm::real rand_gaussian(void) = 0;
 
   /// Print a message to the main log
   virtual void log(std::string const &message) = 0;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -9,150 +9,380 @@
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 
+
+/// \file colvarproxy.h
+/// \brief Colvars proxy classes
+///
+/// This file declares the class for the object responsible for interfacing
+/// Colvars with other codes (MD engines, VMD, Python).  The \link colvarproxy
+/// \endlink class is a derivative of multiple classes, each devoted to a
+/// specific task (e.g. \link colvarproxy_atoms \endlink to access data for
+/// individual atoms).
+///
+/// To interface to a new MD engine, the simplest solution is to derive a new
+/// class from \link colvarproxy \endlink.  Currently implemented are: \link
+/// colvarproxy_lammps, \endlink, \link colvarproxy_namd, \endlink, \link
+/// colvarproxy_vmd, \endlink.
+
+
 // forward declarations
 class colvarscript;
 
-/// \brief Interface between the collective variables module and
-/// the simulation or analysis program (NAMD, VMD, LAMMPS...).
-/// This is the base class: each interfaced program is supported by a derived class.
-/// Only pure virtual functions ("= 0") must be reimplemented to ensure baseline functionality.
 
-class colvarproxy {
+/// \brief Container of atomic data for serial processing by Colvars
+class colvarproxy_atoms {
 
 public:
-
-  /// Pointer to the main object
-  colvarmodule *colvars;
-
-  /// Constructor
-  colvarproxy()
-  {
-    colvars = NULL;
-    b_simulation_running = true;
-    b_smp_active = true;
-    script = NULL;
-  }
 
   /// Destructor
-  virtual ~colvarproxy()
-  {}
-
-  /// (Re)initialize required member data after construction
-  virtual int setup()
+  virtual ~colvarproxy_atoms()
   {
+    reset();
+  }
+
+  /// Prepare this atom for collective variables calculation, selecting it by
+  /// numeric index (1-based)
+  virtual int init_atom(int atom_number) = 0;
+
+  /// Check that this atom number is valid, but do not initialize the
+  /// corresponding atom yet
+  virtual int check_atom_id(int atom_number) = 0;
+
+  /// Select this atom for collective variables calculation, using name and
+  /// residue number.  Not all programs support this: leave this function as
+  /// is in those cases.
+  virtual int init_atom(cvm::residue_id const &residue,
+                        std::string const     &atom_name,
+                        std::string const     &segment_id)
+  {
+    cvm::error("Error: initializing an atom by name and "
+               "residue number is currently not supported.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return COLVARS_NOT_IMPLEMENTED;
+  }
+
+  /// Check that this atom is valid, but do not initialize it yet
+  virtual int check_atom_id(cvm::residue_id const &residue,
+                            std::string const     &atom_name,
+                            std::string const     &segment_id)
+  {
+    cvm::error("Error: initializing an atom by name and "
+               "residue number is currently not supported.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return COLVARS_NOT_IMPLEMENTED;
+  }
+
+  /// \brief Used by the atom class destructor: rather than deleting the array slot
+  /// (costly) set the corresponding atoms_ncopies to zero
+  virtual void clear_atom(int index)
+  {
+    if (((size_t) index) >= atoms_ids.size()) {
+      cvm::error("Error: trying to disable an atom that was not previously requested.\n",
+                 INPUT_ERROR);
+    }
+    if (atoms_ncopies[index] > 0) {
+      atoms_ncopies[index] -= 1;
+    }
+  }
+
+  /// \brief Read atom identifiers from a file \param filename name of
+  /// the file (usually a PDB) \param atoms array to which atoms read
+  /// from "filename" will be appended \param pdb_field (optiona) if
+  /// "filename" is a PDB file, use this field to determine which are
+  /// the atoms to be set
+  virtual int load_atoms(char const *filename,
+                         cvm::atom_group &atoms,
+                         std::string const &pdb_field,
+                         double const pdb_field_value = 0.0)
+  {
+    cvm::error("Error: loading atom identifiers from a file is currently not implemented.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return COLVARS_NOT_IMPLEMENTED;
+  }
+
+  /// \brief Load the coordinates for a group of atoms from a file
+  /// (usually a PDB); if "pos" is already allocated, the number of its
+  /// elements must match the number of atoms in "filename"
+  virtual int load_coords(char const *filename,
+                          std::vector<cvm::atom_pos> &pos,
+                          const std::vector<int> &indices,
+                          std::string const &pdb_field,
+                          double const pdb_field_value = 0.0)
+  {
+    cvm::error("Error: loading atomic coordinates from a file is currently not implemented.\n");
+    return COLVARS_NOT_IMPLEMENTED;
+  }
+
+  inline int reset()
+  {
+    atoms_ids.clear();
+    atoms_ncopies.clear();
+    atoms_masses.clear();
+    atoms_charges.clear();
+    atoms_positions.clear();
+    atoms_total_forces.clear();
+    atoms_new_colvar_forces.clear();
     return COLVARS_OK;
   }
 
-  /// \brief Update data required by the colvars module (e.g. cache atom positions)
-  ///
-  /// TODO Break up colvarproxy_namd and colvarproxy_lammps function into these
-  virtual int update_input()
+  /// Get the numeric ID of the given atom (for the program)
+  inline int get_atom_id(int index) const
   {
-    return COLVARS_OK;
+    return atoms_ids[index];
   }
 
-  /// \brief Update data based from the results of a module update (e.g. send forces)
-  virtual int update_output()
+  /// Get the mass of the given atom
+  inline cvm::real get_atom_mass(int index) const
   {
-    return COLVARS_OK;
+    return atoms_masses[index];
   }
 
-  /// \brief Reset proxy state, e.g. requested atoms
-  virtual int reset();
-
-
-  // **************** SIMULATION PARAMETERS ****************
-
-  /// \brief Value of the unit for atomic coordinates with respect to
-  /// angstroms (used by some variables for hard-coded default values)
-  virtual cvm::real unit_angstrom() = 0;
-
-  /// \brief Boltzmann constant
-  virtual cvm::real boltzmann() = 0;
-
-  /// \brief Temperature of the simulation (K)
-  virtual cvm::real temperature() = 0;
-
-  /// \brief Time step of the simulation (fs)
-  virtual cvm::real dt() = 0;
-
-  /// \brief Pseudo-random number with Gaussian distribution
-  virtual cvm::real rand_gaussian(void) = 0;
-
-  /// \brief Get the current frame number
-  // Returns error code
-  virtual int get_frame(long int&) { return COLVARS_NOT_IMPLEMENTED; }
-
-  /// \brief Set the current frame number (as well as colvarmodule::it)
-  // Returns error code
-  virtual int set_frame(long int) { return COLVARS_NOT_IMPLEMENTED; }
-
-  /// \brief Prefix to be used for input files (restarts, not
-  /// configuration)
-  std::string input_prefix_str, output_prefix_str, restart_output_prefix_str;
-
-  inline std::string & input_prefix()
+  /// Get the charge of the given atom
+  inline cvm::real get_atom_charge(int index) const
   {
-    return input_prefix_str;
+    return atoms_charges[index];
   }
 
-  /// \brief Prefix to be used for output restart files
-  inline std::string restart_output_prefix()
+  /// Read the current position of the given atom
+  inline cvm::rvector get_atom_position(int index) const
   {
-    return restart_output_prefix_str;
+    return atoms_positions[index];
   }
 
-  /// \brief Prefix to be used for output files (final system
-  /// configuration)
-  inline std::string output_prefix()
+  /// Read the current total force of the given atom
+  inline cvm::rvector get_atom_total_force(int index) const
   {
-    return output_prefix_str;
+    return atoms_total_forces[index];
   }
 
-  /// \brief Restarts will be written each time this number of steps has passed
-  virtual size_t restart_frequency()
+  /// Request that this force is applied to the given atom
+  inline void apply_atom_force(int index, cvm::rvector const &new_force)
   {
-    return 0;
+    atoms_new_colvar_forces[index] += new_force;
+  }
+
+  /// Read the current velocity of the given atom
+  inline cvm::rvector get_atom_velocity(int index)
+  {
+    cvm::error("Error: reading the current velocity of an atom "
+               "is not yet implemented.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return cvm::rvector(0.0);
+  }
+
+  inline std::vector<int> *modify_atom_ids()
+  {
+    return &atoms_ids;
+  }
+
+  inline std::vector<cvm::real> *modify_atom_masses()
+  {
+    return &atoms_masses;
+  }
+
+  inline std::vector<cvm::real> *modify_atom_charges()
+  {
+    return &atoms_charges;
+  }
+
+  inline std::vector<cvm::rvector> *modify_atom_positions()
+  {
+    return &atoms_positions;
+  }
+
+  inline std::vector<cvm::rvector> *modify_atom_total_forces()
+  {
+    return &atoms_total_forces;
+  }
+
+  inline std::vector<cvm::rvector> *modify_atom_new_colvar_forces()
+  {
+    return &atoms_new_colvar_forces;
   }
 
 protected:
 
-  /// Whether a simulation is running (and try to prevent irrecovarable errors)
-  bool b_simulation_running;
+  /// \brief Array of 0-based integers used to uniquely associate atoms
+  /// within the host program
+  std::vector<int>          atoms_ids;
+  /// \brief Keep track of how many times each atom is used by a separate colvar object
+  std::vector<size_t>       atoms_ncopies;
+  /// \brief Masses of the atoms (allow redefinition during a run, as done e.g. in LAMMPS)
+  std::vector<cvm::real>    atoms_masses;
+  /// \brief Charges of the atoms (allow redefinition during a run, as done e.g. in LAMMPS)
+  std::vector<cvm::real>    atoms_charges;
+  /// \brief Current three-dimensional positions of the atoms
+  std::vector<cvm::rvector> atoms_positions;
+  /// \brief Most recent total forces on each atom
+  std::vector<cvm::rvector> atoms_total_forces;
+  /// \brief Forces applied from colvars, to be communicated to the MD integrator
+  std::vector<cvm::rvector> atoms_new_colvar_forces;
+
+  /// Used by all init_atom() functions: create a slot for an atom not requested yet
+  inline int add_atom_slot(int atom_id)
+  {
+    atoms_ids.push_back(atom_id);
+    atoms_ncopies.push_back(1);
+    atoms_masses.push_back(1.0);
+    atoms_charges.push_back(0.0);
+    atoms_positions.push_back(cvm::rvector(0.0, 0.0, 0.0));
+    atoms_total_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+    atoms_new_colvar_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+    return (atoms_ids.size() - 1);
+  }
+
+};
+
+
+/// \brief Container of atom group data (allow collection of aggregated atomic
+/// data)
+class colvarproxy_atom_groups {
 
 public:
 
-  /// Whether a simulation is running (and try to prevent irrecovarable errors)
-  virtual bool simulation_running() const
+  /// Destructor
+  virtual ~colvarproxy_atom_groups()
   {
-    return b_simulation_running;
+    reset();
+  }
+
+  /// \brief Whether this proxy implementation has capability for scalable groups
+  virtual int scalable_group_coms()
+  {
+    return COLVARS_NOT_IMPLEMENTED;
+  }
+
+  /// Prepare this group for collective variables calculation, selecting atoms by internal ids (0-based)
+  virtual int init_atom_group(std::vector<int> const &atoms_ids) // TODO Add a handle to cvc objects
+  {
+    cvm::error("Error: initializing a group outside of the colvars module is currently not supported.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return COLVARS_NOT_IMPLEMENTED;
+  }
+
+  /// \brief Used by the atom_group class destructor
+  virtual void clear_atom_group(int index)
+  {
+    if (((size_t) index) >= atom_groups_ids.size()) {
+      cvm::error("Error: trying to disable an atom group that was not previously requested.\n",
+                 INPUT_ERROR);
+    }
+
+    if (atom_groups_ncopies[index] > 0) {
+      atom_groups_ncopies[index] -= 1;
+    }
+  }
+
+  inline int reset()
+  {
+    atom_groups_ids.clear();
+    atom_groups_ncopies.clear();
+    atom_groups_masses.clear();
+    atom_groups_charges.clear();
+    atom_groups_coms.clear();
+    atom_groups_total_forces.clear();
+    atom_groups_new_colvar_forces.clear();
+    return COLVARS_OK;
+  }
+
+  /// Get the numeric ID of the given atom group (for the MD program)
+  inline int get_atom_group_id(int index) const
+  {
+    return atom_groups_ids[index];
+  }
+
+  /// Get the mass of the given atom group
+  inline cvm::real get_atom_group_mass(int index) const
+  {
+    return atom_groups_masses[index];
+  }
+
+  /// Get the charge of the given atom group
+  inline cvm::real get_atom_group_charge(int index) const
+  {
+    return atom_groups_charges[index];
+  }
+
+  /// Read the current position of the center of mass given atom group
+  inline cvm::rvector get_atom_group_com(int index) const
+  {
+    return atom_groups_coms[index];
+  }
+
+  /// Read the current total force of the given atom group
+  inline cvm::rvector get_atom_group_total_force(int index) const
+  {
+    return atom_groups_total_forces[index];
+  }
+
+  /// Request that this force is applied to the given atom group
+  inline void apply_atom_group_force(int index, cvm::rvector const &new_force)
+  {
+    atom_groups_new_colvar_forces[index] += new_force;
+  }
+
+  /// Read the current velocity of the given atom group
+  inline cvm::rvector get_atom_group_velocity(int index)
+  {
+    cvm::error("Error: reading the current velocity of an atom group is not yet implemented.\n",
+               COLVARS_NOT_IMPLEMENTED);
+    return cvm::rvector(0.0);
   }
 
 protected:
 
-  /// \brief Currently opened output files: by default, these are ofstream objects.
-  /// Allows redefinition to implement different output mechanisms
-  std::list<std::ostream *> output_files;
-  /// \brief Identifiers for output_stream objects: by default, these are the names of the files
-  std::list<std::string>    output_stream_names;
+  /// \brief Array of 0-based integers used to uniquely associate atom groups
+  /// within the host program
+  std::vector<int>          atom_groups_ids;
+  /// \brief Keep track of how many times each group is used by a separate cvc
+  std::vector<size_t>       atom_groups_ncopies;
+  /// \brief Total masses of the atom groups
+  std::vector<cvm::real>    atom_groups_masses;
+  /// \brief Total charges of the atom groups (allow redefinition during a run, as done e.g. in LAMMPS)
+  std::vector<cvm::real>    atom_groups_charges;
+  /// \brief Current centers of mass of the atom groups
+  std::vector<cvm::rvector> atom_groups_coms;
+  /// \brief Most recently updated total forces on the com of each group
+  std::vector<cvm::rvector> atom_groups_total_forces;
+  /// \brief Forces applied from colvars, to be communicated to the MD integrator
+  std::vector<cvm::rvector> atom_groups_new_colvar_forces;
+
+  /// Used by all init_atom_group() functions: create a slot for an atom group not requested yet
+  // TODO Add a handle to cvc objects
+  inline int add_atom_group_slot(int atom_group_id)
+  {
+    atom_groups_ids.push_back(atom_group_id);
+    atom_groups_ncopies.push_back(1);
+    atom_groups_masses.push_back(1.0);
+    atom_groups_charges.push_back(0.0);
+    atom_groups_coms.push_back(cvm::rvector(0.0, 0.0, 0.0));
+    atom_groups_total_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+    atom_groups_new_colvar_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
+    return (atom_groups_ids.size() - 1);
+  }
+
+};
+
+
+/// \brief Methods for SMP parallelization
+class colvarproxy_smp {
 
 public:
 
-  virtual char *script_obj_to_str(unsigned char *obj)
-  {
-    return reinterpret_cast<char *>(obj);
-  }
+  /// Whether threaded parallelization should be used (TODO: make this a
+  /// cvm::deps feature)
+  bool b_smp_active;
 
-  // ***************** SHARED-MEMORY PARALLELIZATION *****************
+  colvarproxy_smp()
+  {
+    b_smp_active = true;
+  }
 
   /// Whether threaded parallelization is available (TODO: make this a cvm::deps feature)
   virtual int smp_enabled()
   {
     return COLVARS_NOT_IMPLEMENTED;
   }
-
-  /// Whether threaded parallelization should be used (TODO: make this a cvm::deps feature)
-  bool b_smp_active;
 
   /// Distribute calculation of colvars (and their components) across threads
   virtual int smp_colvars_loop()
@@ -201,10 +431,13 @@ public:
   {
     return COLVARS_OK;
   }
+};
 
-  // **************** MULTIPLE REPLICAS COMMUNICATION ****************
 
-  // Replica exchange commands:
+/// \brief Methods for multiple-replica communication
+class colvarproxy_replicas {
+
+public:
 
   /// \brief Indicate if multi-replica support is available and active
   virtual bool replica_enabled() { return false; }
@@ -228,8 +461,26 @@ public:
     return COLVARS_NOT_IMPLEMENTED;
   }
 
+};
 
-  // **************** SCRIPTING INTERFACE ****************
+
+/// Method for scripting language interface (Tcl or Python)
+class colvarproxy_script {
+
+public:
+
+  colvarproxy_script()
+  {
+    script = NULL;
+  }
+
+  virtual ~colvarproxy_script() {}
+
+  /// Convert a script object (Tcl or Python call argument) to a C string
+  virtual char *script_obj_to_str(unsigned char *obj)
+  {
+    return reinterpret_cast<char *>(obj);
+  }
 
   /// Pointer to the scripting interface object
   /// (does not need to be allocated in a new interface)
@@ -254,24 +505,23 @@ public:
                                            std::vector<cvm::matrix2d<cvm::real> > &gradient)
   { return COLVARS_NOT_IMPLEMENTED; }
 
+};
+
+
+/// Methods for data input/output
+class colvarproxy_io {
+
+public:
 
   // **************** INPUT/OUTPUT ****************
 
-  /// Print a message to the main log
-  virtual void log(std::string const &message) = 0;
+  /// \brief Get the current frame number
+  // Returns error code
+  virtual int get_frame(long int&) { return COLVARS_NOT_IMPLEMENTED; }
 
-  /// Print a message to the main log and let the rest of the program handle the error
-  virtual void error(std::string const &message) = 0;
-
-  /// Print a message to the main log and exit with error code
-  virtual void fatal_error(std::string const &message) = 0;
-
-  /// Print a message to the main log and exit normally
-  virtual void exit(std::string const &message)
-  {
-    cvm::error("Error: exiting without error is not implemented, returning error code.\n",
-               COLVARS_NOT_IMPLEMENTED);
-  }
+  /// \brief Set the current frame number (as well as colvarmodule::it)
+  // Returns error code
+  virtual int set_frame(long int) { return COLVARS_NOT_IMPLEMENTED; }
 
   // TODO the following definitions may be moved to a .cpp file
 
@@ -320,7 +570,148 @@ public:
     return COLVARS_NOT_IMPLEMENTED;
   }
 
+  /// \brief Prefix of the input state file
+  inline std::string & input_prefix()
+  {
+    return input_prefix_str;
+  }
 
+  /// \brief Prefix to be used for output restart files
+  inline std::string & restart_output_prefix()
+  {
+    return restart_output_prefix_str;
+  }
+
+  /// \brief Prefix to be used for output files (final system
+  /// configuration)
+  inline std::string & output_prefix()
+  {
+    return output_prefix_str;
+  }
+
+protected:
+
+  /// \brief Prefix to be used for input files (restarts, not
+  /// configuration)
+  std::string input_prefix_str, output_prefix_str, restart_output_prefix_str;
+
+  /// \brief Currently opened output files: by default, these are ofstream objects.
+  /// Allows redefinition to implement different output mechanisms
+  std::list<std::ostream *> output_files;
+  /// \brief Identifiers for output_stream objects: by default, these are the names of the files
+  std::list<std::string>    output_stream_names;
+
+};
+
+
+/// \brief Interface between the collective variables module and
+/// the simulation or analysis program (NAMD, VMD, LAMMPS...).
+/// This is the base class: each interfaced program is supported by a derived class.
+/// Only pure virtual functions ("= 0") must be reimplemented to ensure baseline functionality.
+class colvarproxy
+  : public colvarproxy_atoms,
+    public colvarproxy_atom_groups,
+    public colvarproxy_smp,
+    public colvarproxy_replicas,
+    public colvarproxy_script,
+    public colvarproxy_io
+{
+
+public:
+
+  /// Pointer to the main object
+  colvarmodule *colvars;
+
+  /// Constructor
+  colvarproxy()
+  {
+    colvars = NULL;
+    b_simulation_running = true;
+  }
+
+  /// Destructor
+  virtual ~colvarproxy()
+  {
+    reset();
+  }
+
+  /// (Re)initialize required member data after construction
+  virtual int setup()
+  {
+    return COLVARS_OK;
+  }
+
+  /// \brief Update data required by the colvars module (e.g. cache atom positions)
+  ///
+  /// TODO Break up colvarproxy_namd and colvarproxy_lammps function into these
+  virtual int update_input()
+  {
+    return COLVARS_OK;
+  }
+
+  /// \brief Update data based from the results of a module update (e.g. send forces)
+  virtual int update_output()
+  {
+    return COLVARS_OK;
+  }
+
+  /// \brief Reset proxy state, e.g. requested atoms
+  virtual int reset();
+
+
+  // **************** SIMULATION PARAMETERS ****************
+
+  /// \brief Value of the unit for atomic coordinates with respect to
+  /// angstroms (used by some variables for hard-coded default values)
+  virtual cvm::real unit_angstrom() = 0;
+
+  /// \brief Boltzmann constant
+  virtual cvm::real boltzmann() = 0;
+
+  /// \brief Target temperature of the simulation (K units)
+  virtual cvm::real temperature() = 0;
+
+  /// \brief Time step of the simulation (fs)
+  virtual cvm::real dt() = 0;
+
+  /// \brief Pseudo-random number with Gaussian distribution
+  virtual cvm::real rand_gaussian(void) = 0;
+
+
+  /// Print a message to the main log
+  virtual void log(std::string const &message) = 0;
+
+  /// Print a message to the main log and let the rest of the program handle the error
+  virtual void error(std::string const &message) = 0;
+
+  /// Print a message to the main log and exit with error code
+  virtual void fatal_error(std::string const &message) = 0;
+
+  /// Print a message to the main log and exit normally
+  virtual void exit(std::string const &message)
+  {
+    cvm::error("Error: exiting without error is not implemented, returning error code.\n",
+               COLVARS_NOT_IMPLEMENTED);
+  }
+
+  /// \brief Restarts will be written each time this number of steps has passed
+  virtual size_t restart_frequency()
+  {
+    return 0;
+  }
+
+protected:
+
+  /// Whether a simulation is running (and try to prevent irrecovarable errors)
+  bool b_simulation_running;
+
+public:
+
+  /// Whether a simulation is running (and try to prevent irrecovarable errors)
+  virtual bool simulation_running() const
+  {
+    return b_simulation_running;
+  }
 
   // **************** ACCESS SYSTEM DATA ****************
 
@@ -374,297 +765,15 @@ public:
       select_closest_image(*pi, ref_pos);
     }
   }
-
-
-  // **************** ACCESS ATOMIC DATA ****************
-protected:
-
-  /// \brief Array of 0-based integers used to uniquely associate atoms
-  /// within the host program
-  std::vector<int>          atoms_ids;
-  /// \brief Keep track of how many times each atom is used by a separate colvar object
-  std::vector<size_t>       atoms_ncopies;
-  /// \brief Masses of the atoms (allow redefinition during a run, as done e.g. in LAMMPS)
-  std::vector<cvm::real>    atoms_masses;
-  /// \brief Charges of the atoms (allow redefinition during a run, as done e.g. in LAMMPS)
-  std::vector<cvm::real>    atoms_charges;
-  /// \brief Current three-dimensional positions of the atoms
-  std::vector<cvm::rvector> atoms_positions;
-  /// \brief Most recent total forces on each atom
-  std::vector<cvm::rvector> atoms_total_forces;
-  /// \brief Forces applied from colvars, to be communicated to the MD integrator
-  std::vector<cvm::rvector> atoms_new_colvar_forces;
-
-  /// Used by all init_atom() functions: create a slot for an atom not requested yet
-  inline int add_atom_slot(int atom_id)
-  {
-    atoms_ids.push_back(atom_id);
-    atoms_ncopies.push_back(1);
-    atoms_masses.push_back(1.0);
-    atoms_charges.push_back(0.0);
-    atoms_positions.push_back(cvm::rvector(0.0, 0.0, 0.0));
-    atoms_total_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
-    atoms_new_colvar_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
-    return (atoms_ids.size() - 1);
-  }
-
-public:
-
-  /// Prepare this atom for collective variables calculation, selecting it by numeric index (1-based)
-  virtual int init_atom(int atom_number) = 0;
-
-  /// Check that this atom number is valid, but do not initialize the corresponding atom yet
-  virtual int check_atom_id(int atom_number) = 0;
-
-  /// Select this atom for collective variables calculation, using name and residue number.
-  /// Not all programs support this: leave this function as is in those cases.
-  virtual int init_atom(cvm::residue_id const &residue,
-                        std::string const     &atom_name,
-                        std::string const     &segment_id)
-  {
-    cvm::error("Error: initializing an atom by name and residue number is currently not supported.\n",
-               COLVARS_NOT_IMPLEMENTED);
-    return COLVARS_NOT_IMPLEMENTED;
-  }
-
-  /// Check that this atom is valid, but do not initialize it yet
-  virtual int check_atom_id(cvm::residue_id const &residue,
-                            std::string const     &atom_name,
-                            std::string const     &segment_id)
-  {
-    cvm::error("Error: initializing an atom by name and residue number is currently not supported.\n",
-               COLVARS_NOT_IMPLEMENTED);
-    return COLVARS_NOT_IMPLEMENTED;
-  }
-
-  /// \brief Used by the atom class destructor: rather than deleting the array slot
-  /// (costly) set the corresponding atoms_ncopies to zero
-  virtual void clear_atom(int index)
-  {
-    if (((size_t) index) >= atoms_ids.size()) {
-      cvm::error("Error: trying to disable an atom that was not previously requested.\n",
-                 INPUT_ERROR);
-    }
-    if (atoms_ncopies[index] > 0) {
-      atoms_ncopies[index] -= 1;
-    }
-  }
-
-  /// Get the numeric ID of the given atom (for the program)
-  inline int get_atom_id(int index) const
-  {
-    return atoms_ids[index];
-  }
-
-  /// Get the mass of the given atom
-  inline cvm::real get_atom_mass(int index) const
-  {
-    return atoms_masses[index];
-  }
-
-  /// Get the charge of the given atom
-  inline cvm::real get_atom_charge(int index) const
-  {
-    return atoms_charges[index];
-  }
-
-  /// Read the current position of the given atom
-  inline cvm::rvector get_atom_position(int index) const
-  {
-    return atoms_positions[index];
-  }
-
-  /// Read the current total force of the given atom
-  inline cvm::rvector get_atom_total_force(int index) const
-  {
-    return atoms_total_forces[index];
-  }
-
-  /// Request that this force is applied to the given atom
-  inline void apply_atom_force(int index, cvm::rvector const &new_force)
-  {
-    atoms_new_colvar_forces[index] += new_force;
-  }
-
-  /// Read the current velocity of the given atom
-  virtual cvm::rvector get_atom_velocity(int index)
-  {
-    cvm::error("Error: reading the current velocity of an atom is not yet implemented.\n",
-               COLVARS_NOT_IMPLEMENTED);
-    return cvm::rvector(0.0);
-  }
-
-  // useful functions for data management outside this class
-  inline std::vector<int> *modify_atom_ids() { return &atoms_ids; }
-  inline std::vector<cvm::real> *modify_atom_masses() { return &atoms_masses; }
-  inline std::vector<cvm::real> *modify_atom_charges() { return &atoms_charges; }
-  inline std::vector<cvm::rvector> *modify_atom_positions() { return &atoms_positions; }
-  inline std::vector<cvm::rvector> *modify_atom_total_forces() { return &atoms_total_forces; }
-  inline std::vector<cvm::rvector> *modify_atom_new_colvar_forces() { return &atoms_new_colvar_forces; }
-
-  /// \brief Read atom identifiers from a file \param filename name of
-  /// the file (usually a PDB) \param atoms array to which atoms read
-  /// from "filename" will be appended \param pdb_field (optiona) if
-  /// "filename" is a PDB file, use this field to determine which are
-  /// the atoms to be set
-  virtual int load_atoms(char const *filename,
-                         cvm::atom_group &atoms,
-                         std::string const &pdb_field,
-                         double const pdb_field_value = 0.0)
-  {
-    cvm::error("Error: loading atom identifiers from a file is currently not implemented.\n",
-               COLVARS_NOT_IMPLEMENTED);
-    return COLVARS_NOT_IMPLEMENTED;
-  }
-
-  /// \brief Load the coordinates for a group of atoms from a file
-  /// (usually a PDB); if "pos" is already allocated, the number of its
-  /// elements must match the number of atoms in "filename"
-  virtual int load_coords(char const *filename,
-                          std::vector<cvm::atom_pos> &pos,
-                          const std::vector<int> &indices,
-                          std::string const &pdb_field,
-                          double const pdb_field_value = 0.0)
-  {
-    cvm::error("Error: loading atomic coordinates from a file is currently not implemented.\n");
-    return COLVARS_NOT_IMPLEMENTED;
-  }
-
-  // **************** ACCESS GROUP DATA ****************
-
-protected:
-
-  /// \brief Array of 0-based integers used to uniquely associate atom groups
-  /// within the host program
-  std::vector<int>          atom_groups_ids;
-  /// \brief Keep track of how many times each group is used by a separate cvc
-  std::vector<size_t>       atom_groups_ncopies;
-  /// \brief Total masses of the atom groups
-  std::vector<cvm::real>    atom_groups_masses;
-  /// \brief Total charges of the atom groups (allow redefinition during a run, as done e.g. in LAMMPS)
-  std::vector<cvm::real>    atom_groups_charges;
-  /// \brief Current centers of mass of the atom groups
-  std::vector<cvm::rvector> atom_groups_coms;
-  /// \brief Most recently updated total forces on the com of each group
-  std::vector<cvm::rvector> atom_groups_total_forces;
-  /// \brief Forces applied from colvars, to be communicated to the MD integrator
-  std::vector<cvm::rvector> atom_groups_new_colvar_forces;
-
-  /// TODO Add here containers of handles to cvc objects that are computed in parallel
-
-public:
-
-  /// \brief Whether this proxy implementation has capability for scalable groups
-  virtual int scalable_group_coms()
-  {
-    return COLVARS_NOT_IMPLEMENTED;
-  }
-
-  /// Used by all init_atom_group() functions: create a slot for an atom group not requested yet
-  // TODO Add a handle to cvc objects
-  inline int add_atom_group_slot(int atom_group_id)
-  {
-    atom_groups_ids.push_back(atom_group_id);
-    atom_groups_ncopies.push_back(1);
-    atom_groups_masses.push_back(1.0);
-    atom_groups_charges.push_back(0.0);
-    atom_groups_coms.push_back(cvm::rvector(0.0, 0.0, 0.0));
-    atom_groups_total_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
-    atom_groups_new_colvar_forces.push_back(cvm::rvector(0.0, 0.0, 0.0));
-    return (atom_groups_ids.size() - 1);
-  }
-
-  /// Prepare this group for collective variables calculation, selecting atoms by internal ids (0-based)
-  virtual int init_atom_group(std::vector<int> const &atoms_ids) // TODO Add a handle to cvc objects
-  {
-    cvm::error("Error: initializing a group outside of the colvars module is currently not supported.\n",
-               COLVARS_NOT_IMPLEMENTED);
-    return COLVARS_NOT_IMPLEMENTED;
-  }
-
-  /// \brief Used by the atom_group class destructor
-  virtual void clear_atom_group(int index)
-  {
-    if (cvm::debug()) {
-      log("Trying to remove/disable atom group number "+cvm::to_str(index)+"\n");
-    }
-
-    if (((size_t) index) >= atom_groups_ids.size()) {
-      cvm::error("Error: trying to disable an atom group that was not previously requested.\n",
-                 INPUT_ERROR);
-    }
-
-    if (atom_groups_ncopies[index] > 0) {
-      atom_groups_ncopies[index] -= 1;
-    }
-  }
-
-  /// Get the numeric ID of the given atom group (for the MD program)
-  inline cvm::real get_atom_group_id(int index) const
-  {
-    return atom_groups_ids[index];
-  }
-
-  /// Get the mass of the given atom group
-  inline cvm::real get_atom_group_mass(int index) const
-  {
-    return atom_groups_masses[index];
-  }
-
-  /// Get the charge of the given atom group
-  inline cvm::real get_atom_group_charge(int index) const
-  {
-    return atom_groups_charges[index];
-  }
-
-  /// Read the current position of the center of mass given atom group
-  inline cvm::rvector get_atom_group_com(int index) const
-  {
-    return atom_groups_coms[index];
-  }
-
-  /// Read the current total force of the given atom group
-  inline cvm::rvector get_atom_group_total_force(int index) const
-  {
-    return atom_groups_total_forces[index];
-  }
-
-  /// Request that this force is applied to the given atom group
-  inline void apply_atom_group_force(int index, cvm::rvector const &new_force)
-  {
-    atom_groups_new_colvar_forces[index] += new_force;
-  }
-
-  /// Read the current velocity of the given atom group
-  virtual cvm::rvector get_atom_group_velocity(int index)
-  {
-    cvm::error("Error: reading the current velocity of an atom group is not yet implemented.\n",
-               COLVARS_NOT_IMPLEMENTED);
-    return cvm::rvector(0.0);
-  }
-
 };
 
 
 inline int colvarproxy::reset()
 {
-  atoms_ids.clear();
-  atoms_ncopies.clear();
-  atoms_masses.clear();
-  atoms_charges.clear();
-  atoms_positions.clear();
-  atoms_total_forces.clear();
-  atoms_new_colvar_forces.clear();
-
-  atom_groups_ids.clear();
-  atom_groups_ncopies.clear();
-  atom_groups_masses.clear();
-  atom_groups_charges.clear();
-  atom_groups_coms.clear();
-  atom_groups_total_forces.clear();
-  atom_groups_new_colvar_forces.clear();
-
-  return COLVARS_OK;
+  int error_code = COLVARS_OK;
+  error_code |= colvarproxy_atoms::reset();
+  error_code |= colvarproxy_atom_groups::reset();
+  return error_code;
 }
 
 

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,1 +1,1 @@
-#define COLVARS_VERSION "2017-06-26_proxy-streamline"
+#define COLVARS_VERSION "2017-06-26_proxy-cleanup"

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,1 +1,1 @@
-#define COLVARS_VERSION "2017-06-23"
+#define COLVARS_VERSION "2017-06-23_proxy-streamline"

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,1 +1,1 @@
-#define COLVARS_VERSION "2017-06-23_proxy-streamline"
+#define COLVARS_VERSION "2017-06-26_proxy-streamline"

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -194,7 +194,7 @@ int colvarscript::run(int objc, unsigned char *const objv[])
       result = "Missing arguments";
       return COLVARSCRIPT_ERROR;
     }
-    proxy->output_prefix_str = obj_to_str(objv[2]);
+    proxy->output_prefix() = obj_to_str(objv[2]);
     int error = 0;
     error |= colvars->setup_output();
     error |= colvars->write_output_files();

--- a/vmd/configure
+++ b/vmd/configure
@@ -820,6 +820,7 @@ if ($config_colvars) {
                       'colvargrid.C',
                       'colvarmodule.C',
                       'colvarparse.C',
+                      'colvarproxy.C',
                       'colvarproxy_vmd.C',
                       'colvarscript.C',
                       'colvartypes.C',

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -256,10 +256,6 @@ void colvarproxy_vmd::error(std::string const &message)
 {
   error_output += message;
   log(message);
-  if (!cvm::debug()) {
-    log("If this error message is unclear, "
-        "try recompiling VMD with -DCOLVARS_DEBUG.\n");
-  }
 }
 
 

--- a/vmd/src/colvarproxy_vmd_version.h
+++ b/vmd/src/colvarproxy_vmd_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2017-03-21"
+#define COLVARPROXY_VERSION "2017-06-26_proxy-cleanup"
 #endif


### PR DESCRIPTION
The `colvarproxy` class has grown too big already some time ago.  However, its ease of use and maintainability have become even more important recently, due to the addition of new interfaces to scripting languages, functions that are only provided by a certain code (e.g. atom group COMs), and support for specific hacks of each program (e.g. `ofstream_namd`), etc.

This PR implements changes aimed at making more readable the API for the `colvarproxy` class by separating it into individual classes and moving most of its functions to a `.cpp` file. 

- [x] Split up colvarproxy members in multiple classes
- [x] Move all but inline functions from colvarproxy.h to colvarproxy.cpp
- [x] Remove unused methods (`select_closest_image()`, `select_closest_images()`, `exit()`).
- [ ] Replace all pure virtual functions with stubs (to be discussed)
- [ ] Document which functions define the minimal API (e.g. `colvarproxy_system` and `colvarproxy_atoms`) 

After this PR is merged, other changes that could be useful are:
- [ ] Merge Tcl interface code into `colvarproxy_script` (remove duplicated code between VMD and NAMD)
- [ ] Merge PDB reading code into `colvarproxy_atoms` (remove duplicated code between VMD and NAMD)
- [ ] Write a thin C-linkage API in `colvarproxy.h` to simplify calling its methods from other codes or with `ctypes`