### PR TITLE
Add Dashboard feature to display cv gradients

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -836,12 +836,9 @@ void colvar::build_atom_list(void)
   temp_id_list.sort();
   temp_id_list.unique();
 
-  // atom_ids = std::vector<int> (temp_id_list.begin(), temp_id_list.end());
-  unsigned int id_i = 0;
   std::list<int>::iterator li;
   for (li = temp_id_list.begin(); li != temp_id_list.end(); ++li) {
-    atom_ids[id_i] = *li;
-    id_i++;
+    atom_ids.push_back(*li);
   }
 
   temp_id_list.clear();
@@ -952,6 +949,7 @@ int colvar::init_dependencies() {
     require_feature_self(f_cv_collect_gradient, f_cv_scalar);
     // The following exlusion could be lifted by implementing the feature
     exclude_feature_self(f_cv_collect_gradient, f_cv_scripted);
+    require_feature_children(f_cv_collect_gradient, f_cvc_explicit_gradient);
 
     init_feature(f_cv_fdiff_velocity, "velocity from finite differences", f_type_dynamic);
 

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -211,9 +211,9 @@ int cvm::atom_group::init_dependencies() {
     init_feature(f_ag_center, "translational fit", f_type_static);
     init_feature(f_ag_rotate, "rotational fit", f_type_static);
     init_feature(f_ag_fitting_group, "reference positions group", f_type_static);
-    init_feature(f_ag_implicit_gradient, "implicit atom gradient", f_type_dynamic);
+    init_feature(f_ag_explicit_gradient, "explicit atom gradient", f_type_dynamic);
     init_feature(f_ag_fit_gradients, "fit gradients", f_type_user);
-    exclude_feature_self(f_ag_fit_gradients, f_ag_implicit_gradient);
+    require_feature_self(f_ag_fit_gradients, f_ag_explicit_gradient);
 
     init_feature(f_ag_atom_forces, "atomic forces", f_type_dynamic);
 
@@ -238,7 +238,7 @@ int cvm::atom_group::init_dependencies() {
   // TODO make f_ag_scalable depend on f_ag_scalable_com (or something else)
   feature_states[f_ag_scalable].available = true;
   feature_states[f_ag_fit_gradients].available = true;
-  feature_states[f_ag_implicit_gradient].available = true;
+  feature_states[f_ag_explicit_gradient].available = true;
 
   return COLVARS_OK;
 }

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -210,7 +210,7 @@ int cvm::atom_group::init_dependencies() {
     init_feature(f_ag_active, "active", f_type_dynamic);
     init_feature(f_ag_center, "translational fit", f_type_static);
     init_feature(f_ag_rotate, "rotational fit", f_type_static);
-    init_feature(f_ag_fitting_group, "reference positions group", f_type_static);
+    init_feature(f_ag_fitting_group, "fitting group", f_type_static);
     init_feature(f_ag_explicit_gradient, "explicit atom gradient", f_type_dynamic);
     init_feature(f_ag_fit_gradients, "fit gradients", f_type_user);
     require_feature_self(f_ag_fit_gradients, f_ag_explicit_gradient);
@@ -238,6 +238,7 @@ int cvm::atom_group::init_dependencies() {
   // TODO make f_ag_scalable depend on f_ag_scalable_com (or something else)
   feature_states[f_ag_scalable].available = true;
   feature_states[f_ag_fit_gradients].available = true;
+  feature_states[f_ag_fitting_group].available = true;
   feature_states[f_ag_explicit_gradient].available = true;
 
   return COLVARS_OK;
@@ -748,6 +749,7 @@ int cvm::atom_group::parse_fitting_options(std::string const &group_conf)
           return INPUT_ERROR;
         }
       }
+      set_enabled(f_ag_fitting_group);
     }
 
     atom_group *group_for_fit = fitting_group ? fitting_group : this;

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -187,15 +187,16 @@ int colvar::cvc::init_dependencies() {
 
     init_feature(f_cvc_gradient, "gradient", f_type_dynamic);
 
-    init_feature(f_cvc_implicit_gradient, "implicit gradient", f_type_static);
-    require_feature_children(f_cvc_implicit_gradient, f_ag_implicit_gradient);
+    init_feature(f_cvc_explicit_gradient, "explicit gradient", f_type_static);
+    require_feature_self(f_cvc_explicit_gradient, f_cvc_gradient);
+    require_feature_children(f_cvc_explicit_gradient, f_ag_explicit_gradient);
 
     init_feature(f_cvc_inv_gradient, "inverse gradient", f_type_dynamic);
     require_feature_self(f_cvc_inv_gradient, f_cvc_gradient);
 
     init_feature(f_cvc_debug_gradient, "debug gradient", f_type_user);
     require_feature_self(f_cvc_debug_gradient, f_cvc_gradient);
-    exclude_feature_self(f_cvc_debug_gradient, f_cvc_implicit_gradient);
+    require_feature_self(f_cvc_debug_gradient, f_cvc_explicit_gradient);
 
     init_feature(f_cvc_Jacobian, "Jacobian derivative", f_type_dynamic);
     require_feature_self(f_cvc_Jacobian, f_cvc_inv_gradient);
@@ -230,16 +231,22 @@ int colvar::cvc::init_dependencies() {
     feature_states.push_back(feature_state(avail, false));
   }
 
-  // CVCs are enabled from the start - get disabled based on flags
-  feature_states[f_cvc_active].enabled = true;
-
   // Features that are implemented by all cvcs by default
   // Each cvc specifies what other features are available
   feature_states[f_cvc_active].available = true;
   feature_states[f_cvc_gradient].available = true;
 
+  // CVCs are enabled from the start - get disabled based on flags
+  enable(f_cvc_active);
+  // feature_states[f_cvc_active].enabled = true;
+
+  // Explicit gradients are implemented in mosts CVCs. Exceptions must be specified explicitly.
+  // feature_states[f_cvc_explicit_gradient].enabled = true;
+  enable(f_cvc_explicit_gradient);
+
   // Use minimum-image distances by default
-  feature_states[f_cvc_pbc_minimum_image].enabled = true;
+  // feature_states[f_cvc_pbc_minimum_image].enabled = true;
+  enable(f_cvc_pbc_minimum_image);
 
   // Features that are implemented by default if their requirements are
   feature_states[f_cvc_one_site_total_force].available = true;

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -306,6 +306,11 @@ std::vector<std::vector<int> > colvar::cvc::get_atom_lists()
   for ( ; agi != atom_groups.end(); ++agi) {
     (*agi)->create_sorted_ids();
     lists.push_back((*agi)->sorted_ids());
+    if ((*agi)->is_enabled(f_ag_fitting_group) && (*agi)->is_enabled(f_ag_fit_gradients)) {
+      cvm::atom_group &fg = *((*agi)->fitting_group);
+      fg.create_sorted_ids();
+      lists.push_back(fg.sorted_ids());
+    }
   }
   return lists;
 }

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -93,7 +93,7 @@ colvar::distance_vec::distance_vec(std::string const &conf)
 {
   function_type = "distance_vec";
   enable(f_cvc_com_based);
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_3vector);
 }
 
@@ -103,7 +103,7 @@ colvar::distance_vec::distance_vec()
 {
   function_type = "distance_vec";
   enable(f_cvc_com_based);
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_3vector);
 }
 
@@ -473,7 +473,7 @@ colvar::distance_dir::distance_dir(std::string const &conf)
 {
   function_type = "distance_dir";
   enable(f_cvc_com_based);
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_unit3vector);
 }
 
@@ -483,7 +483,7 @@ colvar::distance_dir::distance_dir()
 {
   function_type = "distance_dir";
   enable(f_cvc_com_based);
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_unit3vector);
 }
 
@@ -663,7 +663,7 @@ colvar::distance_pairs::distance_pairs(std::string const &conf)
   group2 = parse_group(conf, "group2");
 
   x.type(colvarvalue::type_vector);
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.vector1d_value.resize(group1->size() * group2->size());
 }
 
@@ -671,7 +671,7 @@ colvar::distance_pairs::distance_pairs(std::string const &conf)
 colvar::distance_pairs::distance_pairs()
 {
   function_type = "distance_pairs";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_vector);
 }
 
@@ -1485,7 +1485,7 @@ colvar::cartesian::cartesian(std::string const &conf)
   }
 
   x.type(colvarvalue::type_vector);
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.vector1d_value.resize(atoms->size() * axes.size());
 }
 

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -18,7 +18,7 @@ colvar::alpha_angles::alpha_angles(std::string const &conf)
     cvm::log("Initializing alpha_angles object.\n");
 
   function_type = "alpha_angles";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 
   std::string segment_id;
@@ -109,7 +109,7 @@ colvar::alpha_angles::alpha_angles()
   : cvc()
 {
   function_type = "alpha_angles";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 }
 
@@ -233,7 +233,7 @@ colvar::dihedPC::dihedPC(std::string const &conf)
     cvm::log("Initializing dihedral PC object.\n");
 
   function_type = "dihedPC";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 
   std::string segment_id;
@@ -363,7 +363,7 @@ colvar::dihedPC::dihedPC()
   : cvc()
 {
   function_type = "dihedPC";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 }
 

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -12,7 +12,7 @@ colvar::orientation::orientation(std::string const &conf)
   : cvc()
 {
   function_type = "orientation";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_quaternion);
   init(conf);
 }
@@ -88,7 +88,7 @@ colvar::orientation::orientation()
   : cvc()
 {
   function_type = "orientation";
-  enable(f_cvc_implicit_gradient);
+  disable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_quaternion);
 }
 
@@ -157,7 +157,7 @@ colvar::orientation_angle::orientation_angle(std::string const &conf)
   : orientation()
 {
   function_type = "orientation_angle";
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
   init(conf);
 }
@@ -173,7 +173,7 @@ colvar::orientation_angle::orientation_angle()
   : orientation()
 {
   function_type = "orientation_angle";
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 }
 
@@ -222,7 +222,7 @@ colvar::orientation_proj::orientation_proj(std::string const &conf)
   : orientation()
 {
   function_type = "orientation_proj";
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
   init(conf);
 }
@@ -238,7 +238,7 @@ colvar::orientation_proj::orientation_proj()
   : orientation()
 {
   function_type = "orientation_proj";
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 }
 
@@ -278,7 +278,7 @@ colvar::tilt::tilt(std::string const &conf)
   : orientation()
 {
   function_type = "tilt";
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
   init(conf);
 }
@@ -304,7 +304,7 @@ colvar::tilt::tilt()
   : orientation()
 {
   function_type = "tilt";
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 }
 
@@ -352,7 +352,7 @@ colvar::spin_angle::spin_angle(std::string const &conf)
   function_type = "spin_angle";
   period = 360.0;
   b_periodic = true;
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
   init(conf);
 }
@@ -380,7 +380,7 @@ colvar::spin_angle::spin_angle()
   function_type = "spin_angle";
   period = 360.0;
   b_periodic = true;
-  disable(f_cvc_implicit_gradient);
+  enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 }
 

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -314,8 +314,8 @@ public:
     f_cvc_active,
     f_cvc_scalar,
     f_cvc_gradient,
-    /// \brief CVC doesn't calculate and store explicit atom gradients
-    f_cvc_implicit_gradient,
+    /// \brief CVC calculates and stores explicit atom gradients
+    f_cvc_explicit_gradient,
     f_cvc_inv_gradient,
     /// \brief If enabled, calc_gradients() will call debug_gradients() for every group needed
     f_cvc_debug_gradient,
@@ -337,7 +337,7 @@ public:
     /// ie. not using refpositionsgroup
 //     f_ag_min_msd_fit,
     /// \brief Does not have explicit atom gradients from parent CVC
-    f_ag_implicit_gradient,
+    f_ag_explicit_gradient,
     f_ag_fit_gradients,
     f_ag_atom_forces,
     f_ag_scalable,

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -340,6 +340,31 @@ int colvarscript::proc_colvar(colvar *cv, int objc, unsigned char *const objv[])
     return COLVARS_OK;
   }
 
+  if (subcmd == "getatomids_flat") {
+    std::vector<int>::iterator li = cv->atom_ids.begin();
+
+    for ( ; li != cv->atom_ids.end(); ++li) {
+      result += cvm::to_str(*li);
+      result += " ";
+    }
+    return COLVARS_OK;
+  }
+
+  if (subcmd == "getgradients") {
+    std::vector<cvm::rvector>::iterator li = cv->atomic_gradients.begin();
+
+    for ( ; li != cv->atomic_gradients.end(); ++li) {
+      result += "{";
+      int j;
+      for (j = 0; j < 3; ++j) {
+        result += cvm::to_str((*li)[j]);
+        result += " ";
+      }
+      result += "} ";
+    }
+    return COLVARS_OK;
+  }
+
   if (subcmd == "getappliedforce") {
     result = (cv->applied_force()).to_simple_string();
     return COLVARS_OK;

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -324,7 +324,7 @@ int colvarscript::proc_colvar(colvar *cv, int objc, unsigned char *const objv[])
     return COLVARS_OK;
   }
 
-  if (subcmd == "getatomids") {
+  if (subcmd == "getatomgroups") {
     std::vector<std::vector<int> > lists = cv->get_atom_lists();
     std::vector<std::vector<int> >::iterator li = lists.begin();
 
@@ -340,7 +340,7 @@ int colvarscript::proc_colvar(colvar *cv, int objc, unsigned char *const objv[])
     return COLVARS_OK;
   }
 
-  if (subcmd == "getatomids_flat") {
+  if (subcmd == "getatomids") {
     std::vector<int>::iterator li = cv->atom_ids.begin();
 
     for ( ; li != cv->atom_ids.end(); ++li) {

--- a/vmd/cv_dashboard/cv_dashboard.tcl
+++ b/vmd/cv_dashboard/cv_dashboard.tcl
@@ -460,10 +460,9 @@ proc draw_arrow {mol start end} {
 proc ::cv_dashboard::show_gradients {} {
 
   foreach cv [selected_colvars] {
-    if { [lsearch $::cv_dashboard::grad_cvs $cv] > -1 } { continue }
     if { [run_cv colvar $cv set "collect gradient" 1] == -1 } { continue }
     run_cv colvar $cv update ;# required to get inital values of gradients
-    lappend ::cv_dashboard::grad_cvs $cv
+    if { [lsearch $::cv_dashboard::grad_cvs $cv] == -1 } { lappend ::cv_dashboard::grad_cvs $cv }
   }
   update_shown_gradients
 }
@@ -476,9 +475,8 @@ proc ::cv_dashboard::update_shown_gradients {} {
   }
   set colorid 1
   foreach cv $::cv_dashboard::grad_cvs {
-
-    # For atom groups, could detect identical gradients on atoms, and display based on COM
     set atomids [run_cv colvar $cv getatomids_flat]
+    if { [llength $atomids] == 0 } { continue }
     set grads [run_cv colvar $cv getgradients]
     set sel [atomselect top "index $atomids"]
     set coords [$sel get {x y z}]

--- a/vmd/cv_dashboard/cv_dashboard.tcl
+++ b/vmd/cv_dashboard/cv_dashboard.tcl
@@ -14,26 +14,14 @@
 # This plugin only acts on the "top" molecule
 # which is most consistent for trajectory animation (determined by the frame number of top mol)
 
-# TODO PRIORITY:
-# - currently only way to handle harmonic walls is legacy, bc separate biases are not accessible!
-# - documentation -> link to section in HTML VMD/Colvars on github.io
-
-# TODO:
-# - properly calculate position of cursor in plot when not all the plot is visible (resized window)
-# - retain comments in config strings (needs upstream support in colvars)
-# - Retain the whole config string minus colvars, copy to output? Problem: not visible in interface
-# - histograms - either directly from plot window
-
 # TODO Multiplot:
+# - properly calculate position of cursor in plot when not all the plot is visible (resized window)
 # - handle several windows at once - at least one pairwise, one timeline
 # - integrate interactive hacks into interface
 # - display pairwise traj on top of known 2D data (eg. FE surface)
-# - embed inside main window?
 
 # TODO maybe:
 # - index group builder
-# - graphical representations such as rotation_display
-
 
 package provide cv_dashboard 1.0
 
@@ -153,7 +141,8 @@ proc ::cv_dashboard::createWindow {} {
 
   if {[string compare [run_cv version] "2019-03-18"] >= 0} {
     incr gridrow
-    grid [ttk::button $w.show_gradients -text "Show gradients" -command {::cv_dashboard::show_gradients} -padding "2 0 2 0"] -row $gridrow -column 0 -pady 2 -padx 2 -sticky nsew
+    grid [ttk::button $w.show_gradients -text "Show gradients" -command {::cv_dashboard::show_gradients [::cv_dashboard::selected_colvars]} \
+      -padding "2 0 2 0"] -row $gridrow -column 0 -pady 2 -padx 2 -sticky nsew
     grid [ttk::button $w.hide_gradients -text "Hide all" -command {::cv_dashboard::hide_gradients} -padding "2 0 2 0"] -row $gridrow -column 1 -pady 2 -padx 2 -sticky nsew
   }
 
@@ -216,6 +205,7 @@ proc ::cv_dashboard::refresh_table {} {
     if { [lsearch $::cv_dashboard::cvs $cv] > -1 } { lappend tmp $cv }
   }
   set ::cv_dashboard::grad_cvs $tmp
+  show_gradients $::cv_dashboard::grad_cvs
 
   update_frame internal [molinfo top] w
 }
@@ -447,9 +437,9 @@ proc ::cv_dashboard::hide_atoms {} {
 #################################################################
 
 
-proc ::cv_dashboard::show_gradients {} {
+proc ::cv_dashboard::show_gradients { list } {
 
-  foreach cv [selected_colvars] {
+  foreach cv $list {
     if { [run_cv colvar $cv set "collect gradient" 1] == -1 } { continue }
     run_cv colvar $cv update ;# required to get inital values of gradients
     if { [lsearch $::cv_dashboard::grad_cvs $cv] == -1 } { lappend ::cv_dashboard::grad_cvs $cv }

--- a/vmd/cv_dashboard/cv_dashboard.tcl
+++ b/vmd/cv_dashboard/cv_dashboard.tcl
@@ -211,6 +211,14 @@ proc ::cv_dashboard::refresh_table {} {
       }
     }
   }
+
+  # Remove deleted variables from gradient display
+  set tmp {}
+  foreach cv $::cv_dashboard::grad_cvs {
+    if { [lsearch $::cv_dashboard::cvs $cv] > -1 } { lappend tmp $cv }
+  }
+  set ::cv_dashboard::grad_cvs $tmp
+
   update_frame internal [molinfo top] w
 }
 
@@ -402,7 +410,7 @@ proc ::cv_dashboard::show_atoms {} {
       if {[llength $list] > 0} {
         set group "${sanitized_cvname}_group_${i}"
         # resolve ambiguous names due to colvar name sanitization
-        while {[lsearch -sorted $::cv_dashboard::macros $group] > -1} {
+        while {[lsearch $::cv_dashboard::macros $group] > -1} {
           append sanitized_cvname "_"
           set group "${sanitized_cvname}_group_${i}"
         }
@@ -453,7 +461,7 @@ proc ::cv_dashboard::show_gradients {} {
 
   foreach cv [selected_colvars] {
     if { [lsearch $::cv_dashboard::grad_cvs $cv] > -1 } { continue }
-    run_cv colvar $cv set "collect gradient" 1
+    if { [run_cv colvar $cv set "collect gradient" 1] == -1 } { continue }
     run_cv colvar $cv update ;# required to get inital values of gradients
     lappend ::cv_dashboard::grad_cvs $cv
   }
@@ -519,7 +527,7 @@ proc ::cv_dashboard::hide_gradients {} {
 proc run_cv args  {
   if [ catch { cv {*}$args } res ] {
     tk_messageBox -icon error -title "Colvars error" -parent .cv_dashboard_window\
-      -message "Error running command:\n\n$args" -detail "$res"
+      -message "Error running command:\n$args" -detail "$res\n\nSee console for further details."
     return -1
   }
   return $res


### PR DESCRIPTION
This required fixing the collect_gradient function, which had been broken for years [1], but
apparently unused so far.
In the process, moved `f_cvc_implicit_gradient` to the more positive feature `f_cvc_explicit_gradient`, to allow dependencies from children.

Also had to expose two new scripting functions: `getatomgroups` and `getgradients`.

[1] Commit d3070a0fd1468eb52bb9bd52aa00ef593ecdd36f made the code more portable, but also much more segfaulty.