### PR TITLE
Warn only, but do not try to fix zero-mass problems

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -670,6 +670,22 @@ void colvarproxy_namd::clear_atom(int index)
 }
 
 
+void colvarproxy_namd::update_atom_properties(int index)
+{
+  Molecule *mol = Node::Object()->molecule;
+  // update mass
+  double const mass = mol->atommass(atoms_ids[index]);
+  if (mass <= 0.001) {
+    this->log("Warning: near-zero mass for atom "+
+              cvm::to_str(atoms_ids[index]+1)+
+              "; expect unstable dynamics if you apply forces to it.\n");
+  }
+  atoms_masses[index] = mass;
+  // update charge
+  atoms_charges[index] = mol->atomcharge(atoms_ids[index]);
+}
+
+
 cvm::rvector colvarproxy_namd::position_distance(cvm::atom_pos const &pos1,
                                                  cvm::atom_pos const &pos2)
   const

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -237,14 +237,7 @@ public:
                     std::string const     &segment_id);
   void clear_atom(int index);
 
-  inline void update_atom_properties(int index)
-  {
-    Molecule *mol = Node::Object()->molecule;
-    // update mass
-    atoms_masses[index] = mol->atommass(atoms_ids[index]);
-    // update charge
-    atoms_charges[index] = mol->atomcharge(atoms_ids[index]);
-  }
+  void update_atom_properties(int index);
 
   cvm::rvector position_distance(cvm::atom_pos const &pos1,
                                  cvm::atom_pos const &pos2) const;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -177,8 +177,7 @@ public:
   /// Get the mass of the given atom
   inline cvm::real get_atom_mass(int index) const
   {
-    cvm::real m = atoms_masses[index];
-    return ( m > 0. ? m : 1.0); // Avoid atoms with zero mass
+    return atoms_masses[index];
   }
 
   /// Get the charge of the given atom


### PR DESCRIPTION
The release of NAMD 2.13b1 is being announced in advance to the external developers, via the usual formal notice sent by UIUC:
![LMFO](https://media.tenor.com/images/72444c6a0df2f704d5b82d0a1db07c3f/tenor.gif)

Given the time constraints and the likely impossibility to introduce an error condition for zero-mass atoms, I propose that we warn users, but do not introduce inconsistencies with the NAMD COM code until we have offered a mechanism to control the treatment of zero-masses via the scripting interface.