### PR TITLE
If regtests fail, try lower precision

### DIFF
--- a/lammps/tests/library/run_tests.sh
+++ b/lammps/tests/library/run_tests.sh
@@ -21,13 +21,6 @@ if ! { echo ${DIRLIST} | grep -q 0 ; } then
   DIRLIST=`eval ls -d [0-9][0-9][0-9]_*`
 fi
 
-# Precision requested to pass (negative powers of ten)
-DIFF_PREC=6
-# Minimum precision to be tested
-MIN_PREC=1
-# Absolute precision (fixed)
-ABS_PREC=8
-
 TPUT_RED='true'
 TPUT_GREEN='true'
 TPUT_BLUE='true'
@@ -41,6 +34,11 @@ fi
 
 BASEDIR=$PWD
 ALL_SUCCESS=1
+
+# Precision requested to pass (negative powers of ten)
+DIFF_PREC=6
+# Minimum precision to be tested
+MIN_PREC=1
 
 cleanup_files() {
   for script in test*.lmp.in testres*.lmp.in ; do
@@ -157,7 +155,7 @@ for dir in ${DIRLIST} ; do
       sed 's/fs_/ft_/g' < ${base} > ${TMPDIR}/${base}
       mv -f ${TMPDIR}/${base} ${base}
     fi
-    spiff -r 1e-${DIFF_PREC} -a 1e-${ABS_PREC} $f $base > "$base.diff"
+    spiff -r 1e-${DIFF_PREC} $f $base > "$base.diff"
     RETVAL=$?
     if [ $RETVAL -ne 0 ]
     then

--- a/namd/tests/library/run_tests.sh
+++ b/namd/tests/library/run_tests.sh
@@ -48,7 +48,7 @@ BASEDIR=$PWD
 ALL_SUCCESS=1
 
 # Precision requested to pass (negative powers of ten)
-DIFF_PREC=7
+DIFF_PREC=6
 # Minimum precision to be tested
 MIN_PREC=1
 


### PR DESCRIPTION
Upon failure of a regtest result, try comparing outputs using a given range of lower precisions iteratively.
Makes it easier to run a demanding regtest and see at a glance if the failures are due to large or small divergences.