### PR TITLE
Collect atomic gradients for combination cvcs

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1374,7 +1374,7 @@ int colvar::collect_cvc_gradients()
     }
     for (i = 0; i < cvcs.size(); i++) {
       if (!cvcs[i]->is_enabled()) continue;
-      cvcs[i]->get_gradients(atom_ids, atomic_gradients);
+      cvcs[i]->collect_gradients(atom_ids, atomic_gradients);
     }
   }
   return COLVARS_OK;

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -254,6 +254,12 @@ int cvm::atom_group::init_dependencies() {
 
 int cvm::atom_group::setup()
 {
+  if (atoms_ids.size() == 0) {
+    atoms_ids.reserve(atoms.size());
+    for (cvm::atom_iter ai = atoms.begin(); ai != atoms.end(); ai++) {
+      atoms_ids.push_back(ai->id);
+    }
+  }
   for (cvm::atom_iter ai = atoms.begin(); ai != atoms.end(); ai++) {
     ai->update_mass();
     ai->update_charge();

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -322,7 +322,7 @@ std::vector<std::vector<int> > colvar::cvc::get_atom_lists()
 }
 
 
-void colvar::cvc::get_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients)
+void colvar::cvc::collect_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients)
 {
   // Coefficient: d(a * x^n) = a * n * x^(n-1) * dx
   cvm::real coeff = sup_coeff * cvm::real(sup_np) *

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -165,7 +165,7 @@ public:
 
   /// \brief Calculate atomic gradients and add them to the corresponding item in gradient vector
   /// May be overridden by CVCs that do not store their gradients in the classic way, see dihedPC
-  virtual void get_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
+  virtual void collect_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
 
   /// \brief Calculate the total force from the system using the
   /// inverse atomic gradients
@@ -1152,8 +1152,8 @@ public:
   virtual  ~dihedPC();
   void calc_value();
   void calc_gradients();
-  /// Re-implementation of cvc::get_gradients() to carry over atomic gradients of sub-cvcs
-  void get_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
+  /// Re-implementation of cvc::collect_gradients() to carry over atomic gradients of sub-cvcs
+  void collect_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
   void apply_force(colvarvalue const &force);
   virtual cvm::real dist2(colvarvalue const &x1,
                           colvarvalue const &x2) const;

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -163,6 +163,10 @@ public:
   /// \brief Calculate finite-difference gradients alongside the analytical ones, for each Cartesian component
   virtual void debug_gradients();
 
+  /// \brief Calculate atomic gradients and add them to the corresponding item in gradient vector
+  /// May be overridden by CVCs that do not store their gradients in the classic way, see dihedPC
+  virtual void get_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
+
   /// \brief Calculate the total force from the system using the
   /// inverse atomic gradients
   virtual void calc_force_invgrads();
@@ -1148,6 +1152,8 @@ public:
   virtual  ~dihedPC();
   void calc_value();
   void calc_gradients();
+  /// Re-implementation of cvc::get_gradients() to carry over atomic gradients of sub-cvcs
+  void get_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
   void apply_force(colvarvalue const &force);
   virtual cvm::real dist2(colvarvalue const &x1,
                           colvarvalue const &x2) const;

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -249,7 +249,7 @@ public:
   /// \brief Store a pointer to new atom group, and list as child for dependencies
   inline void register_atom_group(cvm::atom_group *ag) {
     atom_groups.push_back(ag);
-    add_child((colvardeps *) ag);
+    add_child(ag);
   }
 
   /// \brief Whether or not this CVC will be computed in parallel whenever possible
@@ -1034,7 +1034,7 @@ public:
          cvm::atom const &donor,
          cvm::real r0, int en, int ed);
   h_bond();
-  virtual ~h_bond();
+  virtual ~h_bond() {}
   virtual void calc_value();
   virtual void calc_gradients();
   virtual void apply_force(colvarvalue const &force);
@@ -1122,6 +1122,8 @@ public:
   virtual ~alpha_angles();
   void calc_value();
   void calc_gradients();
+  /// Re-implementation of cvc::collect_gradients() to carry over atomic gradients of sub-cvcs
+  void collect_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients);
   void apply_force(colvarvalue const &force);
   virtual cvm::real dist2(colvarvalue const &x1,
                           colvarvalue const &x2) const;

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -399,12 +399,6 @@ colvar::h_bond::h_bond()
 }
 
 
-colvar::h_bond::~h_bond()
-{
-  delete atom_groups[0];
-}
-
-
 void colvar::h_bond::calc_value()
 {
   int const flags = coordnum::ef_null;

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -401,7 +401,7 @@ void colvar::dihedPC::calc_gradients()
 }
 
 
-void colvar::dihedPC::get_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients)
+void colvar::dihedPC::collect_gradients(std::vector<int> const &atom_ids, std::vector<cvm::rvector> &atomic_gradients)
 {
   cvm::real cvc_coeff = sup_coeff * cvm::real(sup_np) * cvm::integer_power(value().real_value, sup_np-1);
   for (size_t i = 0; i < theta.size(); i++) {

--- a/vmd/cv_dashboard/cv_dashboard.tcl
+++ b/vmd/cv_dashboard/cv_dashboard.tcl
@@ -123,7 +123,7 @@ proc ::cv_dashboard::help_window { parent wtitle title text } {
 
   grid $h.text -row 0 -column 0 -sticky nsew
   grid $h.vsb -row 0 -column 1 -sticky nsew
-  grid $h.close -row 1 
+  grid $h.close -row 1
   grid columnconfigure $h 0 -weight 1
   grid rowconfigure $h 0 -weight 1
 }


### PR DESCRIPTION
- delegate work of colvar::collect_cvc_gradients(), which was very intrusive, to cvc::get_gradients()
- overload virtual get_gradients() in CVCs such as dihedPC
- enables gradient display for dihedPC in VMD dashboard
- could be extended to other "special" CVCs
- in the process fix destructor bug that lead to segfault (double delete)