### PR TITLE
Do not integrate extended colvars outside MD

### DIFF
--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1027,9 +1027,6 @@ int colvarmodule::analyze()
     cvm::log("colvarmodule::analyze(), step = "+cvm::to_str(it)+".\n");
   }
 
-  if (cvm::step_relative() == 0)
-    cvm::log("Performing analysis.\n");
-
   // perform colvar-specific analysis
   for (std::vector<colvar *>::iterator cvi = variables_active()->begin();
        cvi != variables_active()->end();


### PR DESCRIPTION
fixes errors updating colvars in VMD for extended Lagrangian CVs
Also get rid of useless message "Performing analysis" everytime step 0 is processed.