### PR TITLE
Parser improvements

### DIFF
--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -150,11 +150,11 @@ void colvarproxy_lammps::init(const char *conf_file)
   }
 
   if (cvm::debug()) {
-    log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
-    log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
-    log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
-    log(cvm::line_marker);
-    log("Info: done initializing the colvars proxy object.\n");
+    cvm::log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
+    cvm::log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
+    cvm::log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
+    cvm::log(cvm::line_marker);
+    cvm::log("Info: done initializing the colvars proxy object.\n");
   }
 }
 
@@ -178,7 +178,7 @@ int colvarproxy_lammps::setup()
 double colvarproxy_lammps::compute()
 {
   if (cvm::debug()) {
-    log(std::string(cvm::line_marker)+
+    cvm::log(std::string(cvm::line_marker)+
         "colvarproxy_lammps step no. "+
         cvm::to_str(_lmp->update->ntimestep)+" [first - last = "+
         cvm::to_str(_lmp->update->beginstep)+" - "+
@@ -231,20 +231,20 @@ double colvarproxy_lammps::compute()
   bias_energy = 0.0;
 
   if (cvm::debug()) {
-    log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
-    log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
-    log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
-    log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
+    cvm::log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
+    cvm::log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
+    cvm::log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
+    cvm::log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
   }
 
   // call the collective variable module
   colvars->calc();
 
   if (cvm::debug()) {
-    log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
-    log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
-    log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
-    log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
+    cvm::log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
+    cvm::log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
+    cvm::log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
+    cvm::log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
   }
 
   return bias_energy;

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -98,8 +98,8 @@ colvarproxy_namd::colvarproxy_namd()
 
   // initiate module: this object will be the communication proxy
   colvars = new colvarmodule(this);
-  log("Using NAMD interface, version "+
-      cvm::to_str(COLVARPROXY_VERSION)+".\n");
+  cvm::log("Using NAMD interface, version "+
+           cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
   if (config) {
     colvars->read_config_file(config->data);
@@ -118,7 +118,7 @@ colvarproxy_namd::colvarproxy_namd()
 #endif
 
   if (simparams->firstTimestep != 0) {
-    log("Initializing step number as firstTimestep.\n");
+    cvm::log("Initializing step number as firstTimestep.\n");
     colvars->it = colvars->it_restart = simparams->firstTimestep;
   }
 
@@ -171,7 +171,7 @@ int colvarproxy_namd::update_atoms_map(AtomIDList::const_iterator begin,
   }
 
   if (cvm::debug()) {
-    log("atoms_map = "+cvm::to_str(atoms_map)+".\n");
+    cvm::log("atoms_map = "+cvm::to_str(atoms_map)+".\n");
   }
 
   return COLVARS_OK;
@@ -182,7 +182,7 @@ int colvarproxy_namd::setup()
 {
   if (colvars->size() == 0) return COLVARS_OK;
 
-  log("Updating NAMD interface:\n");
+  cvm::log("Updating NAMD interface:\n");
 
   if (simparams->wrapAll) {
     cvm::log("Warning: enabling wrapAll can lead to inconsistent results "
@@ -190,7 +190,7 @@ int colvarproxy_namd::setup()
              "as is the default option in NAMD.\n");
   }
 
-  log("updating atomic data ("+cvm::to_str(atoms_ids.size())+" atoms).\n");
+  cvm::log("updating atomic data ("+cvm::to_str(atoms_ids.size())+" atoms).\n");
 
   size_t i;
   for (i = 0; i < atoms_ids.size(); i++) {
@@ -207,8 +207,9 @@ int colvarproxy_namd::setup()
     n_group_atoms += modifyRequestedGroups()[ig].size();
   }
 
-  log("updating group data ("+cvm::to_str(atom_groups_ids.size())+" scalable groups, "+
-      cvm::to_str(n_group_atoms)+" atoms in total).\n");
+  cvm::log("updating group data ("+cvm::to_str(atom_groups_ids.size())+
+           " scalable groups, "+
+           cvm::to_str(n_group_atoms)+" atoms in total).\n");
 
   // Note: groupMassBegin, groupMassEnd may be used here, but they won't work for charges
   for (int ig = 0; ig < modifyRequestedGroups().size(); ig++) {
@@ -290,9 +291,9 @@ void colvarproxy_namd::calculate()
   }
 
   if (cvm::debug()) {
-    log(std::string(cvm::line_marker)+
-        "colvarproxy_namd, step no. "+cvm::to_str(colvars->it)+"\n"+
-        "Updating atomic data arrays.\n");
+    cvm::log(std::string(cvm::line_marker)+
+             "colvarproxy_namd, step no. "+cvm::to_str(colvars->it)+"\n"+
+             "Updating atomic data arrays.\n");
   }
 
   // must delete the forces applied at the previous step: we can do
@@ -330,7 +331,7 @@ void colvarproxy_namd::calculate()
 
   {
     if (cvm::debug()) {
-      log("Updating positions arrays.\n");
+      cvm::log("Updating positions arrays.\n");
     }
     size_t n_positions = 0;
     AtomIDList::const_iterator a_i = getAtomIdBegin();
@@ -355,7 +356,7 @@ void colvarproxy_namd::calculate()
 
     {
       if (cvm::debug()) {
-        log("Updating total forces arrays.\n");
+        cvm::log("Updating total forces arrays.\n");
       }
       size_t n_total_forces = 0;
       AtomIDList::const_iterator a_i = getForceIdBegin();
@@ -378,7 +379,7 @@ void colvarproxy_namd::calculate()
 
     {
       if (cvm::debug()) {
-        log("Updating group total forces arrays.\n");
+        cvm::log("Updating group total forces arrays.\n");
       }
       ForceList::const_iterator f_i = getGroupTotalForceBegin();
       ForceList::const_iterator f_e = getGroupTotalForceEnd();
@@ -398,7 +399,7 @@ void colvarproxy_namd::calculate()
 
   {
     if (cvm::debug()) {
-      log("Updating group positions arrays.\n");
+      cvm::log("Updating group positions arrays.\n");
     }
     // update group data (only coms available so far)
     size_t ig;
@@ -411,21 +412,21 @@ void colvarproxy_namd::calculate()
   }
 
   if (cvm::debug()) {
-    log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
-    log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
-    log("atoms_masses = "+cvm::to_str(atoms_masses)+"\n");
-    log("atoms_charges = "+cvm::to_str(atoms_charges)+"\n");
-    log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
-    log("atoms_total_forces = "+cvm::to_str(atoms_total_forces)+"\n");
-    log(cvm::line_marker);
+    cvm::log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
+    cvm::log("atoms_ncopies = "+cvm::to_str(atoms_ncopies)+"\n");
+    cvm::log("atoms_masses = "+cvm::to_str(atoms_masses)+"\n");
+    cvm::log("atoms_charges = "+cvm::to_str(atoms_charges)+"\n");
+    cvm::log("atoms_positions = "+cvm::to_str(atoms_positions)+"\n");
+    cvm::log("atoms_total_forces = "+cvm::to_str(atoms_total_forces)+"\n");
+    cvm::log(cvm::line_marker);
 
-    log("atom_groups_ids = "+cvm::to_str(atom_groups_ids)+"\n");
-    log("atom_groups_ncopies = "+cvm::to_str(atom_groups_ncopies)+"\n");
-    log("atom_groups_masses = "+cvm::to_str(atom_groups_masses)+"\n");
-    log("atom_groups_charges = "+cvm::to_str(atom_groups_charges)+"\n");
-    log("atom_groups_coms = "+cvm::to_str(atom_groups_coms)+"\n");
-    log("atom_groups_total_forces = "+cvm::to_str(atom_groups_total_forces)+"\n");
-    log(cvm::line_marker);
+    cvm::log("atom_groups_ids = "+cvm::to_str(atom_groups_ids)+"\n");
+    cvm::log("atom_groups_ncopies = "+cvm::to_str(atom_groups_ncopies)+"\n");
+    cvm::log("atom_groups_masses = "+cvm::to_str(atom_groups_masses)+"\n");
+    cvm::log("atom_groups_charges = "+cvm::to_str(atom_groups_charges)+"\n");
+    cvm::log("atom_groups_coms = "+cvm::to_str(atom_groups_coms)+"\n");
+    cvm::log("atom_groups_total_forces = "+cvm::to_str(atom_groups_total_forces)+"\n");
+    cvm::log(cvm::line_marker);
   }
 
   // call the collective variable module
@@ -434,11 +435,11 @@ void colvarproxy_namd::calculate()
   }
 
   if (cvm::debug()) {
-    log(cvm::line_marker);
-    log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
-    log(cvm::line_marker);
-    log("atom_groups_new_colvar_forces = "+cvm::to_str(atom_groups_new_colvar_forces)+"\n");
-    log(cvm::line_marker);
+    cvm::log(cvm::line_marker);
+    cvm::log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
+    cvm::log(cvm::line_marker);
+    cvm::log("atom_groups_new_colvar_forces = "+cvm::to_str(atom_groups_new_colvar_forces)+"\n");
+    cvm::log(cvm::line_marker);
   }
 
   // communicate all forces to the MD integrator
@@ -561,7 +562,7 @@ int colvarproxy_namd::check_atom_id(int atom_number)
   int const aid = (atom_number-1);
 
   if (cvm::debug())
-    log("Adding atom "+cvm::to_str(atom_number)+
+    cvm::log("Adding atom "+cvm::to_str(atom_number)+
         " for collective variables calculation.\n");
 
   if ( (aid < 0) || (aid >= Node::Object()->molecule->numAtoms) ) {
@@ -649,7 +650,7 @@ int colvarproxy_namd::init_atom(cvm::residue_id const &residue,
   }
 
   if (cvm::debug())
-    log("Adding atom \""+
+    cvm::log("Adding atom \""+
         atom_name+"\" in residue "+
         cvm::to_str(residue)+
         " (index "+cvm::to_str(aid)+
@@ -1031,7 +1032,7 @@ std::vector<std::string> colvarproxy_namd::script_obj_to_str_vector(unsigned cha
 int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
 {
   if (cvm::debug())
-    log("Reguesting from NAMD a group of size "+cvm::to_str(atoms_ids.size())+
+    cvm::log("Reguesting from NAMD a group of size "+cvm::to_str(atoms_ids.size())+
         " for collective variables calculation.\n");
 
   // Note: modifyRequestedGroups is supposed to be in sync with the colvarproxy arrays,
@@ -1058,7 +1059,7 @@ int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
 
     if (b_match) {
       if (cvm::debug())
-        log("Group was already added.\n");
+        cvm::log("Group was already added.\n");
       // this group already exists
       atom_groups_ncopies[ig] += 1;
       return ig;
@@ -1076,7 +1077,7 @@ int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
   for (size_t ia = 0; ia < atoms_ids.size(); ia++) {
     int const aid = atoms_ids[ia];
     if (cvm::debug())
-      log("Adding atom "+cvm::to_str(aid+1)+
+      cvm::log("Adding atom "+cvm::to_str(aid+1)+
           " for collective variables calculation.\n");
     if ( (aid < 0) || (aid >= n_all_atoms) ) {
       cvm::error("Error: invalid atom number specified, "+
@@ -1089,8 +1090,8 @@ int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
   update_group_properties(index);
 
   if (cvm::debug()) {
-    log("Group has index "+cvm::to_str(index)+"\n");
-    log("modifyRequestedGroups length = "+cvm::to_str(modifyRequestedGroups().size())+
+    cvm::log("Group has index "+cvm::to_str(index)+"\n");
+    cvm::log("modifyRequestedGroups length = "+cvm::to_str(modifyRequestedGroups().size())+
         ", modifyGroupForces length = "+cvm::to_str(modifyGroupForces().size())+"\n");
   }
 
@@ -1109,8 +1110,8 @@ int colvarproxy_namd::update_group_properties(int index)
 {
   AtomIDList const &namd_group = modifyRequestedGroups()[index];
   if (cvm::debug()) {
-    log("Re-calculating total mass and charge for scalable group no. "+cvm::to_str(index+1)+" ("+
-        cvm::to_str(namd_group.size())+" atoms).\n");
+    cvm::log("Re-calculating total mass and charge for scalable group no. "+cvm::to_str(index+1)+" ("+
+             cvm::to_str(namd_group.size())+" atoms).\n");
   }
 
   cvm::real total_mass = 0.0;
@@ -1123,8 +1124,8 @@ int colvarproxy_namd::update_group_properties(int index)
   atom_groups_charges[index] = total_charge;
 
   if (cvm::debug()) {
-    log("total mass = "+cvm::to_str(total_mass)+
-        ", total charge = "+cvm::to_str(total_charge)+"\n");
+    cvm::log("total mass = "+cvm::to_str(total_mass)+
+             ", total charge = "+cvm::to_str(total_charge)+"\n");
   }
 
   return COLVARS_OK;

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -69,6 +69,7 @@ int colvarbias::init(std::string const &conf)
       cvm::error("Error: no collective variables specified.\n", INPUT_ERROR);
       return INPUT_ERROR;
     }
+
   } else {
     cvm::log("Reinitializing bias \""+name+"\".\n");
   }

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -232,8 +232,8 @@ int colvarbias_restraint_moving::set_state_params(std::string const &conf)
 {
   if (b_chg_centers || b_chg_force_k) {
     if (target_nstages) {
-      if (!get_keyval(conf, "stage", stage))
-        cvm::error("Error: current stage is missing from the restart.\n");
+      get_keyval(conf, "stage", stage, stage,
+                 colvarparse::parse_restart | colvarparse::parse_required);
     }
   }
   return COLVARS_OK;
@@ -427,13 +427,13 @@ int colvarbias_restraint_centers_moving::set_state_params(std::string const &con
   colvarbias_restraint::set_state_params(conf);
 
   if (b_chg_centers) {
-    //    cvm::log ("Reading the updated restraint centers from the restart.\n");
-    if (!get_keyval(conf, "centers", colvar_centers))
-      cvm::error("Error: restraint centers are missing from the restart.\n");
-    if (is_enabled(f_cvb_output_acc_work)) {
-      if (!get_keyval(conf, "accumulatedWork", acc_work))
-        cvm::error("Error: accumulatedWork is missing from the restart.\n");
-    }
+    get_keyval(conf, "centers", colvar_centers, colvar_centers,
+               colvarparse::parse_restart | colvarparse::parse_required);
+  }
+
+  if (is_enabled(f_cvb_output_acc_work)) {
+    get_keyval(conf, "accumulatedWork", acc_work, acc_work,
+               colvarparse::parse_restart | colvarparse::parse_required);
   }
 
   return COLVARS_OK;
@@ -663,13 +663,13 @@ int colvarbias_restraint_k_moving::set_state_params(std::string const &conf)
   colvarbias_restraint::set_state_params(conf);
 
   if (b_chg_force_k) {
-    //    cvm::log ("Reading the updated force constant from the restart.\n");
-    if (!get_keyval(conf, "forceConstant", force_k, force_k))
-      cvm::error("Error: force constant is missing from the restart.\n");
-    if (is_enabled(f_cvb_output_acc_work)) {
-      if (!get_keyval(conf, "accumulatedWork", acc_work))
-        cvm::error("Error: accumulatedWork is missing from the restart.\n");
-    }
+    get_keyval(conf, "forceConstant", force_k, force_k,
+               colvarparse::parse_restart | colvarparse::parse_required);
+  }
+
+  if (is_enabled(f_cvb_output_acc_work)) {
+    get_keyval(conf, "accumulatedWork", acc_work, acc_work,
+               colvarparse::parse_restart | colvarparse::parse_required);
   }
 
   return COLVARS_OK;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1943,105 +1943,106 @@ template<typename T> std::string _to_str_vector(std::vector<T> const &x,
 }
 
 
-std::string cvm::to_str(int const &x,
-                        size_t width, size_t prec)
+
+std::string colvarmodule::to_str(int const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<int>(x, width, prec);
 }
 
-std::string cvm::to_str(size_t const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(size_t const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<size_t>(x, width, prec);
 }
 
-std::string cvm::to_str(long int const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(long int const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<long int>(x, width, prec);
 }
 
-std::string cvm::to_str(cvm::real const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(cvm::real const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<cvm::real>(x, width, prec);
 }
 
-std::string cvm::to_str(cvm::rvector const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(cvm::rvector const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<cvm::rvector>(x, width, prec);
 }
 
-std::string cvm::to_str(cvm::quaternion const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(cvm::quaternion const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<cvm::quaternion>(x, width, prec);
 }
 
-std::string cvm::to_str(colvarvalue const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(colvarvalue const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str<colvarvalue>(x, width, prec);
 }
 
-std::string cvm::to_str(cvm::vector1d<cvm::real> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(cvm::vector1d<cvm::real> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str< cvm::vector1d<cvm::real> >(x, width, prec);
 }
 
-std::string cvm::to_str(cvm::matrix2d<cvm::real> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(cvm::matrix2d<cvm::real> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str< cvm::matrix2d<cvm::real> >(x, width, prec);
 }
 
 
-std::string cvm::to_str(std::vector<int> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<int> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<int>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<size_t> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<size_t> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<size_t>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<long int> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<long int> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<long int>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<cvm::real> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<cvm::real> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<cvm::real>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<cvm::rvector> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<cvm::rvector> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<cvm::rvector>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<cvm::quaternion> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<cvm::quaternion> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<cvm::quaternion>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<colvarvalue> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<colvarvalue> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<colvarvalue>(x, width, prec);
 }
 
-std::string cvm::to_str(std::vector<std::string> const &x,
-                        size_t width, size_t prec)
+std::string colvarmodule::to_str(std::vector<std::string> const &x,
+                                 size_t width, size_t prec)
 {
   return _to_str_vector<std::string>(x, width, prec);
 }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -292,7 +292,7 @@ int colvarmodule::parse_global_params(std::string const &conf)
 
   // Deprecate append flag
   parse->get_keyval(conf, "colvarsTrajAppend",
-                    cv_traj_append, cv_traj_append, colvarparse::parse_restart);
+                    cv_traj_append, cv_traj_append, colvarparse::parse_silent);
 
   parse->get_keyval(conf, "scriptedColvarForces",
                     use_scripted_forces, use_scripted_forces);

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -21,6 +21,8 @@
 colvarmodule::colvarmodule(colvarproxy *proxy_in)
 {
   depth_s = 0;
+  log_level_ = 10;
+
   cv_traj_os = NULL;
 
   if (proxy == NULL) {
@@ -248,6 +250,9 @@ int colvarmodule::append_new_config(std::string const &new_conf)
 
 int colvarmodule::parse_global_params(std::string const &conf)
 {
+  // TODO document and then echo this keyword
+  parse->get_keyval(conf, "logLevel", log_level_, log_level_,
+                    colvarparse::parse_silent);
 
   {
     std::string index_file_name;
@@ -1590,14 +1595,16 @@ std::ostream & colvarmodule::write_traj(std::ostream &os)
 }
 
 
-void cvm::log(std::string const &message)
+void cvm::log(std::string const &message, int min_log_level)
 {
+  if (cvm::log_level() < min_log_level) return;
   // allow logging when the module is not fully initialized
   size_t const d = (cvm::main() != NULL) ? depth() : 0;
-  if (d > 0)
+  if (d > 0) {
     proxy->log((std::string(2*d, ' '))+message);
-  else
+  } else {
     proxy->log(message);
+  }
 }
 
 
@@ -2080,6 +2087,7 @@ colvarproxy *colvarmodule::proxy = NULL;
 // static runtime data
 cvm::real colvarmodule::debug_gradients_step_size = 1.0e-07;
 int       colvarmodule::errorCode = 0;
+int       colvarmodule::log_level_ = 10;
 long      colvarmodule::it = 0;
 long      colvarmodule::it_restart = 0;
 size_t    colvarmodule::restart_out_freq = 0;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -275,16 +275,16 @@ int colvarmodule::parse_global_params(std::string const &conf)
 
   parse->get_keyval(conf, "debugGradientsStepSize", debug_gradients_step_size,
                     debug_gradients_step_size,
-                    colvarparse::parse_restart);
+                    colvarparse::parse_silent);
 
   parse->get_keyval(conf, "monitorEigenvalueCrossing",
                     colvarmodule::rotation::monitor_crossings,
                     colvarmodule::rotation::monitor_crossings,
-                    colvarparse::parse_restart);
+                    colvarparse::parse_silent);
   parse->get_keyval(conf, "eigenvalueCrossingThreshold",
                     colvarmodule::rotation::crossing_threshold,
                     colvarmodule::rotation::crossing_threshold,
-                    colvarparse::parse_restart);
+                    colvarparse::parse_silent);
 
   parse->get_keyval(conf, "colvarsTrajFrequency", cv_traj_freq, cv_traj_freq);
   parse->get_keyval(conf, "colvarsRestartFrequency",

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -254,6 +254,7 @@ int colvarmodule::parse_global_params(std::string const &conf)
     std::string index_file_name;
     size_t pos = 0;
     while (parse->key_lookup(conf, "indexFile", &index_file_name, &pos)) {
+      cvm::log("# indexFile = \""+index_file_name+"\"\n");
       cvm->read_index_file(index_file_name.c_str());
       index_file_name.clear();
     }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1944,6 +1944,21 @@ template<typename T> std::string _to_str_vector(std::vector<T> const &x,
 
 
 
+std::string colvarmodule::to_str(std::string const &x)
+{
+  return std::string("\"")+x+std::string("\"");
+}
+
+std::string colvarmodule::to_str(char const *x)
+{
+  return std::string("\"")+std::string(x)+std::string("\"");
+}
+
+std::string colvarmodule::to_str(bool x)
+{
+  return (x ? "on" : "off");
+}
+
 std::string colvarmodule::to_str(int const &x,
                                  size_t width, size_t prec)
 {

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -274,16 +274,16 @@ int colvarmodule::parse_global_params(std::string const &conf)
 
   parse->get_keyval(conf, "debugGradientsStepSize", debug_gradients_step_size,
                     debug_gradients_step_size,
-                    colvarparse::parse_silent);
+                    colvarparse::parse_restart);
 
   parse->get_keyval(conf, "monitorEigenvalueCrossing",
                     colvarmodule::rotation::monitor_crossings,
                     colvarmodule::rotation::monitor_crossings,
-                    colvarparse::parse_silent);
+                    colvarparse::parse_restart);
   parse->get_keyval(conf, "eigenvalueCrossingThreshold",
                     colvarmodule::rotation::crossing_threshold,
                     colvarmodule::rotation::crossing_threshold,
-                    colvarparse::parse_silent);
+                    colvarparse::parse_restart);
 
   parse->get_keyval(conf, "colvarsTrajFrequency", cv_traj_freq, cv_traj_freq);
   parse->get_keyval(conf, "colvarsRestartFrequency",
@@ -291,7 +291,7 @@ int colvarmodule::parse_global_params(std::string const &conf)
 
   // Deprecate append flag
   parse->get_keyval(conf, "colvarsTrajAppend",
-                    cv_traj_append, cv_traj_append, colvarparse::parse_silent);
+                    cv_traj_append, cv_traj_append, colvarparse::parse_restart);
 
   parse->get_keyval(conf, "scriptedColvarForces",
                     use_scripted_forces, use_scripted_forces);
@@ -1239,12 +1239,12 @@ std::istream & colvarmodule::read_restart(std::istream &is)
     if (is >> colvarparse::read_block("configuration", restart_conf)) {
       parse->get_keyval(restart_conf, "step",
                         it_restart, (size_t) 0,
-                        colvarparse::parse_silent);
+                        colvarparse::parse_restart);
         it = it_restart;
       std::string restart_version;
       parse->get_keyval(restart_conf, "version",
                         restart_version, std::string(""),
-                        colvarparse::parse_silent);
+                        colvarparse::parse_restart);
       if (restart_version.size() && (restart_version != std::string(COLVARS_VERSION))) {
         cvm::log("This state file was generated with version "+restart_version+"\n");
       }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -248,14 +248,13 @@ int colvarmodule::append_new_config(std::string const &new_conf)
 
 int colvarmodule::parse_global_params(std::string const &conf)
 {
-  colvarmodule *cvm = cvm::main();
 
   {
     std::string index_file_name;
     size_t pos = 0;
     while (parse->key_lookup(conf, "indexFile", &index_file_name, &pos)) {
       cvm::log("# indexFile = \""+index_file_name+"\"\n");
-      cvm->read_index_file(index_file_name.c_str());
+      read_index_file(index_file_name.c_str());
       index_file_name.clear();
     }
   }

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -494,18 +494,14 @@ public:
                 long        traj_read_begin,
                 long        traj_read_end);
 
+  /// Convert to string for output purposes
+  static std::string to_str(char const *s);
 
   /// Convert to string for output purposes
-  static inline std::string to_str(char const *s)
-  {
-    return std::string(s);
-  }
+  static std::string to_str(std::string const &s);
 
   /// Convert to string for output purposes
-  static inline std::string to_str(std::string const &s)
-  {
-    return s;
-  }
+  static std::string to_str(bool x);
 
   /// Convert to string for output purposes
   static std::string to_str(int const &x,

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -610,13 +610,59 @@ public:
   static void request_total_force();
 
   /// Print a message to the main log
-  static void log(std::string const &message);
+  /// \param message Message to print
+  /// \param min_log_level Only print if cvm::log_level() >= min_log_level
+  static void log(std::string const &message, int min_log_level = 10);
 
   /// Print a message to the main log and exit with error code
   static int fatal_error(std::string const &message);
 
   /// Print a message to the main log and set global error code
   static int error(std::string const &message, int code = COLVARS_ERROR);
+
+private:
+
+  /// Level of logging requested by the user
+  static int log_level_;
+
+public:
+
+  /// Level of logging requested by the user
+  static inline int log_level()
+  {
+    return log_level_;
+  }
+
+  /// Level at which initialization messages are logged
+  static inline int log_init_messages()
+  {
+    return 1;
+  }
+
+  /// Level at which a keyword's user-provided value is logged
+  static inline int log_user_params()
+  {
+    return 2;
+  }
+
+  /// Level at which a keyword's default value is logged
+  static inline int log_default_params()
+  {
+    return 3;
+  }
+
+  /// Level at which output-file operations are logged
+  static inline int log_output_files()
+  {
+    return 4;
+  }
+
+  /// Level at which input-file operations (configuration, state) are logged
+  static inline int log_input_files()
+  {
+    return 5;
+  }
+
 
   // Replica exchange commands.
   static bool replica_enabled();

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -50,7 +50,7 @@ template<typename TYPE> bool colvarparse::_get_keyval_scalar_(std::string const 
       cvm::error("Error: in parsing \""+
                  std::string(key)+"\".\n", INPUT_ERROR);
     }
-    if (parse_mode != parse_silent) {
+    if (parse_mode | parse_echo) {
       cvm::log("# "+std::string(key)+" = "+
                cvm::to_str(value)+"\n");
     }
@@ -61,7 +61,7 @@ template<typename TYPE> bool colvarparse::_get_keyval_scalar_(std::string const 
                  "for \""+std::string(key)+"\".\n", INPUT_ERROR);
     }
     value = def_value;
-    if (parse_mode != parse_silent) {
+    if (parse_mode | parse_echo_default) {
       cvm::log("# "+std::string(key)+" = "+
                cvm::to_str(def_value)+" [default]\n");
     }
@@ -113,7 +113,7 @@ bool colvarparse::_get_keyval_scalar_string_(std::string const &conf,
                  "are not allowed for keyword \""+
                  std::string(key)+"\".\n", INPUT_ERROR);
     }
-    if (parse_mode != parse_silent) {
+    if (parse_mode != parse_echo) {
       cvm::log("# "+std::string(key)+" = \""+
                cvm::to_str(value)+"\"\n");
     }
@@ -124,7 +124,7 @@ bool colvarparse::_get_keyval_scalar_string_(std::string const &conf,
                  "for \""+std::string(key)+"\".\n", INPUT_ERROR);
     }
     value = def_value;
-    if (parse_mode != parse_silent) {
+    if (parse_mode != parse_echo_default) {
       cvm::log("# "+std::string(key)+" = \""+
                cvm::to_str(def_value)+"\" [default]\n");
     }
@@ -193,7 +193,7 @@ template<typename TYPE> bool colvarparse::_get_keyval_vector_(std::string const 
       }
     }
 
-    if (parse_mode != parse_silent) {
+    if (parse_mode != parse_echo) {
       cvm::log("# "+std::string(key)+" = "+
                cvm::to_str(values)+"\n");
     }
@@ -208,7 +208,7 @@ template<typename TYPE> bool colvarparse::_get_keyval_vector_(std::string const 
     for (size_t i = 0; i < values.size(); i++)
       values[i] = def_values[ (i > def_values.size()) ? 0 : i ];
 
-    if (parse_mode != parse_silent) {
+    if (parse_mode != parse_echo_default) {
       cvm::log("# "+std::string(key)+" = "+
                cvm::to_str(def_values)+" [default]\n");
     }
@@ -332,20 +332,20 @@ bool colvarparse::get_keyval(std::string const &conf,
     } else
       cvm::error("Error: boolean values only are allowed "
                  "for \""+std::string(key)+"\".\n", INPUT_ERROR);
-    if (parse_mode != parse_silent) {
+    if (parse_mode != parse_echo) {
       cvm::log("# "+std::string(key)+" = "+
                (value ? "on" : "off")+"\n");
     }
   } else {
 
     if (b_found_any) {
-      if (parse_mode != parse_silent) {
+      if (parse_mode != parse_echo) {
         cvm::log("# "+std::string(key)+" = on\n");
       }
       value = true;
     } else {
       value = def_value;
-      if (parse_mode != parse_silent) {
+      if (parse_mode != parse_echo_default) {
         cvm::log("# "+std::string(key)+" = "+
                  (def_value ? "on" : "off")+" [default]\n");
       }

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -76,7 +76,7 @@ void colvarparse::mark_key_set_user(std::string const &key_str,
                                     Parse_Mode const &parse_mode)
 {
   key_set_modes[to_lower_cppstr(key_str)] = key_set_user;
-  if (parse_mode | parse_echo) {
+  if (parse_mode & parse_echo) {
     cvm::log("# "+key_str+" = "+cvm::to_str(value)+"\n");
   }
 }
@@ -88,7 +88,7 @@ void colvarparse::mark_key_set_default(std::string const &key_str,
                                        Parse_Mode const &parse_mode)
 {
   key_set_modes[to_lower_cppstr(key_str)] = key_set_default;
-  if (parse_mode | parse_echo_default) {
+  if (parse_mode & parse_echo_default) {
     cvm::log("# "+key_str+" = "+cvm::to_str(def_value)+
              " [default]\n");
   }

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -146,7 +146,7 @@ bool colvarparse::_get_keyval_scalar_(std::string const &conf,
       }
     }
 
-    mark_key_set_user<TYPE>(key, value, parse_mode);
+    mark_key_set_user<TYPE>(key_str, value, parse_mode);
 
   } else { // No string value
 
@@ -154,15 +154,14 @@ bool colvarparse::_get_keyval_scalar_(std::string const &conf,
       if (TEMPLATE_TYPES_EQUAL(TYPE, bool)) {
         // An empty string counts as a user-provided true value
         set_bool(reinterpret_cast<void *>(&value), true);
-        mark_key_set_user<TYPE>(key, value, parse_mode);
+        mark_key_set_user<TYPE>(key_str, value, parse_mode);
       } else {
         cvm::error("Error: improper or missing value "
                    "for \""+key_str+"\".\n", INPUT_ERROR);
       }
     } else {
 
-      value = def_value;
-      mark_key_set_default<TYPE>(key, value, parse_mode);
+      mark_key_set_default<TYPE>(key_str, value, parse_mode);
     }
   }
 
@@ -214,26 +213,26 @@ bool colvarparse::_get_keyval_vector_(std::string const &conf,
       }
     }
 
-    mark_key_set_user< std::vector<TYPE> >(key, values, parse_mode);
+    mark_key_set_user< std::vector<TYPE> >(key_str, values, parse_mode);
 
   } else {
 
     if (b_found_any) {
       cvm::error("Error: improper or missing values for \""+
                  key_str+"\".\n", INPUT_ERROR);
-    }
+    } else {
 
-    if ((values.size() > 0) && (values.size() != def_values.size())) {
-      cvm::error("Error: the number of default values for \""+
-                 key_str+"\" is different from the number of "
-                 "current values.\n", BUG_ERROR);
-    }
+      if ((values.size() > 0) && (values.size() != def_values.size())) {
+        cvm::error("Error: the number of default values for \""+
+                   key_str+"\" is different from the number of "
+                   "current values.\n", BUG_ERROR);
+      }
 
     for (size_t i = 0; i < values.size(); i++) {
       values[i] = def_values[i];
     }
 
-    mark_key_set_default< std::vector<TYPE> >(key, def_values, parse_mode);
+    mark_key_set_default< std::vector<TYPE> >(key_str, def_values, parse_mode);
   }
 
   return b_found_any;
@@ -402,13 +401,13 @@ bool colvarparse::get_keyval(std::string const &conf,
 
 void colvarparse::add_keyword(char const *key)
 {
-  std::string const key_str(to_lower_cppstr(std::string(key)));
+  std::string const key_str_lower(to_lower_cppstr(std::string(key)));
 
-  if (key_set_modes.find(key_str) != key_set_modes.end()) {
+  if (key_set_modes.find(key_str_lower) != key_set_modes.end()) {
     return;
   }
 
-  key_set_modes[key_str] = key_not_set;
+  key_set_modes[key_str_lower] = key_not_set;
 
   allowed_keywords.push_back(key_str);
 }
@@ -426,22 +425,9 @@ void colvarparse::strip_values(std::string &conf)
   for ( ; (data_begin != data_begin_pos.end()) &&
           (data_end   != data_end_pos.end()) ;
         data_begin++, data_end++) {
-
-    //     std::cerr << "data_begin, data_end "
-    //               << *data_begin << ", " << *data_end
-    //               << "\n";
-
     size_t const nchars = *data_end-*data_begin;
-
-    //     std::cerr << "conf[data_begin:data_end] = \""
-    //               << std::string (conf, *data_begin - offset, nchars)
-    //               << "\"\n";
-
     conf.erase(*data_begin - offset, nchars);
     offset += nchars;
-
-    //     std::cerr << ("Stripped config = \"\n"+conf+"\"\n");
-
   }
 }
 

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -77,7 +77,8 @@ void colvarparse::mark_key_set_user(std::string const &key_str,
 {
   key_set_modes[to_lower_cppstr(key_str)] = key_set_user;
   if (parse_mode & parse_echo) {
-    cvm::log("# "+key_str+" = "+cvm::to_str(value)+"\n");
+    cvm::log("# "+key_str+" = "+cvm::to_str(value)+"\n",
+             cvm::log_user_params());
   }
 }
 
@@ -90,7 +91,7 @@ void colvarparse::mark_key_set_default(std::string const &key_str,
   key_set_modes[to_lower_cppstr(key_str)] = key_set_default;
   if (parse_mode & parse_echo_default) {
     cvm::log("# "+key_str+" = "+cvm::to_str(def_value)+
-             " [default]\n");
+             " [default]\n", cvm::log_default_params());
   }
 }
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -62,8 +62,6 @@ public:
     parse_echo = (1<<1),
     /// Print the default value of a keyword, if it is NOT given
     parse_echo_default = (1<<2),
-    /// Print the keyword and its value regardless
-    parse_echo_all = (1<<2) | (1<<1),
     /// Do not print the keyword
     parse_silent = 0,
     /// Raise error if the keyword is not provided
@@ -227,7 +225,7 @@ protected:
   /// Record that the keyword has just been set to its default value
   template<typename TYPE>
   void mark_key_set_default(std::string const &key_str,
-                            TYPE const &value,
+                            TYPE const &def_value,
                             Parse_Mode const &parse_mode);
 
 public:

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -231,10 +231,10 @@ protected:
   /// Raise error condition due to the keyword being required!
   void error_key_required(std::string const &key_str,
                           Parse_Mode const &parse_mode);
-  
+
   /// True if the keyword has been set already
   bool key_already_set(std::string const &key_str);
-  
+
 public:
 
   /// \brief Return a lowercased copy of the string
@@ -335,5 +335,13 @@ protected:
 
 };
 
+
+/// Bitwise OR between two Parse_mode flags
+inline colvarparse::Parse_Mode operator | (colvarparse::Parse_Mode const &mode1,
+                                           colvarparse::Parse_Mode const &mode2)
+{
+  return static_cast<colvarparse::Parse_Mode>(static_cast<int>(mode1) |
+                                              static_cast<int>(mode2));
+}
 
 #endif

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -55,14 +55,22 @@ public:
 
   /// How a keyword is parsed in a string
   enum Parse_Mode {
-    /// \brief(default) Read the first instance of a keyword (if
-    /// any), report its value, and print a warning when there is more
-    /// than one
-    parse_normal,
-    /// \brief Like parse_normal, but don't send any message to the log
-    /// (useful e.g. in restart files when such messages are very
-    /// numerous and redundant)
-    parse_silent
+    /// Zero for all other flags
+    parse_null = 0,
+    /// Print the value of a keyword if it is given
+    parse_echo = (1<<1),
+    /// Print the default value of a keyword, if it is NOT given
+    parse_echo_default = (1<<2),
+    /// Print the keyword and its value regardless
+    parse_echo_all = (1<<2) | (1<<1),
+    /// Do not print the keyword
+    parse_silent = 0,
+    /// Raise error if the keyword is not provided
+    parse_required = (1<<16),
+    /// Alias for parse_null (allows to define behavior later)
+    parse_restart = 0,
+    /// Alias for parse_echo_all (should be phased out)
+    parse_normal = (1<<2) | (1<<1)
   };
 
   /// \brief Check that all the keywords within "conf" are in the list

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -17,35 +17,9 @@
 /// need to parse input inherit from this
 class colvarparse {
 
-protected:
-
-  /// \brief List of legal keywords for this object: this is updated
-  /// by each call to colvarparse::get_keyval() or
-  /// colvarparse::key_lookup()
-  std::list<std::string> allowed_keywords;
-
-  /// \brief List of delimiters for the values of each keyword in the
-  /// configuration string; all keywords will be stripped of their
-  /// values before the keyword check is performed
-  std::list<size_t>      data_begin_pos;
-
-  /// \brief List of delimiters for the values of each keyword in the
-  /// configuration string; all keywords will be stripped of their
-  /// values before the keyword check is performed
-  std::list<size_t>      data_end_pos;
-
-  /// \brief Add a new valid keyword to the list
-  void add_keyword(char const *key);
-
-  /// \brief Remove all the values from the config string
-  void strip_values(std::string &conf);
-
-  /// \brief Configuration string of the object (includes comments)
-  std::string config_string;
-
 public:
 
-
+  /// Default constructor
   inline colvarparse()
   {
     init();
@@ -291,6 +265,32 @@ public:
   /// \param conf The configuration string \param start_pos Start the count
   /// from this position
   static int check_braces(std::string const &conf, size_t const start_pos);
+
+protected:
+
+  /// \brief List of legal keywords for this object: this is updated
+  /// by each call to colvarparse::get_keyval() or
+  /// colvarparse::key_lookup()
+  std::list<std::string> allowed_keywords;
+
+  /// \brief List of delimiters for the values of each keyword in the
+  /// configuration string; all keywords will be stripped of their
+  /// values before the keyword check is performed
+  std::list<size_t>      data_begin_pos;
+
+  /// \brief List of delimiters for the values of each keyword in the
+  /// configuration string; all keywords will be stripped of their
+  /// values before the keyword check is performed
+  std::list<size_t>      data_end_pos;
+
+  /// \brief Add a new valid keyword to the list
+  void add_keyword(char const *key);
+
+  /// \brief Remove all the values from the config string
+  void strip_values(std::string &conf);
+
+  /// \brief Configuration string of the object (includes comments)
+  std::string config_string;
 
 };
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -194,23 +194,37 @@ public:
 
 protected:
 
-  // Templates
-  template<typename TYPE> bool _get_keyval_scalar_(std::string const &conf,
-                                                   char const *key,
-                                                   TYPE &value,
-                                                   TYPE const &def_value,
-                                                   Parse_Mode const parse_mode);
-  bool _get_keyval_scalar_string_(std::string const &conf,
-                                  char const *key,
-                                  std::string &value,
-                                  std::string const &def_value,
-                                  Parse_Mode const parse_mode);
+  /// Get the string value of a keyword, and save it for later parsing
+  bool get_key_string_value(std::string const &conf,
+                            char const *key, std::string &data);
 
-  template<typename TYPE> bool _get_keyval_vector_(std::string const &conf,
-                                                   char const *key,
-                                                   std::vector<TYPE> &values,
-                                                   std::vector<TYPE> const &def_values,
-                                                   Parse_Mode const parse_mode);
+  /// Template for single-value keyword parsers
+  template<typename TYPE>
+  bool _get_keyval_scalar_(std::string const &conf,
+                           char const *key,
+                           TYPE &value,
+                           TYPE const &def_value,
+                           Parse_Mode const &parse_mode);
+
+  /// Template for multiple-value keyword parsers
+  template<typename TYPE>
+  bool _get_keyval_vector_(std::string const &conf,
+                           char const *key,
+                           std::vector<TYPE> &values,
+                           std::vector<TYPE> const &def_values,
+                           Parse_Mode const &parse_mode);
+
+  /// If parse_mode requires it, print that the keyword has been user-defined
+  template<typename TYPE>
+  void echo_key_set_user(char const *key,
+                         TYPE const &value,
+                         Parse_Mode const &parse_mode);
+
+  /// If parse_mode requires it, print that the keyword has been set by default
+  template<typename TYPE>
+  void echo_key_set_default(char const *key,
+                            TYPE const &value,
+                            Parse_Mode const &parse_mode);
 
 public:
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -69,8 +69,8 @@ public:
     /// Successive calls to get_keyval() will override the previous values
     /// when the keyword is not given any more
     parse_override = (1<<17),
-    /// Alias for parse_null (allows redefining its behavior later)
-    parse_restart = 0,
+    /// The call is being executed from a read_restart() function
+    parse_restart = (1<<18),
     /// Alias for old default behavior (should be phased out)
     parse_normal = (1<<2) | (1<<1) | (1<<17)
   };
@@ -228,6 +228,13 @@ protected:
                             TYPE const &def_value,
                             Parse_Mode const &parse_mode);
 
+  /// Raise error condition due to the keyword being required!
+  void error_key_required(std::string const &key_str,
+                          Parse_Mode const &parse_mode);
+  
+  /// True if the keyword has been set already
+  bool key_already_set(std::string const &key_str);
+  
 public:
 
   /// \brief Return a lowercased copy of the string

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -763,11 +763,11 @@ int colvarproxy_vmd::init_atom(cvm::residue_id const &resid,
   }
 
   if (cvm::debug())
-    log("Adding atom \""+
-        atom_name+"\" in residue "+
-        cvm::to_str(resid)+
-        " (index "+cvm::to_str(aid)+
-        ") for collective variables calculation.\n");
+    cvm::log("Adding atom \""+
+             atom_name+"\" in residue "+
+             cvm::to_str(resid)+
+             " (index "+cvm::to_str(aid)+
+             ") for collective variables calculation.\n");
 
   int const index = add_atom_slot(aid);
 


### PR DESCRIPTION
Closes #68 

This PR makes `Parse_Mode` a set of feature flags using bitwise operators.  A small number of hard-coded tests (e.g. missing parameters from the restart of restraint biases) make use of new flags `parse_required` and `parse_restart`.

Much duplicated code has also been removed from the `colvarparse` class.  Conversely, `cvm::to_str()` is now a set of regular overloaded functions, instantiating the original template: this is a cherry-pick of 49f2873 (`compiler_fixes` branch).  This turned out to be more important to incorporate when using the method in the parsing functions.

The `parse_quiet` flag that I mentioned in #68 seemed a bit too simplified in the end, and I opted for `logLevel` instead.  The keyword is so far *not* documented due to its limited support (see 12056cc), and should be fully implemented in another PR.

The same applies to integration with the dependency handler discussed in #68.