### PR TITLE
Check for matching braces before beginning to parse

### DIFF
--- a/doc/cv_version.tex
+++ b/doc/cv_version.tex
@@ -1,1 +1,1 @@
-\newcommand{\cvversion}{2018-07-24}
+\newcommand{\cvversion}{2018-07-24\_check_braces_first}

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps_version.h
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2018-07-24"
+#define COLVARPROXY_VERSION "2018-07-24_check_braces_first"
 #endif

--- a/namd/src/colvarproxy_namd_version.h
+++ b/namd/src/colvarproxy_namd_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2018-07-24"
+#define COLVARPROXY_VERSION "2018-07-24_check_braces_first"
 #endif

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -184,6 +184,12 @@ int colvarmodule::parse_config(std::string &conf)
 {
   extra_conf.clear();
 
+  // Check that the input has matching braces
+  if (colvarparse::check_braces(conf, 0) != COLVARS_OK) {
+    return cvm::error("Error: unmatched curly braces in configuration.\n",
+                      INPUT_ERROR);
+  }
+
   // Parse global options
   if (catch_input_errors(parse_global_params(conf))) {
     return get_error();

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -600,7 +600,7 @@ bool colvarparse::key_lookup(std::string const &conf,
     }
 
     // check that there are matching braces between here and the end of conf
-    bool const b_not_within_block = brace_check(conf, pos);
+    bool const b_not_within_block = (check_braces(conf, pos) == COLVARS_OK);
 
     bool const b_isolated = (b_isolated_left && b_isolated_right &&
                              b_not_within_block);
@@ -774,19 +774,15 @@ std::istream & operator>> (std::istream &is, colvarparse::read_block const &rb)
 }
 
 
-bool colvarparse::brace_check(std::string const &conf,
+int colvarparse::check_braces(std::string const &conf,
                               size_t const start_pos)
 {
-  size_t brace_count = 0;
+  int brace_count = 0;
   size_t brace = start_pos;
-  while ( (brace = conf.find_first_of("{}", brace)) != std::string::npos) {
+  while ((brace = conf.find_first_of("{}", brace)) != std::string::npos) {
     if (conf[brace] == '{') brace_count++;
     if (conf[brace] == '}') brace_count--;
     brace++;
   }
-
-  if (brace_count != 0)
-    return false;
-  else
-    return true;
+  return (brace_count != 0) ? INPUT_ERROR : COLVARS_OK;
 }

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -282,9 +282,11 @@ public:
   static std::istream & getline_nocomments(std::istream &is,
                                            std::string &s);
 
-  /// Check if the content of the file has matching braces
-  bool brace_check(std::string const &conf,
-                   size_t const start_pos = 0);
+  /// \brief Check if the content of a config string has matching braces
+  /// \param conf The configuration string \param start_pos Start the count
+  /// from this position
+  static int check_braces(std::string const &conf,
+                          size_t const start_pos);
 
 };
 

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARS_VERSION
-#define COLVARS_VERSION "2018-07-24"
+#define COLVARS_VERSION "2018-07-24_check_braces_first"
 #endif

--- a/vmd/src/colvarproxy_vmd_version.h
+++ b/vmd/src/colvarproxy_vmd_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARPROXY_VERSION
-#define COLVARPROXY_VERSION "2018-07-24"
+#define COLVARPROXY_VERSION "2018-07-24_check_braces_first"
 #endif


### PR DESCRIPTION
Should take care of complicated errors due to unmatching braces.

Also a good opportunity to test the merge workflow. 