### PR TITLE
Use 64-bit integers to store simulation step numbers

### DIFF
--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -146,7 +146,8 @@ void colvarproxy_lammps::init(const char *conf_file)
   if (_lmp->update->ntimestep != 0) {
     cvm::log("Setting initial step number from LAMMPS: "+
              cvm::to_str(_lmp->update->ntimestep)+"\n");
-    colvars->it = colvars->it_restart = _lmp->update->ntimestep;
+    colvars->it = colvars->it_restart =
+      static_cast<cvm::step_number>(_lmp->update->ntimestep);
   }
 
   if (cvm::debug()) {

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -124,7 +124,8 @@ colvarproxy_namd::colvarproxy_namd()
 
   if (simparams->firstTimestep != 0) {
     cvm::log("Initializing step number as firstTimestep.\n");
-    colvars->it = colvars->it_restart = simparams->firstTimestep;
+    colvars->it = colvars->it_restart =
+      static_cast<cvm::step_number>(simparams->firstTimestep);
   }
 
   reduction = ReductionMgr::Object()->willSubmit(REDUCTIONS_BASIC);

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -17,7 +17,7 @@ colvar::colvar()
 {
   runave_os = NULL;
 
-  prev_timestep = -1;
+  prev_timestep = -1L;
   after_restart = false;
   kinetic_energy = 0.0;
   potential_energy = 0.0;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -369,7 +369,7 @@ protected:
   void update_active_cvc_square_norm();
 
   /// \brief Absolute timestep number when this colvar was last updated
-  int prev_timestep;
+  cvm::step_number prev_timestep;
 
 public:
 

--- a/src/colvar_UIestimator.h
+++ b/src/colvar_UIestimator.h
@@ -294,7 +294,7 @@ namespace UIestimator {
         ~UIestimator() {}
 
         // called from MD engine every step
-        bool update(const int step, std::vector<double> x, std::vector<double> y) {
+        bool update(cvm::step_number step, std::vector<double> x, std::vector<double> y) {
 
             int i;
 

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -16,7 +16,7 @@ colvarbias::colvarbias(char const *key)
   has_data = false;
   b_output_energy = false;
   reset();
-  state_file_step = 0;
+  state_file_step = 0L;
   description = "uninitialized " + cvm::to_str(key) + " bias";
 }
 

--- a/src/colvarbias.h
+++ b/src/colvarbias.h
@@ -216,7 +216,7 @@ protected:
   bool                     has_data;
 
   /// \brief Step number read from the last state file
-  size_t                   state_file_step;
+  cvm::step_number         state_file_step;
 
 };
 

--- a/src/colvarbias_abf.h
+++ b/src/colvarbias_abf.h
@@ -127,7 +127,7 @@ private:
   // shared ABF
   bool    shared_on;
   size_t  shared_freq;
-  int     shared_last_step;
+  cvm::step_number shared_last_step;
   // Share between replicas -- may be called independently of update
   virtual int replica_share();
 

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -1419,8 +1419,8 @@ std::istream & colvarbias_meta::read_hill(std::istream &is)
     return is;
   }
 
-  size_t h_it;
-  get_keyval(data, "step", h_it, 0, parse_silent);
+  cvm::step_number h_it;
+  get_keyval(data, "step", h_it, 0L, parse_silent);
   if (h_it <= state_file_step) {
     if (cvm::debug())
       cvm::log("Skipping a hill older than the state file for metadynamics bias \""+

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -31,6 +31,8 @@ colvarbias_meta::colvarbias_meta(char const *key)
   new_hills_begin = hills.end();
   hills_traj_os = NULL;
   replica_hills_os = NULL;
+
+  ebmeta_equil_steps = 0L;
 }
 
 
@@ -215,7 +217,7 @@ int colvarbias_meta::init_ebmeta_params(std::string const &conf)
     target_dist->multiply_constant(1.0/target_dist->integral());
     cvm::real volume = cvm::exp(target_dist->entropy());
     target_dist->multiply_constant(volume);
-    get_keyval(conf, "ebMetaEquilSteps", ebmeta_equil_steps, 0);
+    get_keyval(conf, "ebMetaEquilSteps", ebmeta_equil_steps, ebmeta_equil_steps);
   }
 
   return COLVARS_OK;
@@ -484,9 +486,9 @@ int colvarbias_meta::update_bias()
 
     if (ebmeta) {
       hills_scale *= 1.0/target_dist->value(target_dist->get_colvars_index());
-      if(cvm::step_absolute() <= long(ebmeta_equil_steps)) {
+      if(cvm::step_absolute() <= ebmeta_equil_steps) {
         cvm::real const hills_lambda =
-          (cvm::real(long(ebmeta_equil_steps) - cvm::step_absolute())) /
+          (cvm::real(ebmeta_equil_steps - cvm::step_absolute())) /
           (cvm::real(ebmeta_equil_steps));
         hills_scale = hills_lambda + (1-hills_lambda)*hills_scale;
       }

--- a/src/colvarbias_meta.h
+++ b/src/colvarbias_meta.h
@@ -167,12 +167,14 @@ protected:
   /// \brief Biasing temperature in well-tempered metadynamics
   cvm::real  bias_temperature;
 
-  // EBmeta parameters
+  /// Ensemble-biased metadynamics (EBmeta) flag
   bool       ebmeta;
+
+  /// Target distribution for EBmeta
   colvar_grid_scalar* target_dist;
-  std::string target_dist_file;
-  cvm::real target_dist_volume;
-  size_t ebmeta_equil_steps;
+
+  /// Number of equilibration steps for EBmeta
+  cvm::step_number ebmeta_equil_steps;
 
 
   /// \brief Try to read the restart information by allocating new

--- a/src/colvarbias_meta.h
+++ b/src/colvarbias_meta.h
@@ -12,8 +12,8 @@
 #include "colvargrid.h"
 
 /// Metadynamics bias (implementation of \link colvarbias \endlink)
-class colvarbias_meta 
-  : public virtual colvarbias, 
+class colvarbias_meta
+  : public virtual colvarbias,
     public virtual colvarbias_ti
 {
 
@@ -278,7 +278,7 @@ public:
   friend class colvarbias_meta;
 
   /// Time step at which this hill was added
-  size_t      it;
+  cvm::step_number it;
 
   /// Identity of the replica who added this hill (only in multiple replica simulations)
   std::string replica;
@@ -289,9 +289,9 @@ public:
   /// replica (optional) Identity of the replica which creates the
   /// hill
   inline hill(cvm::real             const &W_in,
-               std::vector<colvar *>       &cv,
-               cvm::real             const &hill_width,
-               std::string           const &replica_in = "")
+              std::vector<colvar *>       &cv,
+              cvm::real             const &hill_width,
+              std::string           const &replica_in = "")
     : sW(1.0),
       W(W_in),
       centers(cv.size()),
@@ -318,11 +318,11 @@ public:
   /// weight Weight of the hill \param centers Center of the hill
   /// \param widths Width of the hill around centers \param replica
   /// (optional) Identity of the replica which creates the hill
-  inline hill(size_t                    const &it_in,
-               cvm::real                 const &W_in,
-               std::vector<colvarvalue>  const &centers_in,
-               std::vector<cvm::real>    const &widths_in,
-               std::string               const &replica_in = "")
+  inline hill(cvm::step_number          const &it_in,
+              cvm::real                 const &W_in,
+              std::vector<colvarvalue>  const &centers_in,
+              std::vector<cvm::real>    const &widths_in,
+              std::string               const &replica_in = "")
     : sW(1.0),
       W(W_in),
       centers(centers_in),

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -170,7 +170,7 @@ int colvarbias_restraint_k::change_configuration(std::string const &conf)
 colvarbias_restraint_moving::colvarbias_restraint_moving(char const *key)
 {
   target_nstages = 0;
-  target_nsteps = 0;
+  target_nsteps = 0L;
   stage = 0;
   acc_work = 0.0;
   b_chg_centers = false;

--- a/src/colvarbias_restraint.h
+++ b/src/colvarbias_restraint.h
@@ -125,7 +125,7 @@ protected:
 
   /// \brief Number of steps required to reach the target force constant
   /// or restraint centers
-  long target_nsteps;
+  step_number target_nsteps;
 
   /// \brief Accumulated work (computed when outputAccumulatedWork == true)
   cvm::real acc_work;

--- a/src/colvarbias_restraint.h
+++ b/src/colvarbias_restraint.h
@@ -125,7 +125,7 @@ protected:
 
   /// \brief Number of steps required to reach the target force constant
   /// or restraint centers
-  step_number target_nsteps;
+  cvm::step_number target_nsteps;
 
   /// \brief Accumulated work (computed when outputAccumulatedWork == true)
   cvm::real acc_work;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1260,7 +1260,7 @@ std::istream & colvarmodule::read_restart(std::istream &is)
     std::string restart_conf;
     if (is >> colvarparse::read_block("configuration", restart_conf)) {
       parse->get_keyval(restart_conf, "step",
-                        it_restart, (step_number) 0,
+                        it_restart, static_cast<step_number>(0),
                         colvarparse::parse_restart);
         it = it_restart;
       std::string restart_version;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1260,7 +1260,7 @@ std::istream & colvarmodule::read_restart(std::istream &is)
     std::string restart_conf;
     if (is >> colvarparse::read_block("configuration", restart_conf)) {
       parse->get_keyval(restart_conf, "step",
-                        it_restart, (size_t) 0,
+                        it_restart, (step_number) 0,
                         colvarparse::parse_restart);
         it = it_restart;
       std::string restart_version;
@@ -2000,6 +2000,12 @@ std::string colvarmodule::to_str(long int const &x,
   return _to_str<long int>(x, width, prec);
 }
 
+std::string colvarmodule::to_str(step_number const &x,
+                                 size_t width, size_t prec)
+{
+  return _to_str<step_number>(x, width, prec);
+}
+
 std::string colvarmodule::to_str(cvm::real const &x,
                                  size_t width, size_t prec)
 {
@@ -2105,8 +2111,8 @@ colvarproxy *colvarmodule::proxy = NULL;
 cvm::real colvarmodule::debug_gradients_step_size = 1.0e-07;
 int       colvarmodule::errorCode = 0;
 int       colvarmodule::log_level_ = 10;
-long      colvarmodule::it = 0;
-long      colvarmodule::it_restart = 0;
+cvm::step_number colvarmodule::it = 0;
+cvm::step_number colvarmodule::it_restart = 0;
 size_t    colvarmodule::restart_out_freq = 0;
 size_t    colvarmodule::cv_traj_freq = 0;
 bool      colvarmodule::use_scripted_forces = false;

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -85,7 +85,7 @@ public:
   friend class colvarscript;
 
   /// Use a 64-bit integer to store the step number
-  typedef int64_t step_number;
+  typedef long long step_number;
 
   /// Defining an abstract real number allows to switch precision
   typedef  double    real;

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -84,6 +84,9 @@ public:
   // TODO colvarscript should be unaware of colvarmodule's internals
   friend class colvarscript;
 
+  /// Use a 64-bit integer to store the step number
+  typedef int64_t step_number;
+
   /// Defining an abstract real number allows to switch precision
   typedef  double    real;
 
@@ -213,19 +216,19 @@ public:
 
 
   /// Current step number
-  static long it;
+  static step_number it;
   /// Starting step number for this run
-  static long it_restart;
+  static step_number it_restart;
 
   /// Return the current step number from the beginning of this run
-  static inline long step_relative()
+  static inline step_number step_relative()
   {
     return it - it_restart;
   }
 
   /// Return the current step number from the beginning of the whole
   /// calculation
-  static inline long step_absolute()
+  static inline step_number step_absolute()
   {
     return it;
   }
@@ -514,6 +517,10 @@ public:
 
   /// Convert to string for output purposes
   static std::string to_str(long int const &x,
+                            size_t width = 0, size_t prec = 0);
+
+  /// Convert to string for output purposes
+  static std::string to_str(step_number const &x,
                             size_t width = 0, size_t prec = 0);
 
   /// Convert to string for output purposes

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -323,6 +323,15 @@ bool colvarparse::get_keyval(std::string const &conf,
 
 bool colvarparse::get_keyval(std::string const &conf,
                              char const *key,
+                             cvm::step_number &value,
+                             cvm::step_number const &def_value,
+                             Parse_Mode const parse_mode)
+{
+  return _get_keyval_scalar_<cvm::step_number>(conf, key, value, def_value, parse_mode);
+}
+
+bool colvarparse::get_keyval(std::string const &conf,
+                             char const *key,
                              std::string &value,
                              std::string const &def_value,
                              Parse_Mode const parse_mode)

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -125,6 +125,11 @@ public:
                   Parse_Mode const parse_mode = parse_normal);
   bool get_keyval(std::string const &conf,
                   char const *key,
+                  cvm::step_number &value,
+                  cvm::step_number const &def_value = 0,
+                  Parse_Mode const parse_mode = parse_normal);
+  bool get_keyval(std::string const &conf,
+                  char const *key,
                   std::string &value,
                   std::string const &def_value = std::string(""),
                   Parse_Mode const parse_mode = parse_normal);


### PR DESCRIPTION
Implements #239 

- [x] Define a 64-bit integer type around `int64_t`
- [x] Make global step number use this type
- [x] Convert metadynamics steps (e.g. `hill::it`)
- [x] Convert ABF steps (e.g. `shared_last_step`) 
- [x] Convert restraint steps (e.g. `target_nsteps`)
- [x] Convert `UIestimator::update()` and `colvar::prev_timestep`
