### PR TITLE
Raise error when walls coincide in non-trivial ways

### DIFF
--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -989,11 +989,16 @@ int colvarbias_restraint_harmonic_walls::init(std::string const &conf)
   if ((lower_walls.size() > 0) && (upper_walls.size() > 0)) {
     for (i = 0; i < num_variables(); i++) {
       if (lower_walls[i] >= upper_walls[i]) {
-        cvm::error("Error: one upper wall, "+
-                   cvm::to_str(upper_walls[i])+
-                   ", is not higher than the lower wall, "+
-                   cvm::to_str(lower_walls[i])+".\n",
-                   INPUT_ERROR);
+        return cvm::error("Error: one upper wall, "+
+                          cvm::to_str(upper_walls[i])+
+                          ", is not higher than the lower wall, "+
+                          cvm::to_str(lower_walls[i])+".\n",
+                          INPUT_ERROR);
+      }
+      if (variables(i)->dist2(lower_walls[i], upper_walls[i]) < 1.0e-12) {
+        return cvm::error("Error: lower wall and upper wall are equal "
+                          "in the domain of the variable \""+
+                          variables(i)->name+"\".\n", INPUT_ERROR);
       }
     }
     if (lower_wall_k * upper_wall_k == 0.0) {


### PR DESCRIPTION
(e.g. periodic variables).  This addresses issue raised with PLB tutorial files, containing invalid input, and reported by David Hardy ahead of the Urbana FE workshop.