### PR TITLE
Print group masses and charges only after being updated

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -66,6 +66,9 @@ colvarproxy_namd::colvarproxy_namd()
 
   random = Random(simparams->randomSeed);
 
+  // both fields are taken from data structures already available
+  updated_masses_ = updated_charges_ = true;
+
   // take the output prefixes from the namd input
   output_prefix_str = std::string(simparams->outputFilename);
   restart_output_prefix_str = std::string(simparams->restartFilename);
@@ -96,10 +99,10 @@ colvarproxy_namd::colvarproxy_namd()
 #endif
 
 
-  // initiate module: this object will be the communication proxy
+  // initialize module: this object will be the communication proxy
   colvars = new colvarmodule(this);
-  log("Using NAMD interface, version "+
-      cvm::to_str(COLVARPROXY_VERSION)+".\n");
+  cvm::log("Using NAMD interface, version "+
+           cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
   if (config) {
     colvars->read_config_file(config->data);

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -929,14 +929,15 @@ int colvar::parse_analysis(std::string const &conf)
 }
 
 
-void colvar::setup() {
-  // loop over all components to reset masses of all groups
+void colvar::setup()
+{
+  // loop over all components to update masses and charges of all groups
   for (size_t i = 0; i < cvcs.size(); i++) {
     for (size_t ig = 0; ig < cvcs[i]->atom_groups.size(); ig++) {
-      cvm::atom_group &atoms = *(cvcs[i]->atom_groups[ig]);
-      atoms.setup();
-      atoms.reset_mass(name, i, ig);
-      atoms.read_positions();
+      cvm::atom_group *atoms = cvcs[i]->atom_groups[ig];
+      atoms->setup();
+      atoms->print_properties(name, i, ig);
+      atoms->read_positions();
     }
   }
 }

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -93,13 +93,19 @@ public:
   /// Get the latest value of the mass
   inline void update_mass()
   {
-    mass = (cvm::proxy)->get_atom_mass(index);
+    colvarproxy *p = cvm::proxy;
+    if (p->updated_masses()) {
+      mass = p->get_atom_mass(index);
+    }
   }
 
   /// Get the latest value of the charge
   inline void update_charge()
   {
-    charge = (cvm::proxy)->get_atom_charge(index);
+    colvarproxy *p = cvm::proxy;
+    if (p->updated_charges()) {
+      charge = p->get_atom_charge(index);
+    }
   }
 
   /// Get the current position
@@ -191,10 +197,10 @@ public:
   /// \brief Remove an atom object from this group
   int remove_atom(cvm::atom_iter ai);
 
-  /// \brief Re-initialize the total mass of a group.
+  /// \brief Print the updated the total mass and charge of a group.
   /// This is needed in case the hosting MD code has an option to
   /// change atom masses after their initialization.
-  void reset_mass(std::string const &colvar_name, int i, int j);
+  void print_properties(std::string const &colvar_name, int i, int j);
 
   /// \brief Implementation of the feature list for atom group
   static std::vector<feature *> ag_features;
@@ -340,15 +346,19 @@ public:
 
   /// Total mass of the atom group
   cvm::real total_mass;
+
+  /// Update the total mass of the atom group
   void update_total_mass();
 
   /// Total charge of the atom group
   cvm::real total_charge;
+
+  /// Update the total mass of the group
   void update_total_charge();
 
   /// \brief Don't apply any force on this group (use its coordinates
   /// only to calculate a colvar)
-  bool        noforce;
+  bool noforce;
 
   /// \brief Get the current positions
   void read_positions();

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1079,7 +1079,6 @@ int colvarmodule::end_of_step()
 int colvarmodule::setup()
 {
   if (this->size() == 0) return cvm::get_error();
-  // loop over all components of all colvars to reset masses of all groups
   for (std::vector<colvar *>::iterator cvi = variables()->begin();
        cvi != variables()->end();  cvi++) {
     (*cvi)->setup();

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -122,7 +122,10 @@ cvm::rvector colvarproxy_system::position_distance(cvm::atom_pos const &pos1,
 
 
 
-colvarproxy_atoms::colvarproxy_atoms() {}
+colvarproxy_atoms::colvarproxy_atoms()
+{
+  updated_masses_ = updated_charges_ = false;
+}
 
 
 colvarproxy_atoms::~colvarproxy_atoms()

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -220,11 +220,15 @@ public:
 
   inline std::vector<cvm::real> *modify_atom_masses()
   {
+    // assume that we are requesting masses to change them
+    updated_masses_ = true;
     return &atoms_masses;
   }
 
   inline std::vector<cvm::real> *modify_atom_charges()
   {
+    // assume that we are requesting charges to change them
+    updated_charges_ = true;
     return &atoms_charges;
   }
 
@@ -241,6 +245,18 @@ public:
   inline std::vector<cvm::rvector> *modify_atom_new_colvar_forces()
   {
     return &atoms_new_colvar_forces;
+  }
+
+  /// Record whether masses have been updated
+  inline bool updated_masses() const
+  {
+    return updated_masses_;
+  }
+
+  /// Record whether masses have been updated
+  inline bool updated_charges() const
+  {
+    return updated_charges_;
   }
 
 protected:
@@ -260,6 +276,9 @@ protected:
   std::vector<cvm::rvector> atoms_total_forces;
   /// \brief Forces applied from colvars, to be communicated to the MD integrator
   std::vector<cvm::rvector> atoms_new_colvar_forces;
+
+  /// Whether the masses and charges have been updated from the host code
+  bool updated_masses_, updated_charges_;
 
   /// Used by all init_atom() functions: create a slot for an atom not
   /// requested yet; returns the index in the arrays

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -123,6 +123,9 @@ colvarproxy_vmd::colvarproxy_vmd(Tcl_Interp *interp, VMDApp *v, int molid)
   version_int = get_version_from_string(COLVARPROXY_VERSION);
   b_simulation_running = false;
 
+  // both fields are taken from data structures already available
+  updated_masses_ = updated_charges_ = true;
+
   colvars = new colvarmodule(this);
   cvm::log("Using VMD interface, version "+
            cvm::to_str(COLVARPROXY_VERSION)+".\n");


### PR DESCRIPTION
This is most relevant in LAMMPS, where atom masses and charges are generally available only when the first "run" has begun, and the `fix colvars` instance communicates the relevant masses and charges from all MPI processes to the first MPI process, where the fix is executed (and output printed).

No changes in VMD and NAMD. @HubLot this will be relevant for the GROMACS interface, if you merge `master` into your branch (otherwise, I'll just add the relevant line upon merging PR #190).