### PR TITLE
Clarify when new-style wall force constants are scaled

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -4156,10 +4156,12 @@ A harmonic restraint is set up by a \texttt{harmonic~\{...\}} block, which may c
     Scaled force constant (\cvnamdonly{kcal/mol}\cvvmdonly{kcal/mol}\cvlammpsonly{unit of energy specified by \texttt{units}})}{%
     positive decimal}{%
     \texttt{1.0}}{%
-    This option defines a scaled force constant $k$ for the harmonic potential (eq.~\ref{eq:colvarbias_harmonic_multi}).
+    This option defines a \emph{scaled} force constant $k$ for the harmonic potential (eq.~\ref{eq:colvarbias_harmonic_multi}).
     To ensure consistency for multidimensional restraints, it is divided internally by the square of the specific \texttt{width} of each variable (which is 1 by default).
     This makes all values effectively dimensionless and of commensurate size.
-    For instance, setting a scaled force constant of 10~kcal/mol acting on two variables, an angle with a \texttt{width} of 5~degrees and a distance  with a width of 0.5~\AA{}, will apply actual force constants of 0.4~kcal/mol$\times$degree$^{-2}$ for the angle and 40~kcal/mol/\AA$^2$ for the distance.
+    For instance, if this force constant is set to $RT$, then the thermal fluctuations of each variable will be on the order of its \texttt{width}.
+    % Setting a scaled force constant of 10~kcal/mol acting on two variables, an angle with a \texttt{width} of 5~degrees and a distance  with a width of 0.5~\AA{},
+    % will apply actual force constants of 0.4~kcal/mol$\times$degree$^{-2}$ for the angle and 40~kcal/mol/\AA$^2$ for the distance.
     \emph{The values of the actual force constants are always printed when the restraint is defined.}
   }
 
@@ -4395,8 +4397,8 @@ The \texttt{harmonicWalls~\{...\}} bias is closely related to the harmonic bias 
 \end{equation}
 where $\xi_{\mathrm{lower}}$ and $\xi_{\mathrm{upper}}$ are the lower and upper wall thresholds, respectively; \emph{(ii)} because an interval between two walls is defined, only scalar variables can be used (but any number of variables can be defined, and the wall bias is intrinsically multi-dimensional).
 
-\textbf{Note:} this bias replaces the keywords \texttt{lowerWall}, \texttt{lowerWallConstant}, \texttt{upperWall} and \texttt{upperWallConstant} defined in the \texttt{colvar} context (see \ref{sec:colvar}).
-These keywords are still supported, but are deprecated for future uses.
+\textbf{Note:} this bias replaces the keywords \texttt{lowerWall}, \texttt{lowerWallConstant}, \texttt{upperWall} and \texttt{upperWallConstant} defined in the \texttt{colvar} context.
+Those keywords are deprecated.
 
 The \texttt{harmonicWalls} bias implements the following options:
 \begin{itemize}
@@ -4432,6 +4434,7 @@ The \texttt{harmonicWalls} bias implements the following options:
     positive decimal}{%
     \texttt{forceConstant}}{%
     When both sets of walls are defined (lower and upper), this keyword allows setting different force constants for them.
+    As with \texttt{forceConstant}, the specified constant is divided internally by the square of the specific \texttt{width} of each variable (which is 1 by default).
     The force constant reported in the output as ``$k$'', and used in the change of force constant scheme, is the geometric mean of the two.
   }
 
@@ -4486,7 +4489,7 @@ using \cite{Pitera2012}.
     Scaled force constant (\cvnamdonly{kcal/mol}\cvvmdonly{kcal/mol}\cvlammpsonly{unit of energy specified by \texttt{units}})}{%
     positive decimal}{%
     \texttt{1.0}}{%
-    This option defines a scaled force constant for the linear bias.
+    This option defines a \emph{scaled} force constant for the linear bias.
     To ensure consistency for multidimensional restraints, it is divided internally by the specific \texttt{width} of each variable (which is 1 by default), so that all variables are effectively dimensionless and of commensurate size.
     \emph{The values of the actual force constants are always printed when the restraint is defined.}
 }

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -4160,7 +4160,7 @@ A harmonic restraint is set up by a \texttt{harmonic~\{...\}} block, which may c
     This option defines a \emph{scaled} force constant $k$ for the harmonic potential (eq.~\ref{eq:colvarbias_harmonic_multi}).
     To ensure consistency for multidimensional restraints, it is divided internally by the square of the specific \texttt{width} of each variable (which is 1 by default).
     This makes all values effectively dimensionless and of commensurate size.
-    For instance, if this force constant is set to the thermal energy $\kappa_{\mathrm{B}}T$ (equal to $RT$ if kcal/mol units are used), then the amplitude of the thermal fluctuations of each variable $\xi$ will be on the order of its \texttt{width}, $w_{\xi}$.
+    For instance, if this force constant is set to the thermal energy $\kappa_{\mathrm{B}}T$ (equal to $RT$ if molar units are used), then the amplitude of the thermal fluctuations of each variable $\xi$ will be on the order of its \texttt{width}, $w_{\xi}$.
     This can be used to estimate the optimal spacing of umbrella-sampling windows (under the assumption that the force constant is larger than the curvature of the underlying free energy).
     \emph{The values of the actual force constants $k/w_{\xi}^2$ are always printed when the restraint is defined.}
   }

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -4150,6 +4150,7 @@ A harmonic restraint is set up by a \texttt{harmonic~\{...\}} block, which may c
 \item \dupkey{writeTISamples}{\texttt{harmonic}}{sec:colvarbias}{biasing and analysis methods}
 
 \item %
+  \labelkey{harmonic|forceConstant}
   \keydef
     {forceConstant}{%
     \texttt{harmonic}}{%
@@ -4159,10 +4160,9 @@ A harmonic restraint is set up by a \texttt{harmonic~\{...\}} block, which may c
     This option defines a \emph{scaled} force constant $k$ for the harmonic potential (eq.~\ref{eq:colvarbias_harmonic_multi}).
     To ensure consistency for multidimensional restraints, it is divided internally by the square of the specific \texttt{width} of each variable (which is 1 by default).
     This makes all values effectively dimensionless and of commensurate size.
-    For instance, if this force constant is set to $RT$, then the thermal fluctuations of each variable will be on the order of its \texttt{width}.
-    % Setting a scaled force constant of 10~kcal/mol acting on two variables, an angle with a \texttt{width} of 5~degrees and a distance  with a width of 0.5~\AA{},
-    % will apply actual force constants of 0.4~kcal/mol$\times$degree$^{-2}$ for the angle and 40~kcal/mol/\AA$^2$ for the distance.
-    \emph{The values of the actual force constants are always printed when the restraint is defined.}
+    For instance, if this force constant is set to the thermal energy $\kappa_{\mathrm{B}}T$ (equal to $RT$ if kcal/mol units are used), then the amplitude of the thermal fluctuations of each variable $\xi$ will be on the order of its \texttt{width}, $w_{\xi}$.
+    This can be used to estimate the optimal spacing of umbrella-sampling windows (under the assumption that the force constant is larger than the curvature of the underlying free energy).
+    \emph{The values of the actual force constants $k/w_{\xi}^2$ are always printed when the restraint is defined.}
   }
 
 \item %
@@ -4434,8 +4434,8 @@ The \texttt{harmonicWalls} bias implements the following options:
     positive decimal}{%
     \texttt{forceConstant}}{%
     When both sets of walls are defined (lower and upper), this keyword allows setting different force constants for them.
-    As with \texttt{forceConstant}, the specified constant is divided internally by the square of the specific \texttt{width} of each variable (which is 1 by default).
-    The force constant reported in the output as ``$k$'', and used in the change of force constant scheme, is the geometric mean of the two.
+    As with \texttt{forceConstant}, the specified constant is divided internally by the square of the specific \texttt{width} of each variable (see also the equivalent keyword for the harmonic restraint, \refkey{forceConstant}{harmonic|forceConstant}).
+    The force constant reported in the output as ``$k$'', and used in the change of force constant scheme, is the geometric mean of \texttt{upperWallConstant} and \texttt{upperWallConstant}.
   }
 
 \item %
@@ -4491,7 +4491,8 @@ using \cite{Pitera2012}.
     \texttt{1.0}}{%
     This option defines a \emph{scaled} force constant for the linear bias.
     To ensure consistency for multidimensional restraints, it is divided internally by the specific \texttt{width} of each variable (which is 1 by default), so that all variables are effectively dimensionless and of commensurate size.
-    \emph{The values of the actual force constants are always printed when the restraint is defined.}
+    See also the equivalent keyword for the harmonic restraint, \refkey{forceConstant}{harmonic|forceConstant}.
+    \emph{The values of the actual force constants $k/w_{\xi}$ are always printed when the restraint is defined.}
 }
 
 \item %

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -464,7 +464,7 @@ int colvar::init_grid_parameters(std::string const &conf)
     if (get_keyval(conf, "lowerWallConstant", lower_wall_k, 0.0,
                    parse_silent)) {
       cvm::log("Reading legacy options lowerWall and lowerWallConstant: "
-               "consider using a harmonicWalls restraint.\n");
+               "consider using a harmonicWalls restraint\n(caution: force constant would then be scaled by width^2).\n");
       lower_wall.type(value());
       if (!get_keyval(conf, "lowerWall", lower_wall, lower_boundary)) {
         cvm::log("Warning: lowerWall will need to be "
@@ -478,7 +478,7 @@ int colvar::init_grid_parameters(std::string const &conf)
     if (get_keyval(conf, "upperWallConstant", upper_wall_k, 0.0,
                    parse_silent)) {
       cvm::log("Reading legacy options upperWall and upperWallConstant: "
-               "consider using a harmonicWalls restraint.\n");
+               "consider using a harmonicWalls restraint\n(caution: force constant would then be scaled by width^2).\n");
       upper_wall.type(value());
       if (!get_keyval(conf, "upperWall", upper_wall, upper_boundary)) {
         cvm::log("Warning: upperWall will need to be "

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -780,11 +780,11 @@ int colvarbias_restraint_harmonic::init(std::string const &conf)
   colvarbias_restraint_k_moving::init(conf);
 
   for (size_t i = 0; i < num_variables(); i++) {
-    if (variables(i)->width != 1.0)
-      cvm::log("The force constant for colvar \""+variables(i)->name+
-               "\" will be rescaled to "+
-               cvm::to_str(force_k / (variables(i)->width * variables(i)->width))+
-               " according to the specified width.\n");
+    cvm::real const w = variables(i)->width;
+    cvm::log("The force constant for colvar \""+variables(i)->name+
+             "\" will be rescaled to "+
+             cvm::to_str(force_k/(w*w))+
+             " according to the specified width ("+cvm::to_str(w)+").\n");
   }
 
   return COLVARS_OK;
@@ -1030,25 +1030,21 @@ int colvarbias_restraint_harmonic_walls::init(std::string const &conf)
 
   if (lower_walls.size() > 0) {
     for (i = 0; i < num_variables(); i++) {
-      if (variables(i)->width != 1.0)
-        cvm::log("The lower wall force constant for colvar \""+
-                 variables(i)->name+
-                 "\" will be rescaled to "+
-                 cvm::to_str(lower_wall_k * force_k /
-                             (variables(i)->width * variables(i)->width))+
-                 " according to the specified width.\n");
+      cvm::real const w = variables(i)->width;
+      cvm::log("The lower wall force constant for colvar \""+
+               variables(i)->name+"\" will be rescaled to "+
+               cvm::to_str(lower_wall_k * force_k / (w*w))+
+               " according to the specified width ("+cvm::to_str(w)+").\n");
     }
   }
 
   if (upper_walls.size() > 0) {
     for (i = 0; i < num_variables(); i++) {
-      if (variables(i)->width != 1.0)
-        cvm::log("The upper wall force constant for colvar \""+
-                 variables(i)->name+
-                 "\" will be rescaled to "+
-                 cvm::to_str(upper_wall_k * force_k /
-                             (variables(i)->width * variables(i)->width))+
-                 " according to the specified width.\n");
+      cvm::real const w = variables(i)->width;
+      cvm::log("The upper wall force constant for colvar \""+
+               variables(i)->name+"\" will be rescaled to "+
+               cvm::to_str(upper_wall_k * force_k / (w*w))+
+               " according to the specified width ("+cvm::to_str(w)+").\n");
     }
   }
 
@@ -1218,11 +1214,11 @@ int colvarbias_restraint_linear::init(std::string const &conf)
                  INPUT_ERROR);
       return INPUT_ERROR;
     }
-    if (variables(i)->width != 1.0)
-      cvm::log("The force constant for colvar \""+variables(i)->name+
-               "\" will be rescaled to "+
-               cvm::to_str(force_k / variables(i)->width)+
-               " according to the specified width.\n");
+    cvm::real const w = variables(i)->width;
+    cvm::log("The force constant for colvar \""+variables(i)->name+
+             "\" will be rescaled to "+
+             cvm::to_str(force_k / w)+
+             " according to the specified width ("+cvm::to_str(w)+").\n");
   }
 
   return COLVARS_OK;


### PR DESCRIPTION
to help users in the transition from colvar/upperWallConstant to separate biases. See issue #211 