### PR TITLE
Obtain ABF gradient and free energy through Tcl interface

### DIFF
--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -69,7 +69,6 @@ int colvarbias::init(std::string const &conf)
       cvm::error("Error: no collective variables specified.\n", INPUT_ERROR);
       return INPUT_ERROR;
     }
-
   } else {
     cvm::log("Reinitializing bias \""+name+"\".\n");
   }
@@ -266,6 +265,16 @@ int colvarbias::current_bin()
 int colvarbias::bin_count(int bin_index)
 {
   cvm::error("Error: bin_count() not implemented.\n");
+  return COLVARS_NOT_IMPLEMENTED;
+}
+cvm::real colvarbias::bin_gradient(int bin_index)
+{
+  cvm::error("Error: bin_gradient() not implemented.\n");
+  return COLVARS_NOT_IMPLEMENTED;
+}
+cvm::real colvarbias::delta_free_energy(cvm::real x)
+{
+  cvm::error("Error: delta_free_energy() not implemented.\n");
   return COLVARS_NOT_IMPLEMENTED;
 }
 int colvarbias::replica_share()

--- a/src/colvarbias.h
+++ b/src/colvarbias.h
@@ -77,6 +77,10 @@ public:
   //// Give the count at a given bin index.
   // FIXME this is currently 1D only
   virtual int bin_count(int bin_index);
+  //// Give gradient at a given bin index.
+  virtual cvm::real bin_gradient(int bin_index);
+  //// Integrate the gradient up to position x.
+  virtual cvm::real delta_free_energy(cvm::real x);
   //// Share information between replicas, whatever it may be.
   virtual int replica_share();
 

--- a/src/colvarbias_abf.h
+++ b/src/colvarbias_abf.h
@@ -124,8 +124,12 @@ private:
   virtual int bin_num();
   /// Calculate the bin index for a given bias.
   virtual int current_bin();
-  //// Give the count at a given bin index.
+  /// Give the count at a given bin index.
   virtual int bin_count(int bin_index);
+  /// Give the gradient at a given bin index.
+  virtual cvm::real bin_gradient(int bin_index);
+  /// Give the free energy from grid edge 0 to current position.
+  virtual cvm::real delta_free_energy(cvm::real x);
 
   /// Write human-readable FE gradients and sample count, and DX file in dim > 2
   void write_gradients_samples(const std::string &prefix, bool append = false);

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -450,6 +450,7 @@ int colvarscript::proc_bias(colvarbias *b, int objc, unsigned char *const objv[]
     return COLVARS_OK;
   }
 
+  
   if (subcmd == "share") {
     int r = b->replica_share();
     if (r < 0) {
@@ -480,10 +481,33 @@ int colvarscript::proc_bias(colvarbias *b, int objc, unsigned char *const objv[]
     if (subcmd == "count") {
       int index;
       if (!(std::istringstream(param) >> index)) {
-        result = "bin_count: error parsing bin index";
+        result = "bias count: error parsing bin index";
         return COLVARSCRIPT_ERROR;
       }
       result = cvm::to_str(b->bin_count(index));
+      return COLVARS_OK;
+    }
+
+    // Get ABF gradient
+    if (subcmd == "gradient") {
+      int index;
+      if (!(std::istringstream(param) >> index)) {
+	result = "bias gradient: error parsing bin index";
+	return COLVARSCRIPT_ERROR;
+      }
+      result = cvm::to_str(-b->bin_gradient(index));
+      return COLVARS_OK;
+    }
+
+    // Get free energy by integrating over gradients
+    if (subcmd == "freeenergy") {
+      cvm::real x;
+      if (!(std::istringstream(param) >> x)) {
+	result = "bias freeenergy: error parsing colvar value";
+	return COLVARSCRIPT_ERROR;
+      }
+      cvm::real dg = b->delta_free_energy(x);
+      result = cvm::to_str(dg);
       return COLVARS_OK;
     }
 


### PR DESCRIPTION
I've added the ability to get the ABF gradient and free energy through the Tcl interface. This is useful for replica exchange ABF. I've tested it to make sure that "cv bias abf1 freeenergy $x" gives the correct effective applied energy (including the influence of fullSamples). As of now, it works only for 1-dimensional ABF. It may or may not work for eABF. I plan on looking into that.