### PR TITLE
Allow outputCenters to be parsed for immobile umbrellas

### DIFF
--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -279,7 +279,7 @@ int colvarbias_restraint_centers_moving::init(std::string const &conf)
     }
   } else {
     target_centers.clear();
-    return COLVARS_OK;
+    //return COLVARS_OK; //This short circuits parsing outputCenters and outputAccumulatedWork in REUS simulations, and makes scripts fail that didn't use to fail.
   }
 
   get_keyval(conf, "outputCenters", b_output_centers, b_output_centers);


### PR DESCRIPTION
In REUS simulations, it is handy to have the centers be output. However, the umbrellas are immobile, so currently the keyword isn't parsed, and so inputs that used to work in earlier versions no longer do, and do not output the centers anymore, making parsing the output much more annoying.