### PR TITLE
Raise error when the same keyword is being used repeatedly

### DIFF
--- a/doc/cv_version.tex
+++ b/doc/cv_version.tex
@@ -1,1 +1,1 @@
-\newcommand{\cvversion}{2018-07-25}
+\newcommand{\cvversion}{2018-08-18}

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -36,9 +36,10 @@ template<typename TYPE> bool colvarparse::_get_keyval_scalar_(std::string const 
     }
   } while (b_found);
 
-  if (found_count > 1)
-    cvm::log("Warning: found more than one instance of \""+
-             std::string(key)+"\".\n");
+  if (found_count > 1) {
+    cvm::error("Error: found more than one instance of \""+
+               std::string(key)+"\".\n", INPUT_ERROR);
+  }
 
   if (data.size()) {
     std::istringstream is(data);
@@ -91,9 +92,10 @@ bool colvarparse::_get_keyval_scalar_string_(std::string const &conf,
     }
   } while (b_found);
 
-  if (found_count > 1)
-    cvm::log("Warning: found more than one instance of \""+
-             std::string(key)+"\".\n");
+  if (found_count > 1) {
+    cvm::error("Error: found more than one instance of \""+
+               std::string(key)+"\".\n", INPUT_ERROR);
+  }
 
   if (data.size()) {
     std::istringstream is(data);
@@ -155,9 +157,10 @@ template<typename TYPE> bool colvarparse::_get_keyval_vector_(std::string const 
     }
   } while (b_found);
 
-  if (found_count > 1)
-    cvm::log("Warning: found more than one instance of \""+
-             std::string(key)+"\".\n");
+  if (found_count > 1) {
+    cvm::error("Error: found more than one instance of \""+
+               std::string(key)+"\".\n", INPUT_ERROR);
+  }
 
   if (data.size()) {
     std::istringstream is(data);
@@ -312,9 +315,10 @@ bool colvarparse::get_keyval(std::string const &conf,
     }
   } while (b_found);
 
-  if (found_count > 1)
-    cvm::log("Warning: found more than one instance of \""+
-             std::string(key)+"\".\n");
+  if (found_count > 1) {
+    cvm::error("Error: found more than one instance of \""+
+               std::string(key)+"\".\n", INPUT_ERROR);
+  }
 
   if (data.size()) {
     if ( (data == std::string("on")) ||

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARS_VERSION
-#define COLVARS_VERSION "2018-07-25"
+#define COLVARS_VERSION "2018-08-18"
 #endif


### PR DESCRIPTION
The usefulness of warnings is in decline: this change makes get_keyval() raise
an error condition instead of a warning (current behavior) when the
corresponding keyword is detected multiple times.  In nearly all cases, it is
clear from the documentation that only one of the values will be used.
One exception to this rule are the atom selection keywords, where some
(e.g. atomNameResidueRange) can be repeated but others (e.g. indexGroup,
atomsFile) cannot.

Coming improvements to the group class will allow all selection keywords to be
repeated.  This change is meant to prevent other instances of undefined
behavior that have not yet been considered.