### PR TITLE
Implementation of the geometric path collective variables

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2032,7 +2032,7 @@ This component returns a $N_{\mathrm{1}}\times{}N_{\mathrm{2}}$-dimensional vect
 
 \cvsubsec{Geometric path collective variables}{sec:cvc_gpath}
 
-The geometric path collective variables define the progress along a path, $s$, and the distance from the path, $z$. These CVs are proposed by Leines and Ensing\cite{Leines2012} , which differ from that\cite{Branduardi2007} proposed by Branduardi et al., and utilize a set of geometric algorithm. The path is defined as a set of frames in the atomic Cartesian coordinate space or the CV space. $s$ and $z$ are computed as
+The geometric path collective variables define the progress along a path, $s$, and the distance from the path, $z$. These CVs are proposed by Leines and Ensing\cite{Leines2012} , which differ from that\cite{Branduardi2007} proposed by Branduardi et al., and utilize a set of geometric algorithms. The path is defined as a series of frames in the atomic Cartesian coordinate space or the CV space. $s$ and $z$ are computed as
 
 \begin{equation}
 s = \frac{m}{M} \pm \frac{1}{2M} \left( \frac{\sqrt{(\mathbf{v}_1 \cdot \mathbf{v}_3)^2-|\mathbf{v}_3|^2 (|\mathbf{v}_1|^2 - |\mathbf{v}_2|^2)}-(\mathbf{v}_1 \cdot \mathbf{v}_3)}{|\mathbf{v}_3|^2} -1 \right)
@@ -2042,7 +2042,7 @@ s = \frac{m}{M} \pm \frac{1}{2M} \left( \frac{\sqrt{(\mathbf{v}_1 \cdot \mathbf{
 z = \sqrt{\left(\mathbf{v}_1 + \frac{1}{2}\left(\frac{\sqrt{(\mathbf{v}_1 \cdot \mathbf{v}_3)^2-|\mathbf{v}_3|^2 (|\mathbf{v}_1|^2 - |\mathbf{v}_2|^2)}-(\mathbf{v}_1 \cdot \mathbf{v}_3)}{|\mathbf{v}_3|^2} -1 \right)\mathbf{v}_4 \right)^2}
 \end{equation}
 
-where $\mathbf{v}_1 = \mathbf{s}_{m} - \mathbf{z} $ is the vector connecting the current position to the closest frame, $\mathbf{v}_2 = \mathbf{z} - \mathbf{s}_{m-1}$ is the vector connecting the second closest frame to the current position, $\mathbf{v}_3 = \mathbf{s}_{m+1} - \mathbf{s}_{m}$ is the vector connecting the closest frame to the third closest frame, and $\mathbf{v}_4 = \mathbf{s}_m - \mathbf{s}_{m-1}$ is the vector connecting the second closest frame to the closest frame. $m$ and $M$ are the current index of the closest frame and the total number of frames respectively. If the current position is on the left of the closest reference frame, the $\pm$ in $s$ turns to positive sign. Otherwise it turns to the negative sign.
+where $\mathbf{v}_1 = \mathbf{s}_{m} - \mathbf{z} $ is the vector connecting the current position to the closest frame, $\mathbf{v}_2 = \mathbf{z} - \mathbf{s}_{m-1}$ is the vector connecting the second closest frame to the current position, $\mathbf{v}_3 = \mathbf{s}_{m+1} - \mathbf{s}_{m}$ is the vector connecting the closest frame to the third closest frame, and $\mathbf{v}_4 = \mathbf{s}_m - \mathbf{s}_{m-1}$ is the vector connecting the second closest frame to the closest frame. $m$ and $M$ are the current index of the closest frame and the total number of frames, respectively. If the current position is on the left of the closest reference frame, the $\pm$ in $s$ turns to the positive sign. Otherwise it turns to the negative sign.
 
 The equations above assume: (i) the frames are equidistant and (ii) the second and the third closest frames are neighbouring to the closest frame. When these assumptions are not satisfied, this set of path CV should be used carefully.
 
@@ -2096,6 +2096,15 @@ In the \texttt{gspath~\{...\}} and the \texttt{gzpath~\{...\}} block all vectors
     \texttt{off}}{%
     The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the second closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
   }
+
+\item %
+  \key
+    {fittingAtoms}{%
+    \texttt{gspath} and \texttt{gspath}}{%
+    The atoms that are used for alignment}{%
+    Group of atoms}{%
+		Before calculating $\mathbf{v}_1$, $\mathbf{v}_2$, $\mathbf{v}_3$ and $\mathbf{v}_4$, the current frame need to be aligned to the corresponding reference frames. This option specifies which atoms are used to do alignment.
+    }
 
 \end{cvcoptions}
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2030,6 +2030,235 @@ This can be useful, for example, to develop a new variable defined over two grou
 This component returns a $N_{\mathrm{1}}\times{}N_{\mathrm{2}}$-dimensional vector of numbers, each ranging from $0$ to the largest possible distance within the chosen boundary conditions.
 
 
+\cvsubsec{Geometric path collective variables}{sec:cvc_gpath}
+
+The geometric path collective variables define the progress along a path, $s$, and the distance from the path, $z$. These CVs are proposed by Leines and Ensing\cite{Leines2012} , which differ from that\cite{Branduardi2007} proposed by Branduardi et al., and utilize a set of geometric algorithm. The path is defined as a set of frames in the atomic Cartesian coordinate space or the CV space. $s$ and $z$ are computed as
+
+\begin{equation}
+s = \frac{m}{M} \pm \frac{1}{2M} \left( \frac{\sqrt{(\mathbf{v}_1 \cdot \mathbf{v}_3)^2-|\mathbf{v}_3|^2 (|\mathbf{v}_1|^2 - |\mathbf{v}_2|^2)}-(\mathbf{v}_1 \cdot \mathbf{v}_3)}{|\mathbf{v}_3|^2} -1 \right)
+\end{equation}
+
+\begin{equation}
+z = \sqrt{\left(\mathbf{v}_1 + \frac{1}{2}\left(\frac{\sqrt{(\mathbf{v}_1 \cdot \mathbf{v}_3)^2-|\mathbf{v}_3|^2 (|\mathbf{v}_1|^2 - |\mathbf{v}_2|^2)}-(\mathbf{v}_1 \cdot \mathbf{v}_3)}{|\mathbf{v}_3|^2} -1 \right)\mathbf{v}_4 \right)^2}
+\end{equation}
+
+where $\mathbf{v}_1 = \mathbf{s}_{m} - \mathbf{z} $ is the vector connecting the current position to the closest frame, $\mathbf{v}_2 = \mathbf{z} - \mathbf{s}_{m-1}$ is the vector connecting the second closest frame to the current position, $\mathbf{v}_3 = \mathbf{s}_{m+1} - \mathbf{s}_{m}$ is the vector connecting the closest frame to the third closest frame, and $\mathbf{v}_4 = \mathbf{s}_m - \mathbf{s}_{m-1}$ is the vector connecting the second closest frame to the closest frame. $m$ and $M$ are the current index of the closest frame and the total number of frames respectively. If the current position is on the left of the closest reference frame, the $\pm$ in $s$ turns to positive sign. Otherwise it turns to the negative sign.
+
+The equations above assume: (i) the frames are equidistant and (ii) the second and the third closest frames are neighbouring to the closest frame. When these assumptions are not satisfied, this set of path CV should be used carefully.
+
+\cvsubsubsec{\texttt{gspath}: progress along a path defined in atomic Cartesian coordinate space.}{sec:cvc_gspath}
+\labelkey{colvar|gspath}
+
+In the \texttt{gspath~\{...\}} and the \texttt{gzpath~\{...\}} block all vectors, namely $\mathbf{z}$ and $\mathbf{s}_{k}$ are defined in atomic Cartesian coordinate space. More specifically, $\mathbf{z} = \left[\mathbf{r}_{1}, \cdots, \mathbf{r}_{n}\right]$, where $\mathbf{r}_{i}$ is the $i$-th atom specified in the \texttt{atoms} block. $\mathbf{s}_{k} = \left[\mathbf{r}_{k,1}, \cdots, \mathbf{r}_{k,n}\right]$, where $\mathbf{r}_{k,i}$ means the $i$-th atom of the $k$-th reference frame.
+
+\begin{cvcoptions}
+\item %
+  \key
+    {atoms}{%
+    \texttt{gspath} and \texttt{gzpath}}{%
+    Group of atoms}{%
+    Block \texttt{atoms \{...\}}}{%
+    Defines the atoms whose coordinates make up the value of the component.}
+
+\item %
+  \key
+    {refPositionsCol}{%
+    \texttt{gspath} and \texttt{gzpath}}{%
+    PDB column containing atom flags}{%
+    \texttt{O}, \texttt{B}, \texttt{X}, \texttt{Y}, or \texttt{Z}}{%
+    If \texttt{refPositionsFileN} is a PDB file that contains all the atoms in the topology, this option may be provided to set which PDB field is used to flag the reference coordinates for \texttt{atoms}.}
+
+\item %
+  \key
+    {refPositionsFileN}{%
+    \texttt{gspath} and \texttt{gzpath}}{%
+    File containing the reference positions for fitting}{%
+    UNIX filename}{%
+		The path is defined by multiple \texttt{refPositionsFile}s which are similiar to \texttt{refPositionsFile} in the \texttt{rmsd} CV. If your path consists of $10$ nodes, you can list the coordinate file (in PDB or XYZ format) from \texttt{refPositionsFile1} to \texttt{refPositionsFile10}.
+    }
+
+\item %
+  \keydef
+    {useSecondClosestFrame}{%
+    \texttt{gspath} and \texttt{gzpath}}{%
+    Define $\mathbf{s}_{m-1}$ as the second closest frame?}{%
+    boolean}{%
+    \texttt{on}}{%
+    The definition assumes the second closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on} (default), $\mathbf{s}_{m-1}$ is defined as the second closest frame. If this option is set to \texttt{off}, $\mathbf{s}_{m-1}$ is defined as the left or right neighbouring frame of the closest frame.
+  }
+
+\item %
+  \keydef
+    {useThirdClosestFrame}{%
+    \texttt{gspath} and \texttt{gzpath}}{%
+    Define $\mathbf{s}_{m+1}$ as the third closest frame?}{%
+    boolean}{%
+    \texttt{off}}{%
+    The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the second closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
+  }
+
+\end{cvcoptions}
+
+\cvsubsubsec{\texttt{gzpath}: distance from a path defined in atomic Cartesian coordinate space.}{sec:cvc_gzpath}
+\labelkey{colvar|gzpath}
+
+\begin{cvcoptions}
+
+\item %
+  \keydef
+    {useZsquare}{%
+    \texttt{gzpath}}{%
+    Compute $z^2$ instead of $z$}{%
+    boolean}{%
+    \texttt{off}}{%
+    $z$ is not differentiable when it is zero. This implementation workarounds it by setting the derivative of $z$ to zero when $z = 0$. Another workaround is set this option to \texttt{on}, which computes $z^2$ instead of $z$, and then $z^2$ is differentiable when it is zero.
+  }
+
+\end{cvcoptions}
+
+The usage of \texttt{gzpath} and \texttt{gspath} is illustrated below:
+
+\bigskip
+{%
+% verbatim can't appear within commands
+\noindent\ttfamily colvar \{\\
+\-~~\# Progress along the path\\
+\-~~name gs\\
+\-~~\# The path is defined by 5 reference frames (from string-00.pdb to string-04.pdb)\\
+\-~~\# Use atomic coordinate from atoms 1, 2 and 3 to compute the path\\
+\-~~gspath \{\\
+\-~~~~atoms \{atomnumbers \{ 1 2 3 \}\}\\
+\-~~~~refPositionFile1 string-00.pdb\\
+\-~~~~refPositionFile2 string-01.pdb\\
+\-~~~~refPositionFile3 string-02.pdb\\
+\-~~~~refPositionFile4 string-03.pdb\\
+\-~~~~refPositionFile5 string-04.pdb\\
+\-~~\}\\
+\}\\
+\noindent\ttfamily colvar \{\\
+\-~~\# Distance from the path\\
+\-~~name gz\\
+\-~~\# The path is defined by 5 reference frames (from string-00.pdb to string-04.pdb)\\
+\-~~\# Use atomic coordinate from atoms 1, 2 and 3 to compute the path\\
+\-~~gzpath \{\\
+\-~~~~atoms \{atomnumbers \{ 1 2 3 \}\}\\
+\-~~~~refPositionFile1 string-00.pdb\\
+\-~~~~refPositionFile2 string-01.pdb\\
+\-~~~~refPositionFile3 string-02.pdb\\
+\-~~~~refPositionFile4 string-03.pdb\\
+\-~~~~refPositionFile5 string-04.pdb\\
+\-~~\}\\
+\}}
+
+\cvsubsubsec{\texttt{subColvar}: Helper CV to define a linear combination of other CVs}{sec:cvc_subColvar}
+\labelkey{colvar|subColvar}
+
+This is a helper CV which can be defined as a linear combination of other CVs. It maybe useful when you want to define the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} as  combinations of other CVs.
+
+\cvsubsubsec{\texttt{gspathCV}: progress along a path defined in CV space.}{sec:cvc_gspathCV}
+\labelkey{colvar|gspathCV}
+
+In the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} block all vectors, namely $\mathbf{z}$ and $\mathbf{s}_{k}$ are defined in CV space.  More specifically, $\mathbf{z} = \left[{\xi}_{1}, \cdots, {\xi}_{n}\right]$, where ${\xi}_{i}$ is the $i$-th CV. $\mathbf{s}_{k} = \left[{\xi}_{k,1}, \cdots, {\xi}_{k,n}\right]$, where ${\xi}_{k,i}$ means the $i$-th CV of the $k$-th reference frame. It should be note that these two CVs requires the \texttt{pathFile} option, which specifies a path file. Each line in the path file contains a set of space-seperated CV value of the reference frame. The sequence of reference frames matches the sequence of the lines.
+
+
+\begin{cvcoptions}
+\item %
+  \keydef
+    {useSecondClosestFrame}{%
+    \texttt{gspathCV} and \texttt{gzpathCV}}{%
+    Define $\mathbf{s}_{m-1}$ as the second closest frame?}{%
+    boolean}{%
+    \texttt{on}}{%
+    The definition assumes the second closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on} (default), $\mathbf{s}_{m-1}$ is defined as the second closest frame. If this option is set to \texttt{off}, $\mathbf{s}_{m-1}$ is defined as the left or right neighbouring frame of the closest frame.
+  }
+
+\item %
+  \keydef
+    {useThirdClosestFrame}{%
+    \texttt{gspathCV} and \texttt{gzpathCV}}{%
+    Define $\mathbf{s}_{m+1}$ as the third closest frame?}{%
+    boolean}{%
+    \texttt{off}}{%
+    The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the second closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
+  }
+
+\item %
+  \key
+    {pathFile}{%
+    \texttt{gspathCV} and \texttt{gspathCV}}{%
+    The file name of the path file.}{%
+    UNIX filename}{%
+		The path is defined by the \texttt{pathFile}. The lines of the \texttt{pathFile} matches the total number of reference frames. The columns of the \texttt{pathFile} matches the number of CVs in this block and are seperated by space.
+    }
+
+\end{cvcoptions}
+
+\cvsubsubsec{\texttt{gzpathCV}: distance from a path defined in CV space.}{sec:cvc_gzpathCV}
+\labelkey{colvar|gzpathCV}
+
+\begin{cvcoptions}
+
+\item %
+  \keydef
+    {useZsquare}{%
+    \texttt{gzpathCV}}{%
+    Compute $z^2$ instead of $z$}{%
+    boolean}{%
+    \texttt{off}}{%
+    $z$ is not differentiable when it is zero. This implementation workarounds it by setting the derivative of $z$ to zero when $z = 0$. Another workaround is set this option to \texttt{on}, which computes $z^2$ instead of $z$, and then $z^2$ is differentiable when it is zero.
+  }
+
+\end{cvcoptions}
+
+The usage of \texttt{gzpathCV} and \texttt{gspathCV} is illustrated below:
+
+\bigskip
+{%
+% verbatim can't appear within commands
+\noindent\ttfamily colvar \{\\
+\-~~\# Progress along the path\\
+\-~~name gs\\
+\-~~\# Path defined by the CV space of two dihedral angles\\
+\-~~gspathCV \{\\
+\-~~~~pathFile ./path.txt\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 001\\
+\-~~~~~~group1 \{atomNumbers \{5\}\}\\
+\-~~~~~~group2 \{atomNumbers \{7\}\}\\
+\-~~~~~~group3 \{atomNumbers \{9\}\}\\
+\-~~~~~~group4 \{atomNumbers \{15\}\}\\
+\-~~~~\}\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 002\\
+\-~~~~~~group1 \{atomNumbers \{7\}\}\\
+\-~~~~~~group2 \{atomNumbers \{9\}\}\\
+\-~~~~~~group3 \{atomNumbers \{15\}\}\\
+\-~~~~~~group4 \{atomNumbers \{17\}\}\\
+\-~~~~\}\\
+\-~~\}\\
+\}\\
+\noindent\ttfamily colvar \{\\
+\-~~\# Distance from the path\\
+\-~~name gz\\
+\-~~gzpathCV \{\\
+\-~~~~pathFile ./path.txt\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 001\\
+\-~~~~~~group1 \{atomNumbers \{5\}\}\\
+\-~~~~~~group2 \{atomNumbers \{7\}\}\\
+\-~~~~~~group3 \{atomNumbers \{9\}\}\\
+\-~~~~~~group4 \{atomNumbers \{15\}\}\\
+\-~~~~\}\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 002\\
+\-~~~~~~group1 \{atomNumbers \{7\}\}\\
+\-~~~~~~group2 \{atomNumbers \{9\}\}\\
+\-~~~~~~group3 \{atomNumbers \{15\}\}\\
+\-~~~~~~group4 \{atomNumbers \{17\}\}\\
+\-~~~~\}\\
+\-~~\}\\
+\}}
+
 
 \cvsubsec{Shared keywords for all components}{sec:cvc_common}
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2159,8 +2159,8 @@ The usage of \texttt{gzpath} and \texttt{gspath} is illustrated below:
 \-~~\}\\
 \}}
 
-\cvsubsubsec{\texttt{subColvar}: Helper CV to define a linear combination of other CVs}{sec:cvc_subColvar}
-\labelkey{colvar|subColvar}
+\cvsubsubsec{\texttt{linearCombination}: Helper CV to define a linear combination of other CVs}{sec:cvc_linearCombination}
+\labelkey{colvar|linearCombination}
 
 This is a helper CV which can be defined as a linear combination of other CVs. It maybe useful when you want to define the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} as  combinations of other CVs.
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2094,7 +2094,7 @@ In the \texttt{gspath~\{...\}} and the \texttt{gzpath~\{...\}} block all vectors
     Define $\mathbf{s}_{m+1}$ as the third closest frame?}{%
     boolean}{%
     \texttt{off}}{%
-    The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the second closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
+    The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the third closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
   }
 
 \item %
@@ -2188,7 +2188,7 @@ In the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} block all vec
     Define $\mathbf{s}_{m+1}$ as the third closest frame?}{%
     boolean}{%
     \texttt{off}}{%
-    The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the second closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
+    The definition assumes the third closest frame is neighbouring to the closest frame. This is not always true especially when the path is crooked. If this option is set to \texttt{on}, $\mathbf{s}_{m+1}$ is defined as the third closest frame. If this option is set to \texttt{off} (default), $\mathbf{s}_{m+1}$ is defined as the left or right neighbouring frame of the closest frame.
   }
 
 \item %

--- a/doc/colvars-refman.bib
+++ b/doc/colvars-refman.bib
@@ -327,3 +327,12 @@ year = {2014}
   volume = {8},
   pages = {810-823},
 }
+
+@ARTICLE{Leines2012,
+    author = {G. D. Leines and B. Ensing},
+    title = {Path Finding on High-Dimensional Free Energy Landscapes},
+    journal = {Phys. Rev. Lett.},
+    year = {2012},
+    volume = {109},
+    pages = {020601},
+}

--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -7751,6 +7751,20 @@ obj/colvarcomp_rotations.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_rotations.o $(COPTC) colvars/src/colvarcomp_rotations.cpp
+obj/colvarcomp_gpath.o: \
+	obj/.exists \
+	colvars/src/colvarcomp_gpath.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvar.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h
+	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
 obj/colvardeps.o: \
 	obj/.exists \
 	colvars/src/colvardeps.cpp \

--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -7565,6 +7565,7 @@ obj/colvar.o: \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvarbias.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvar.o $(COPTC) colvars/src/colvar.cpp
@@ -7679,7 +7680,8 @@ obj/colvarcomp.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp.o $(COPTC) colvars/src/colvarcomp.cpp
 obj/colvarcomp_angles.o: \
 	obj/.exists \
@@ -7693,7 +7695,8 @@ obj/colvarcomp_angles.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_angles.o $(COPTC) colvars/src/colvarcomp_angles.cpp
 obj/colvarcomp_coordnums.o: \
 	obj/.exists \
@@ -7707,7 +7710,8 @@ obj/colvarcomp_coordnums.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvardeps.h \
 	colvars/src/colvar.h \
-	colvars/src/colvarcomp.h
+	colvars/src/colvarcomp.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_coordnums.o $(COPTC) colvars/src/colvarcomp_coordnums.cpp
 obj/colvarcomp_distances.o: \
 	obj/.exists \
@@ -7721,7 +7725,8 @@ obj/colvarcomp_distances.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_distances.o $(COPTC) colvars/src/colvarcomp_distances.cpp
 obj/colvarcomp_protein.o: \
 	obj/.exists \
@@ -7735,7 +7740,8 @@ obj/colvarcomp_protein.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_protein.o $(COPTC) colvars/src/colvarcomp_protein.cpp
 obj/colvarcomp_rotations.o: \
 	obj/.exists \
@@ -7749,7 +7755,8 @@ obj/colvarcomp_rotations.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_rotations.o $(COPTC) colvars/src/colvarcomp_rotations.cpp
 obj/colvarcomp_gpath.o: \
 	obj/.exists \
@@ -7763,7 +7770,8 @@ obj/colvarcomp_gpath.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
 obj/colvardeps.o: \
 	obj/.exists \
@@ -7789,6 +7797,7 @@ obj/colvargrid.o: \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h \
 	colvars/src/colvargrid.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvargrid.o $(COPTC) colvars/src/colvargrid.cpp
 obj/colvarmodule.o: \
@@ -7812,7 +7821,8 @@ obj/colvarmodule.o: \
 	colvars/src/colvarbias_restraint.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarcomp.h
+	colvars/src/colvarcomp.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarmodule.o $(COPTC) colvars/src/colvarmodule.cpp
 obj/colvarparse.o: \
 	obj/.exists \

--- a/namd/colvars/src/Makefile.namd
+++ b/namd/colvars/src/Makefile.namd
@@ -13,6 +13,7 @@ COLVARSLIB = \
 	$(DSTDIR)/colvarcomp_distances.o \
 	$(DSTDIR)/colvarcomp_protein.o \
 	$(DSTDIR)/colvarcomp_rotations.o \
+	$(DSTDIR)/colvarcomp_gpath.o \
 	$(DSTDIR)/colvardeps.o \
 	$(DSTDIR)/colvargrid.o \
 	$(DSTDIR)/colvarmodule.o \

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -793,6 +793,8 @@ int colvar::init_components(std::string const &conf)
   error_code |= init_components_type<eigenvector>(conf, "eigenvector", "eigenvector");
   error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
   error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
+  error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
+  error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
 
   if (!cvcs.size() || (error_code != COLVARS_OK)) {
     cvm::error("Error: no valid components were provided "

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1,12 +1,5 @@
 // -*- c++ -*-
 
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
 #include <list>
 #include <vector>
 #include <algorithm>

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -784,13 +784,11 @@ int colvar::init_components(std::string const &conf)
     "inertia", "inertia");
   error_code |= init_components_type<inertia_z>(conf, "moment of inertia around an axis", "inertiaZ");
   error_code |= init_components_type<eigenvector>(conf, "eigenvector", "eigenvector");
-#if (__cplusplus >= 201103L)
   error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
   error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
   error_code |= init_components_type<linearCombination>(conf, "linear combination of other collective variables", "subColvar");
   error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
   error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
-#endif // C++11 checking
 
   if (!cvcs.size() || (error_code != COLVARS_OK)) {
     cvm::error("Error: no valid components were provided "

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <list>
 #include <vector>
 #include <algorithm>
@@ -784,6 +791,8 @@ int colvar::init_components(std::string const &conf)
     "inertia", "inertia");
   error_code |= init_components_type<inertia_z>(conf, "moment of inertia around an axis", "inertiaZ");
   error_code |= init_components_type<eigenvector>(conf, "eigenvector", "eigenvector");
+  error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
+  error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
 
   if (!cvcs.size() || (error_code != COLVARS_OK)) {
     cvm::error("Error: no valid components were provided "

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -791,11 +791,13 @@ int colvar::init_components(std::string const &conf)
     "inertia", "inertia");
   error_code |= init_components_type<inertia_z>(conf, "moment of inertia around an axis", "inertiaZ");
   error_code |= init_components_type<eigenvector>(conf, "eigenvector", "eigenvector");
+#if (__cplusplus >= 201103L)
   error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
   error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
   error_code |= init_components_type<subcolvar>(conf, "linear combination of other collective variables", "subColvar");
   error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
   error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
+#endif // C++11 checking
 
   if (!cvcs.size() || (error_code != COLVARS_OK)) {
     cvm::error("Error: no valid components were provided "

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -787,7 +787,7 @@ int colvar::init_components(std::string const &conf)
 #if (__cplusplus >= 201103L)
   error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
   error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
-  error_code |= init_components_type<subcolvar>(conf, "linear combination of other collective variables", "subColvar");
+  error_code |= init_components_type<linearCombination>(conf, "linear combination of other collective variables", "subColvar");
   error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
   error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
 #endif // C++11 checking

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -793,6 +793,7 @@ int colvar::init_components(std::string const &conf)
   error_code |= init_components_type<eigenvector>(conf, "eigenvector", "eigenvector");
   error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
   error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
+  error_code |= init_components_type<subcolvar>(conf, "linear combination of other collective variables", "subColvar");
   error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
   error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
 

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -571,6 +571,8 @@ public:
   class dihedPC;
   class gspath;
   class gzpath;
+  class gspathCV;
+  class gzpathCV;
 
   // non-scalar components
   class distance_vec;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -7,6 +7,13 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVAR_H
 #define COLVAR_H
 
@@ -569,8 +576,10 @@ public:
   class alpha_dihedrals;
   class alpha_angles;
   class dihedPC;
+  class CartesianBasedPath;
   class gspath;
   class gzpath;
+  class CVBasedPath;
   class gspathCV;
   class gzpathCV;
 

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -562,7 +562,7 @@ public:
   class alpha_dihedrals;
   class alpha_angles;
   class dihedPC;
-#if (__cplusplus >= 201103L)
+  class componentDisabled;
   class CartesianBasedPath;
   class gspath;
   class gzpath;
@@ -570,7 +570,6 @@ public:
   class CVBasedPath;
   class gspathCV;
   class gzpathCV;
-#endif // C++11 checking
 
   // non-scalar components
   class distance_vec;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -566,7 +566,7 @@ public:
   class CartesianBasedPath;
   class gspath;
   class gzpath;
-  class subcolvar;
+  class linearCombination;
   class CVBasedPath;
   class gspathCV;
   class gzpathCV;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -1,19 +1,5 @@
 // -*- c++ -*-
 
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
 #ifndef COLVAR_H
 #define COLVAR_H
 

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVAR_H
 #define COLVAR_H
 
@@ -562,6 +569,8 @@ public:
   class alpha_dihedrals;
   class alpha_angles;
   class dihedPC;
+  class gspath;
+  class gzpath;
 
   // non-scalar components
   class distance_vec;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -576,6 +576,7 @@ public:
   class alpha_dihedrals;
   class alpha_angles;
   class dihedPC;
+#if (__cplusplus >= 201103L)
   class CartesianBasedPath;
   class gspath;
   class gzpath;
@@ -583,6 +584,7 @@ public:
   class CVBasedPath;
   class gspathCV;
   class gzpathCV;
+#endif // C++11 checking
 
   // non-scalar components
   class distance_vec;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -579,6 +579,7 @@ public:
   class CartesianBasedPath;
   class gspath;
   class gzpath;
+  class subcolvar;
   class CVBasedPath;
   class gspathCV;
   class gzpathCV;

--- a/src/colvar_geometricpath.h
+++ b/src/colvar_geometricpath.h
@@ -11,7 +11,6 @@
 namespace GeometricPathCV {
 
 enum path_sz {S, Z};
-void split_string(const std::string& data, const std::string& delim, std::vector<std::string>& dest);
 
 template <typename element_type, typename scalar_type, path_sz path_type>
 class GeometricPathBase {

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1390,6 +1390,8 @@ private:
     std::vector<cvm::atom_pos> v1;
     std::vector<cvm::atom_pos> v2;
     std::vector<cvm::atom_pos> v3;
+    // Optimal rotation for compute v3
+    cvm::rotation rot_v3;
     // m, M and the sign before f;
     long sign;
     double M;
@@ -1457,6 +1459,9 @@ private:
     cvm::real v2_2;
     cvm::real v3_2;
     cvm::real v4_2;
+    // Optimal rotation for compute v3, v4
+    cvm::rotation rot_v3;
+    cvm::rotation rot_v4;
     // other intermediate variables
     cvm::real f;
     cvm::real dx;

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1375,6 +1375,22 @@ public:
 };
 
 
+
+class colvar::componentDisabled
+  : public colvar::cvc
+{
+public:
+    componentDisabled(std::string const &conf) {
+        cvm::error("Error: this component is not enabled in the current build; please see https://colvars.github.io/README-c++11.html");
+    }
+    virtual ~componentDisabled() {}
+    virtual void calc_value() {}
+    virtual void calc_gradients() {}
+    virtual void apply_force(colvarvalue const &force) {}
+};
+
+
+
 #if (__cplusplus >= 201103L)
 class colvar::CartesianBasedPath
   : public colvar::cvc
@@ -1520,6 +1536,57 @@ public:
     virtual void calc_value();
     virtual void calc_gradients();
     virtual void apply_force(colvarvalue const &force);
+};
+
+#else // if the compiler doesn't support C++11
+
+class colvar::linearCombination
+  : public colvar::componentDisabled
+{
+public:
+    linearCombination(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::CartesianBasedPath
+  : public colvar::componentDisabled
+{
+public:
+    CartesianBasedPath(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::CVBasedPath
+  : public colvar::componentDisabled
+{
+public:
+    CVBasedPath(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::gspath
+  : public colvar::componentDisabled
+{
+public:
+    gspath(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::gzpath
+  : public colvar::componentDisabled
+{
+public:
+    gzpath(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::gspathCV
+  : public colvar::componentDisabled
+{
+public:
+    gspathCV(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::gzpathCV
+  : public colvar::componentDisabled
+{
+public:
+    gzpathCV(std::string const &conf) : componentDisabled(conf) {}
 };
 
 #endif // C++11 checking

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1393,6 +1393,7 @@ public:
 };
 
 
+#if (__cplusplus >= 201103L)
 class colvar::CartesianBasedPath
   : public colvar::cvc
 {
@@ -1536,6 +1537,7 @@ public:
     virtual void apply_force(colvarvalue const &force);
 };
 
+#endif // C++11 checking
 
 // metrics functions for cvc implementations
 

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARCOMP_H
 #define COLVARCOMP_H
 
@@ -1365,6 +1372,127 @@ public:
   virtual void calc_value();
   virtual void calc_gradients();
   virtual void apply_force(colvarvalue const &force);
+};
+
+
+
+/// \brief Colvar component: alternative path collective variable using geometry, variable s
+/// For more information see https://plumed.github.io/doc-v2.5/user-doc/html/_p_a_t_h.html
+/// Díaz Leines, G.; Ensing, B. Path Finding on High-Dimensional Free Energy Landscapes. Phys. Rev. Lett. 2012, 109 (2), 020601. https://doi.org/10.1103/PhysRevLett.109.020601.
+class colvar::gspath
+  : public colvar::cvc
+{
+private:
+    void update_distances();
+    // Indices used to sort and find closest image
+    std::vector<size_t> frame_index;
+    // Store v1, v2 and v3
+    std::vector<cvm::atom_pos> v1;
+    std::vector<cvm::atom_pos> v2;
+    std::vector<cvm::atom_pos> v3;
+    // m, M and the sign before f;
+    long sign;
+    double M;
+    double m;
+    // v1v3, v1^2, v2^2, v3^2
+    cvm::real v1v3;
+    cvm::real v1_2;
+    cvm::real v2_2;
+    cvm::real v3_2;
+    // Derivatives
+    std::vector<cvm::atom_pos> dfdv1;
+    std::vector<cvm::atom_pos> dfdv2;
+protected:
+    /// Selected atoms
+    cvm::atom_group *atoms;
+    /// Reference frames
+    std::vector<std::vector<cvm::atom_pos>> reference_frames;
+    /// Current distance to reference frames;
+    std::vector<cvm::real> frame_distances;
+    /// Atom groups for RMSD calculation together with reference frames
+    std::vector<cvm::atom_group*> comp_atoms;
+public:
+    gspath(std::string const &conf);
+    virtual ~gspath() {
+        if (atoms != nullptr) {
+            delete atoms;
+            atoms = nullptr;
+        }
+        for (auto it_comp_atoms = comp_atoms.begin(); it_comp_atoms != comp_atoms.end(); ++it_comp_atoms) {
+            if (*it_comp_atoms != nullptr) {
+                delete (*it_comp_atoms);
+                (*it_comp_atoms) = nullptr;
+            }
+        }
+    }
+    virtual void calc_value();
+    virtual void calc_gradients();
+    virtual void apply_force(colvarvalue const &force);
+};
+
+
+
+/// \brief Colvar component: alternative path collective variable using geometry, variable z
+/// This should be merged with gspath in the same class by class inheritance or something else
+class colvar::gzpath
+  : public colvar::cvc
+{
+private:
+    void update_distances();
+    // Indices used to sort and find closest image
+    std::vector<size_t> frame_index;
+    // Store v1, v2 and v3
+    std::vector<cvm::atom_pos> v1;
+    std::vector<cvm::atom_pos> v2;
+    std::vector<cvm::atom_pos> v3;
+    // For computing z it's convenient to has another vector v4
+    std::vector<cvm::atom_pos> v4;
+    // m, M and the sign before f;
+    long sign;
+    double M;
+    double m;
+    // v1v3, v1^2, v2^2, v3^2, v4^2
+    cvm::real v1v3;
+    cvm::real v1_2;
+    cvm::real v2_2;
+    cvm::real v3_2;
+    cvm::real v4_2;
+    // other intermediate variables
+    cvm::real f;
+    cvm::real dx;
+    cvm::real z;
+    cvm::real v1v4;
+    // Derivatives
+    std::vector<cvm::atom_pos> dfdv1;
+    std::vector<cvm::atom_pos> dfdv2;
+    std::vector<cvm::atom_pos> dzdv1;
+    std::vector<cvm::atom_pos> dzdv2;
+protected:
+    /// Selected atoms
+    cvm::atom_group *atoms;
+    /// Reference frames
+    std::vector<std::vector<cvm::atom_pos>> reference_frames;
+    /// Current distance to reference frames;
+    std::vector<cvm::real> frame_distances;
+    /// Atom groups for RMSD calculation together with reference frames
+    std::vector<cvm::atom_group*> comp_atoms;
+public:
+    gzpath(std::string const &conf);
+    virtual ~gzpath() {
+        if (atoms != nullptr) {
+            delete atoms;
+            atoms = nullptr;
+        }
+        for (auto it_comp_atoms = comp_atoms.begin(); it_comp_atoms != comp_atoms.end(); ++it_comp_atoms) {
+            if (*it_comp_atoms != nullptr) {
+                delete (*it_comp_atoms);
+                (*it_comp_atoms) = nullptr;
+            }
+        }
+    }
+    virtual void calc_value();
+    virtual void calc_gradients();
+    virtual void apply_force(colvarvalue const &force);
 };
 
 

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -16,9 +16,12 @@
 #include "colvarmodule.h"
 #include "colvar.h"
 #include "colvaratoms.h"
-#include "geometric_path.h"
 
+#if (__cplusplus >= 201103L)
+#include "colvar_geometricpath.h"
 #include <functional>
+#endif // C++11 checking
+
 #include <map>
 
 
@@ -1439,7 +1442,7 @@ public:
 };
 
 /// Current only linear combination of sub-CVCs is available
-class colvar::subcolvar
+class colvar::linearCombination
   : public colvar::cvc
 {
 protected:
@@ -1452,8 +1455,8 @@ protected:
 protected:
     cvm::real getPolynomialFactorOfCVGradient(size_t i_cv) const;
 public:
-    subcolvar(std::string const &conf);
-    virtual ~subcolvar();
+    linearCombination(std::string const &conf);
+    virtual ~linearCombination();
     virtual void calc_value();
     virtual void calc_gradients();
     virtual void apply_force(colvarvalue const &force);

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1386,6 +1386,11 @@ private:
     void update_distances();
     // Indices used to sort and find closest image
     std::vector<size_t> frame_index;
+    bool use_second_closest_frame;
+    bool use_third_closest_frame;
+    long min_frame_index_1;
+    long min_frame_index_2;
+    long min_frame_index_3;
     // Store v1, v2 and v3
     std::vector<cvm::atom_pos> v1;
     std::vector<cvm::atom_pos> v2;
@@ -1443,6 +1448,11 @@ private:
     void update_distances();
     // Indices used to sort and find closest image
     std::vector<size_t> frame_index;
+    bool use_second_closest_frame;
+    bool use_third_closest_frame;
+    long min_frame_index_1;
+    long min_frame_index_2;
+    long min_frame_index_3;
     // Store v1, v2 and v3
     std::vector<cvm::atom_pos> v1;
     std::vector<cvm::atom_pos> v2;

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1,26 +1,5 @@
 // -*- c++ -*-
 
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
 #ifndef COLVARCOMP_H
 #define COLVARCOMP_H
 
@@ -1401,8 +1380,11 @@ protected:
     virtual void computeReferenceDistance(std::vector<cvm::real>& result);
     /// Selected atoms
     cvm::atom_group *atoms;
+    /// Fitting options
+    bool has_user_defined_fitting;
     /// Reference frames
     std::vector<std::vector<cvm::atom_pos>> reference_frames;
+    std::vector<std::vector<cvm::atom_pos>> reference_fitting_frames;
     /// Atom groups for RMSD calculation together with reference frames
     std::vector<cvm::atom_group*> comp_atoms;
     /// Total number of reference frames

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -14,6 +14,13 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARCOMP_H
 #define COLVARCOMP_H
 
@@ -1454,7 +1461,7 @@ class colvar::CVBasedPath
 {
 protected:
     /// Map from string to the types of colvar components
-    std::map<std::string, std::function<colvar::cvc* (std::string subcv_conf)>> string_cv_map;
+    std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> string_cv_map;
     /// Sub-colvar components
     std::vector<colvar::cvc*> cv;
     /// Refernce colvar values from path

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1455,6 +1455,27 @@ public:
     virtual void apply_force(colvarvalue const &force);
 };
 
+/// Current only linear combination of sub-CVCs is available
+class colvar::subcolvar
+  : public colvar::cvc
+{
+protected:
+    /// Map from string to the types of colvar components
+    std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> string_cv_map;
+    /// Sub-colvar components
+    std::vector<colvar::cvc*> cv;
+    /// If all sub-cvs use explicit gradients then we also use it
+    bool use_explicit_gradients;
+protected:
+    cvm::real getPolynomialFactorOfCVGradient(size_t i_cv) const;
+public:
+    subcolvar(std::string const &conf);
+    virtual ~subcolvar();
+    virtual void calc_value();
+    virtual void calc_gradients();
+    virtual void apply_force(colvarvalue const &force);
+};
+
 
 class colvar::CVBasedPath
   : public colvar::cvc

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -1,0 +1,389 @@
+#include <numeric>
+#include <algorithm>
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
+
+#include "colvarmodule.h"
+#include "colvarvalue.h"
+#include "colvarparse.h"
+#include "colvar.h"
+#include "colvarcomp.h"
+
+colvar::gspath::gspath(std::string const &conf): cvc(conf), atoms(nullptr), reference_frames(0), frame_distances(0) {
+    function_type = "gspath";
+    // Parse selected atoms
+    atoms = parse_group(conf, "atoms");
+    // Lookup reference column of PDB
+    // Copied from the RMSD class
+    std::string reference_column;
+    double reference_column_value;
+    if (get_keyval(conf, "refPositionsCol", reference_column, std::string(""))) {
+        bool found = get_keyval(conf, "refPositionsColValue", reference_column_value, 0.0);
+        if (found && reference_column_value == 0.0) {
+          cvm::error("Error: refPositionsColValue, "
+                     "if provided, must be non-zero.\n");
+          return;
+        }
+    }
+    // Lookup all reference frames
+    bool has_frames = true;
+    size_t num_frames = 1;
+    while (has_frames) {
+        std::string reference_position_file_lookup = "refPositionFile" + std::to_string(num_frames);
+        if (key_lookup(conf, reference_position_file_lookup.c_str())) {
+            std::string reference_position_filename;
+            get_keyval(conf, reference_position_file_lookup.c_str(), reference_position_filename, std::string(""));
+            std::vector<cvm::atom_pos> reference_position(atoms->size());
+            cvm::load_coords(reference_position_filename.c_str(), &reference_position, atoms, reference_column, reference_column_value);
+            reference_frames.push_back(reference_position);
+            ++num_frames;
+        } else {
+            has_frames = false;
+        }
+    }
+    frame_distances.resize(reference_frames.size());
+    frame_index.resize(reference_frames.size());
+    std::iota(frame_index.begin(), frame_index.end(), 0);
+    v1.resize(atoms->size());
+    v2.resize(atoms->size());
+    v3.resize(atoms->size());
+    dfdv1.resize(atoms->size());
+    dfdv2.resize(atoms->size());
+    sign = 0;
+    M = double(reference_frames.size() - 1);
+    m = 1.0;
+    // Setup alignment to compute RMSD with respect to reference frames
+    for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
+        cvm::atom_group* tmp_atoms = parse_group(conf, "atoms");
+        // Swipe from the rmsd class
+        tmp_atoms->b_center = true;
+        tmp_atoms->b_rotate = true;
+        tmp_atoms->ref_pos = reference_frames[i_frame];
+        tmp_atoms->center_ref_pos();
+        tmp_atoms->enable(f_ag_fit_gradients);
+        tmp_atoms->rot.request_group1_gradients(tmp_atoms->size());
+        tmp_atoms->rot.request_group2_gradients(tmp_atoms->size());
+        comp_atoms.push_back(tmp_atoms);
+    }
+    x.type(colvarvalue::type_scalar);
+    // Don't use implicit gradient
+    // enable(f_cvc_implicit_gradient);
+    // Option for debug gradients
+    bool debug_gradients = false;
+    get_keyval(conf, "debugGradients", debug_gradients, false);
+    if (debug_gradients) enable(f_cvc_debug_gradient);
+    // Logging
+    cvm::log(std::string("Geometrical pathCV(s) is initialized.\n"));
+    cvm::log(std::string("Geometrical pathCV(s) loaded ") + std::to_string(reference_frames.size()) + std::string(" frames.\n"));
+}
+
+void colvar::gspath::update_distances() {
+    for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
+        cvm::real frame_rmsd = 0.0;
+        atoms->ref_pos = reference_frames[i_frame];
+        atoms->calc_apply_roto_translation();
+        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+            frame_rmsd += ((*(comp_atoms[i_frame]))[i_atom].pos - reference_frames[i_frame][i_atom]).norm2();
+        }
+        frame_rmsd /= cvm::real(atoms->size());
+        frame_rmsd = cvm::sqrt(frame_rmsd);
+        frame_distances[i_frame] = frame_rmsd;
+    }
+}
+
+void colvar::gspath::calc_value() {
+    // Update distance from the frames
+    update_distances();
+    // Find the closest and the second closest frames
+    std::sort(frame_index.begin(), frame_index.end(), [this](size_t i1, size_t i2){return frame_distances[i1] < frame_distances[i2];});
+    // Mimic the code in http://www.acmm.nl/ensing/software/PathCV.cpp
+    // Determine the sign
+    sign = static_cast<long>(frame_index[0]) - static_cast<long>(frame_index[1]);
+    if (sign > 1) {
+        // sigma(z) is on the left side of the closest frame
+        sign = 1;
+    } else if (sign < -1) {
+        // sigma(z) is on the right side of the closest frame
+        sign = -1;
+    }
+    if (std::abs(static_cast<long>(frame_index[0]) - static_cast<long>(frame_index[1])) > 1) {
+        // TODO: Should I throw an error here?
+        // NOTE: The math derivation of s and z depends on the assumption that 
+        //       the second closest frame is the neibouring frame, which is not 
+        //       always true.
+        cvm::log(std::string("Warning: Geometrical pathCV(s) relies on the assumption that the second closest frame is the neibouring frame\n"));
+        cvm::log(std::string("         Please check your configuration or increase restraint on z(σ)\n"));
+        for (size_t i_frame = 0; i_frame < frame_index.size(); ++i_frame) {
+            std::string frame_info_line = std::string{"Frame index: "} + std::to_string(frame_index[i_frame]) + std::string{" ; optimal RMSD = "} + std::to_string(frame_distances[frame_index[i_frame]]) + std::string{"\n"};
+            cvm::log(frame_info_line);
+        }
+    }
+    const size_t min_frame_index_1 = frame_index[0];
+    const size_t min_frame_index_2 = min_frame_index_1 - sign;
+    const size_t min_frame_index_3 = min_frame_index_1 + sign;
+    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - (*(comp_atoms[min_frame_index_1]))[i_atom].pos;
+        v2[i_atom] = (*(comp_atoms[min_frame_index_2]))[i_atom].pos - reference_frames[min_frame_index_2][i_atom];
+    }
+    if (min_frame_index_3 < 0 || min_frame_index_3 > M) {
+        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+            v3[i_atom] = reference_frames[min_frame_index_1][i_atom] - reference_frames[min_frame_index_2][i_atom];
+        }
+    } else {
+        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+            v3[i_atom] = reference_frames[min_frame_index_3][i_atom] - reference_frames[min_frame_index_1][i_atom];
+        }
+    }
+    // Compute v1v3 and the norm2 of v1, v2 and v3
+    v1v3 = 0;
+    v1_2 = 0;
+    v2_2 = 0;
+    v3_2 = 0;
+    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        v1v3 += v1[i_atom] * v3[i_atom];
+        v1_2 += v1[i_atom] * v1[i_atom];
+        v2_2 += v2[i_atom] * v2[i_atom];
+        v3_2 += v3[i_atom] * v3[i_atom];
+    }
+    const cvm::real f = (std::sqrt(v1v3 * v1v3 - v3_2 * (v1_2 - v2_2)) - v1v3) / v3_2;
+    // Determine M and m
+    m = static_cast<double>(frame_index[0]);
+    // Finally compute sigma
+    x = m/M + static_cast<double>(sign) * ((f - 1) / (2 * M));
+}
+
+void colvar::gspath::calc_gradients() {
+    // ATOMS GRADIENTS MUST BE EXPLICIT SET HERE!
+    //      Implicit gradients doesn't support fit gradients.
+    const cvm::real factor1 = 1.0 / (2.0 * v3_2 * std::sqrt(v1v3 * v1v3 - v3_2 * (v1_2 - v2_2)));
+    const cvm::real factor2 = 1.0 / v3_2;
+    // Compute the derivative of f with vector v1
+    std::transform(v1.begin(), v1.end(), v3.begin(), dfdv1.begin(), [factor1, factor2, this](cvm::atom_pos v1atom, cvm::atom_pos v3atom){
+        return (factor1 * (2.0 * v1v3 * v3atom - 2.0 * v3_2 * v1atom) - factor2 * v3atom);
+    });
+    // Compute the derivative of f with vector v2
+    std::transform(v2.begin(), v2.end(), dfdv2.begin(), [factor1, this](cvm::atom_pos v2atom){
+        return (factor1 * (2.0 * v3_2 * v2atom));
+    });
+    cvm::rvector tmp_atom_grad_v1, tmp_atom_grad_v2;
+    const size_t min_frame_index_1 = frame_index[0];
+    const size_t min_frame_index_2 = min_frame_index_1 - sign;
+    // dS(v1, v2(r), v3) / dr = ∂S/∂v1 * dv1/dr + ∂S/∂v2 * dv2/dr
+    // dv1/dr = [fitting matrix 1][-1, ..., -1]
+    // dv2/dr = [fitting matrix 2][1, ..., 1]
+    // ∂S/∂v1 = ± (∂f/∂v1) / (2M)
+    // ∂S/∂v2 = ± (∂f/∂v2) / (2M)
+    // dS(v1, v2(r), v3) / dr = -1.0 * ± (∂f/∂v1) / (2M) + ± (∂f/∂v2) / (2M)
+    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        tmp_atom_grad_v1[0] = -1.0 * sign * 0.5 * dfdv1[i_atom][0] / M;
+        tmp_atom_grad_v1[1] = -1.0 * sign * 0.5 * dfdv1[i_atom][1] / M;
+        tmp_atom_grad_v1[2] = -1.0 * sign * 0.5 * dfdv1[i_atom][2] / M;
+        tmp_atom_grad_v2[0] = sign * 0.5 * dfdv2[i_atom][0] / M;
+        tmp_atom_grad_v2[1] = sign * 0.5 * dfdv2[i_atom][1] / M;
+        tmp_atom_grad_v2[2] = sign * 0.5 * dfdv2[i_atom][2] / M;
+        (*(comp_atoms[min_frame_index_1]))[i_atom].grad += tmp_atom_grad_v1;
+        (*(comp_atoms[min_frame_index_2]))[i_atom].grad += tmp_atom_grad_v2;
+    }
+}
+
+void colvar::gspath::apply_force(colvarvalue const &force) {
+    // The force applied to this CV is scalar type
+    cvm::real const &F = force.real_value;
+    const size_t min_frame_index_1 = frame_index[0];
+    const size_t min_frame_index_2 = min_frame_index_1 - sign;
+    (*(comp_atoms[min_frame_index_1])).apply_colvar_force(F);
+    (*(comp_atoms[min_frame_index_2])).apply_colvar_force(F);
+}
+
+colvar::gzpath::gzpath(std::string const &conf): cvc(conf), atoms(nullptr), reference_frames(0), frame_distances(0) {
+    function_type = "gzpath";
+    // Parse selected atoms
+    atoms = parse_group(conf, "atoms");
+    // Lookup reference column of PDB
+    // Copied from the RMSD class
+    std::string reference_column;
+    double reference_column_value;
+    if (get_keyval(conf, "refPositionsCol", reference_column, std::string(""))) {
+        bool found = get_keyval(conf, "refPositionsColValue", reference_column_value, 0.0);
+        if (found && reference_column_value == 0.0) {
+          cvm::error("Error: refPositionsColValue, "
+                     "if provided, must be non-zero.\n");
+          return;
+        }
+    }
+    // Lookup all reference frames
+    bool has_frames = true;
+    size_t num_frames = 1;
+    while (has_frames) {
+        std::string reference_position_file_lookup = "refPositionFile" + std::to_string(num_frames);
+        if (key_lookup(conf, reference_position_file_lookup.c_str())) {
+            std::string reference_position_filename;
+            get_keyval(conf, reference_position_file_lookup.c_str(), reference_position_filename, std::string(""));
+            std::vector<cvm::atom_pos> reference_position(atoms->size());
+            cvm::load_coords(reference_position_filename.c_str(), &reference_position, atoms, reference_column, reference_column_value);
+            reference_frames.push_back(reference_position);
+            ++num_frames;
+        } else {
+            has_frames = false;
+        }
+    }
+    frame_distances.resize(reference_frames.size());
+    frame_index.resize(reference_frames.size());
+    std::iota(frame_index.begin(), frame_index.end(), 0);
+    v1.resize(atoms->size());
+    v2.resize(atoms->size());
+    v3.resize(atoms->size());
+    v4.resize(atoms->size());
+    dfdv1.resize(atoms->size());
+    dfdv2.resize(atoms->size());
+    dzdv1.resize(atoms->size());
+    dzdv2.resize(atoms->size());
+    sign = 0;
+    M = double(reference_frames.size() - 1);
+    m = 1.0;
+    // Setup alignment to compute RMSD with respect to reference frames
+    for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
+        cvm::atom_group* tmp_atoms = parse_group(conf, "atoms");
+        // Swipe from the rmsd class
+        tmp_atoms->b_center = true;
+        tmp_atoms->b_rotate = true;
+        tmp_atoms->ref_pos = reference_frames[i_frame];
+        tmp_atoms->center_ref_pos();
+        tmp_atoms->enable(f_ag_fit_gradients);
+        tmp_atoms->rot.request_group1_gradients(tmp_atoms->size());
+        tmp_atoms->rot.request_group2_gradients(tmp_atoms->size());
+        comp_atoms.push_back(tmp_atoms);
+    }
+    x.type(colvarvalue::type_scalar);
+    // enable(f_cvc_implicit_gradient);
+    // Option for debug gradients
+    bool debug_gradients = false;
+    get_keyval(conf, "debugGradients", debug_gradients, false);
+    if (debug_gradients) enable(f_cvc_debug_gradient);
+    // Logging
+    cvm::log(std::string("Geometrical pathCV(z) is initialized.\n"));
+    cvm::log(std::string("Geometrical pathCV(z) loaded ") + std::to_string(reference_frames.size()) + std::string(" frames.\n"));
+}
+
+void colvar::gzpath::update_distances() {
+    for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
+        cvm::real frame_rmsd = 0.0;
+        atoms->ref_pos = reference_frames[i_frame];
+        atoms->calc_apply_roto_translation();
+        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+            frame_rmsd += ((*(comp_atoms[i_frame]))[i_atom].pos - reference_frames[i_frame][i_atom]).norm2();
+        }
+        frame_rmsd /= cvm::real(atoms->size());
+        frame_rmsd = cvm::sqrt(frame_rmsd);
+        frame_distances[i_frame] = frame_rmsd;
+    }
+}
+
+void colvar::gzpath::calc_value() {
+    // Update distance from the frames
+    update_distances();
+    // Find the closest and the second closest frames
+    std::sort(frame_index.begin(), frame_index.end(), [this](size_t i1, size_t i2){return frame_distances[i1] < frame_distances[i2];});
+    // Mimic the code in http://www.acmm.nl/ensing/software/PathCV.cpp
+    // Determine the sign
+    sign = static_cast<long>(frame_index[0]) - static_cast<long>(frame_index[1]);
+    if (sign > 1) {
+        // sigma(z) is on the left side of the closest frame
+        sign = 1;
+    } else if (sign < -1) {
+        // sigma(z) is on the right side of the closest frame
+        sign = -1;
+    }
+    if (std::abs(static_cast<long>(frame_index[0]) - static_cast<long>(frame_index[1])) > 1) {
+        // TODO: Should I throw an error here?
+        // NOTE: The math derivation of s and z depends on the assumption that 
+        //       the second closest frame is the neibouring frame, which is not 
+        //       always true.
+    }
+    const size_t min_frame_index_1 = frame_index[0];
+    const size_t min_frame_index_2 = min_frame_index_1 - sign;
+    const size_t min_frame_index_3 = min_frame_index_1 + sign;
+    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - (*(comp_atoms[min_frame_index_1]))[i_atom].pos;
+        v2[i_atom] = (*(comp_atoms[min_frame_index_2]))[i_atom].pos - reference_frames[min_frame_index_2][i_atom];
+        // v4 only computes in gzpath
+        v4[i_atom] = reference_frames[min_frame_index_1][i_atom] - reference_frames[min_frame_index_2][i_atom];
+    }
+    if (min_frame_index_3 < 0 || min_frame_index_3 > M) {
+        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+            v3[i_atom] = reference_frames[min_frame_index_1][i_atom] - reference_frames[min_frame_index_2][i_atom];
+        }
+    } else {
+        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+            v3[i_atom] = reference_frames[min_frame_index_3][i_atom] - reference_frames[min_frame_index_1][i_atom];
+        }
+    }
+    // Compute v1v3 and the norm2 of v1, v2 and v3
+    v1v3 = 0;
+    v1_2 = 0;
+    v2_2 = 0;
+    v3_2 = 0;
+    v4_2 = 0;
+    v1v4 = 0;
+    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        v1v3 += v1[i_atom] * v3[i_atom];
+        v1v4 += v1[i_atom] * v4[i_atom];
+        v1_2 += v1[i_atom] * v1[i_atom];
+        v2_2 += v2[i_atom] * v2[i_atom];
+        v3_2 += v3[i_atom] * v3[i_atom];
+        v4_2 += v4[i_atom] * v4[i_atom];
+    }
+    f = (std::sqrt(v1v3 * v1v3 - v3_2 * (v1_2 - v2_2)) - v1v3) / v3_2;
+    dx = 0.5 * (f - 1);
+    // z = sqrt((-v1 - dx * v4)^2)
+    //   = sqrt(v1^2 + 2dx*(v1⋅v4) + dx * dx * v4^2)
+    const cvm::real z_2 = v1_2 + 2 * dx * v1v4 + dx * dx * v4_2;
+    z = std::sqrt(z_2);
+    x = z;
+}
+
+void colvar::gzpath::calc_gradients() {
+    // The derivative in Ensing's PathCV.cpp seems incomplete
+    const cvm::real factor1 = 1.0 / (2.0 * v3_2 * std::sqrt(v1v3 * v1v3 - v3_2 * (v1_2 - v2_2)));
+    const cvm::real factor2 = 1.0 / v3_2;
+    // Compute the derivative of f with vector v1
+    std::transform(v1.begin(), v1.end(), v3.begin(), dfdv1.begin(), [factor1, factor2, this](cvm::atom_pos v1atom, cvm::atom_pos v3atom){
+        return (factor1 * (2.0 * v1v3 * v3atom - 2.0 * v3_2 * v1atom) - factor2 * v3atom);
+    });
+    // Compute the derivative of f with vector v2
+    std::transform(v2.begin(), v2.end(), dfdv2.begin(), [factor1, this](cvm::atom_pos v2atom){
+        return (factor1 * (2.0 * v3_2 * v2atom));
+    });
+    // dZ(v1(r), v2(r), v3) / dr = ∂Z/∂v1 * dv1/dr + ∂Z/∂v2 * dv2/dr
+    // dv1/dr = [fitting matrix 1][-1, ..., -1]
+    // dv2/dr = [fitting matrix 2][1, ..., 1]
+    // ∂Z/∂v1 = 1/(2*z) * (2v1 + (f-1)v4 + (v1⋅v4)∂f/∂v1 + v4^2 * 1/4 * 2(f-1) * ∂f/∂v1)
+    // ∂Z/∂v2 = 1/(2*z) * ((v1⋅v4)∂f/∂v2 + v4^2 * 1/4 * 2(f-1) * ∂f/∂v2)
+    cvm::rvector tmp_atom_grad_v1, tmp_atom_grad_v2;
+    const size_t min_frame_index_1 = frame_index[0];
+    const size_t min_frame_index_2 = min_frame_index_1 - sign;
+    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        tmp_atom_grad_v1[0] = -1.0 * (1.0 / (2.0 * z)) * (2.0 * v1[i_atom][0] + (f-1) * v4[i_atom][0] + v1v4 * dfdv1[i_atom][0] + v4_2 * 0.25 * 2.0 * (f-1) * dfdv1[i_atom][0]);
+        tmp_atom_grad_v1[1] = -1.0 * (1.0 / (2.0 * z)) * (2.0 * v1[i_atom][1] + (f-1) * v4[i_atom][1] + v1v4 * dfdv1[i_atom][1] + v4_2 * 0.25 * 2.0 * (f-1) * dfdv1[i_atom][1]);
+        tmp_atom_grad_v1[2] = -1.0 * (1.0 / (2.0 * z)) * (2.0 * v1[i_atom][2] + (f-1) * v4[i_atom][2] + v1v4 * dfdv1[i_atom][2] + v4_2 * 0.25 * 2.0 * (f-1) * dfdv1[i_atom][2]);
+        tmp_atom_grad_v2[0] = (1.0 / (2.0 * z)) * (v1v4 * dfdv2[i_atom][0] + v4_2 * 0.25 * 2.0 * (f-1) * dfdv2[i_atom][0]);
+        tmp_atom_grad_v2[1] = (1.0 / (2.0 * z)) * (v1v4 * dfdv2[i_atom][1] + v4_2 * 0.25 * 2.0 * (f-1) * dfdv2[i_atom][1]);
+        tmp_atom_grad_v2[2] = (1.0 / (2.0 * z)) * (v1v4 * dfdv2[i_atom][2] + v4_2 * 0.25 * 2.0 * (f-1) * dfdv2[i_atom][2]);
+        (*(comp_atoms[min_frame_index_1]))[i_atom].grad += tmp_atom_grad_v1;
+        (*(comp_atoms[min_frame_index_2]))[i_atom].grad += tmp_atom_grad_v2;
+    }
+}
+
+void colvar::gzpath::apply_force(colvarvalue const &force) {
+    // The force applied to this CV is scalar type
+    cvm::real const &F = force.real_value;
+    const size_t min_frame_index_1 = frame_index[0];
+    const size_t min_frame_index_2 = min_frame_index_1 - sign;
+    (*(comp_atoms[min_frame_index_1])).apply_colvar_force(F);
+    (*(comp_atoms[min_frame_index_2])).apply_colvar_force(F);
+}

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -1,3 +1,5 @@
+#if (__cplusplus >= 201103L)
+
 #include <numeric>
 #include <algorithm>
 #include <cmath>
@@ -813,3 +815,5 @@ void GeometricPathCV::init_string_cv_map(std::map<std::string, std::function<col
     string_cv_map["dihedralPC"]            = [](const std::string& conf){return new colvar::dihedPC(conf);};
     string_cv_map["subColvar"]             = [](const std::string& conf){return new colvar::subcolvar(conf);};
 }
+
+#endif

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -282,12 +282,12 @@ colvar::gzpath::gzpath(std::string const &conf): CartesianBasedPath(conf) {
     } else {
         cvm::log(std::string("Geometric path z(σ) will use the neighbouring frame to compute s_(m+1)\n"));
     }
-    bool use_z_square = false;
-    get_keyval(conf, "useZsquare", use_z_square, false);
-    if (use_z_square == true) {
+    bool b_use_z_square = false;
+    get_keyval(conf, "useZsquare", b_use_z_square, false);
+    if (b_use_z_square == true) {
         cvm::log(std::string("Geometric path z(σ) will use the square of distance from current frame to path compute z\n"));
     }
-    GeometricPathCV::GeometricPathBase<cvm::atom_pos, cvm::real, GeometricPathCV::path_sz::Z>::initialize(atoms->size(), cvm::atom_pos(), total_reference_frames, use_second_closest_frame, use_third_closest_frame, use_z_square);
+    GeometricPathCV::GeometricPathBase<cvm::atom_pos, cvm::real, GeometricPathCV::path_sz::Z>::initialize(atoms->size(), cvm::atom_pos(), total_reference_frames, use_second_closest_frame, use_third_closest_frame, b_use_z_square);
     // Logging
     cvm::log(std::string("Geometric pathCV(z) is initialized.\n"));
     cvm::log(std::string("Geometric pathCV(z) loaded ") + cvm::to_str(reference_frames.size()) + std::string(" frames.\n"));
@@ -758,12 +758,12 @@ colvar::gzpathCV::gzpathCV(std::string const &conf): CVBasedPath(conf) {
     } else {
         cvm::log(std::string("Geometric path z(σ) will use the neighbouring frame to compute s_(m+1)\n"));
     }
-    bool use_z_square = false;
-    get_keyval(conf, "useZsquare", use_z_square, false);
-    if (use_z_square == true) {
+    bool b_use_z_square = false;
+    get_keyval(conf, "useZsquare", b_use_z_square, false);
+    if (b_use_z_square == true) {
         cvm::log(std::string("Geometric path z(σ) will use the square of distance from current frame to path compute z\n"));
     }
-    GeometricPathCV::GeometricPathBase<colvarvalue, cvm::real, GeometricPathCV::path_sz::Z>::initialize(cv.size(), ref_cv[0], total_reference_frames, use_second_closest_frame, use_third_closest_frame, use_z_square);
+    GeometricPathCV::GeometricPathBase<colvarvalue, cvm::real, GeometricPathCV::path_sz::Z>::initialize(cv.size(), ref_cv[0], total_reference_frames, use_second_closest_frame, use_third_closest_frame, b_use_z_square);
     x.type(colvarvalue::type_scalar);
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -7,24 +7,9 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
 #include <cmath>
 #include <cstdlib>
-#include <cfenv>
 #include <limits>
-
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
@@ -41,7 +26,7 @@
 #include "colvarcomp.h"
 
 namespace GeometricPathCV {
-void init_string_cv_map(std::map<std::string, std::function<colvar::cvc* (std::string subcv_conf)>>& string_cv_map);
+void init_string_cv_map(std::map<std::string, std::function<colvar::cvc* (const std::string& conf)>>& string_cv_map);
 }
 
 colvar::CartesianBasedPath::CartesianBasedPath(std::string const &conf): cvc(conf), atoms(nullptr), reference_frames(0) {
@@ -708,9 +693,15 @@ void GeometricPathCV::split_string(const std::string& data, const std::string& d
     }
 }
 
-void GeometricPathCV::init_string_cv_map(std::map<std::string, std::function<colvar::cvc* (std::string subcv_conf)>>& string_cv_map) {
+void GeometricPathCV::init_string_cv_map(std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>>& string_cv_map) {
     // TODO: copy-and-paste work to support all combinations of sub-CVCs
-    string_cv_map["distance"] = [](std::string conf){return new colvar::distance(conf);};
-    string_cv_map["dihedral"] = [](std::string conf){return new colvar::dihedral(conf);};
-    string_cv_map["angle"] = [](std::string conf){return new colvar::angle(conf);};
+    string_cv_map["distance"]       = [](const std::string& conf){return new colvar::distance(conf);};
+    string_cv_map["dihedral"]       = [](const std::string& conf){return new colvar::dihedral(conf);};
+    string_cv_map["angle"]          = [](const std::string& conf){return new colvar::angle(conf);};
+    string_cv_map["rmsd"]           = [](const std::string& conf){return new colvar::rmsd(conf);};
+    string_cv_map["gyration"]       = [](const std::string& conf){return new colvar::gyration(conf);};
+    string_cv_map["inertia"]        = [](const std::string& conf){return new colvar::inertia(conf);};
+    string_cv_map["distanceZ"]      = [](const std::string& conf){return new colvar::distance_z(conf);};
+    string_cv_map["distanceXY"]     = [](const std::string& conf){return new colvar::distance_xy(conf);};
+    string_cv_map["distanceVec"]    = [](const std::string& conf){return new colvar::distance_vec(conf);};
 }

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -321,7 +321,8 @@ colvar::subcolvar::subcolvar(std::string const &conf): cvc(conf) {
             register_atom_group(*it_atom_group);
         }
     }
-    x.type(cv[0]->value().type());
+    x.type(cv[0]->value());
+    x.reset();
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
@@ -350,7 +351,7 @@ colvar::subcolvar::~subcolvar() {
 }
 
 void colvar::subcolvar::calc_value() {
-    x = colvarvalue(x.type());
+    x.reset();
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         cv[i_cv]->calc_value();
         colvarvalue current_cv_value(cv[i_cv]->value());
@@ -421,7 +422,9 @@ colvar::CVBasedPath::CVBasedPath(std::string const &conf): cvc(conf) {
         for (auto it_atom_group = (*it_sub_cv)->atom_groups.begin(); it_atom_group != (*it_sub_cv)->atom_groups.end(); ++it_atom_group) {
             register_atom_group(*it_atom_group);
         }
-        tmp_cv.push_back(colvarvalue((*it_sub_cv)->value().type()));
+        colvarvalue tmp_i_cv((*it_sub_cv)->value());
+        tmp_i_cv.reset();
+        tmp_cv.push_back(tmp_i_cv);
     }
     // Read path file
     // Lookup all reference CV values

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -122,7 +122,8 @@ void colvar::gspath::updateReferenceDistances() {
 }
 
 void colvar::gspath::prepareVectors() {
-    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+    size_t i_atom;
+    for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
         // v1 = s_m - z
         v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - (*(comp_atoms[min_frame_index_1]))[i_atom].pos;
         // v2 = z - s_(m-1)
@@ -130,7 +131,7 @@ void colvar::gspath::prepareVectors() {
     }
     if (min_frame_index_3 < 0 || min_frame_index_3 > M) {
         cvm::atom_pos reference_cog_1, reference_cog_2;
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             reference_cog_1 += reference_frames[min_frame_index_1][i_atom];
             reference_cog_2 += reference_frames[min_frame_index_2][i_atom];
         }
@@ -138,17 +139,17 @@ void colvar::gspath::prepareVectors() {
         reference_cog_2 /= reference_frames[min_frame_index_2].size();
         std::vector<cvm::atom_pos> tmp_reference_frame_1(reference_frames[min_frame_index_1].size());
         std::vector<cvm::atom_pos> tmp_reference_frame_2(reference_frames[min_frame_index_2].size());
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             tmp_reference_frame_1[i_atom] = reference_frames[min_frame_index_1][i_atom] - reference_cog_1;
             tmp_reference_frame_2[i_atom] = reference_frames[min_frame_index_2][i_atom] - reference_cog_2;
         }
         rot_v3.calc_optimal_rotation(tmp_reference_frame_1, tmp_reference_frame_2);
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             v3[i_atom] = rot_v3.q.rotate(tmp_reference_frame_1[i_atom]) - tmp_reference_frame_2[i_atom];
         }
     } else {
         cvm::atom_pos reference_cog_1, reference_cog_3;
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             reference_cog_1 += reference_frames[min_frame_index_1][i_atom];
             reference_cog_3 += reference_frames[min_frame_index_3][i_atom];
         }
@@ -156,12 +157,12 @@ void colvar::gspath::prepareVectors() {
         reference_cog_3 /= reference_frames[min_frame_index_3].size();
         std::vector<cvm::atom_pos> tmp_reference_frame_1(reference_frames[min_frame_index_1].size());
         std::vector<cvm::atom_pos> tmp_reference_frame_3(reference_frames[min_frame_index_3].size());
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             tmp_reference_frame_1[i_atom] = reference_frames[min_frame_index_1][i_atom] - reference_cog_1;
             tmp_reference_frame_3[i_atom] = reference_frames[min_frame_index_3][i_atom] - reference_cog_3;
         }
         rot_v3.calc_optimal_rotation(tmp_reference_frame_1, tmp_reference_frame_3);
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             // v3 = s_(m+1) - s_m
             v3[i_atom] = tmp_reference_frame_3[i_atom] - rot_v3.q.rotate(tmp_reference_frame_1[i_atom]);
         }
@@ -232,7 +233,8 @@ void colvar::gzpath::updateReferenceDistances() {
 
 void colvar::gzpath::prepareVectors() {
     cvm::atom_pos reference_cog_1, reference_cog_2;
-    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+    size_t i_atom;
+    for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
         reference_cog_1 += reference_frames[min_frame_index_1][i_atom];
         reference_cog_2 += reference_frames[min_frame_index_2][i_atom];
     }
@@ -240,12 +242,12 @@ void colvar::gzpath::prepareVectors() {
     reference_cog_2 /= reference_frames[min_frame_index_2].size();
     std::vector<cvm::atom_pos> tmp_reference_frame_1(reference_frames[min_frame_index_1].size());
     std::vector<cvm::atom_pos> tmp_reference_frame_2(reference_frames[min_frame_index_2].size());
-    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+    for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
         tmp_reference_frame_1[i_atom] = reference_frames[min_frame_index_1][i_atom] - reference_cog_1;
         tmp_reference_frame_2[i_atom] = reference_frames[min_frame_index_2][i_atom] - reference_cog_2;
     }
     rot_v4.calc_optimal_rotation(tmp_reference_frame_1, tmp_reference_frame_2);
-    for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+    for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
         v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - (*(comp_atoms[min_frame_index_1]))[i_atom].pos;
         v2[i_atom] = (*(comp_atoms[min_frame_index_2]))[i_atom].pos - reference_frames[min_frame_index_2][i_atom];
         // v4 only computes in gzpath
@@ -256,16 +258,16 @@ void colvar::gzpath::prepareVectors() {
         v3 = v4;
     } else {
         cvm::atom_pos reference_cog_3;
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             reference_cog_3 += reference_frames[min_frame_index_3][i_atom];
         }
         reference_cog_3 /= reference_frames[min_frame_index_3].size();
         std::vector<cvm::atom_pos> tmp_reference_frame_3(reference_frames[min_frame_index_3].size());
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             tmp_reference_frame_3[i_atom] = reference_frames[min_frame_index_3][i_atom] - reference_cog_3;
         }
         rot_v3.calc_optimal_rotation(tmp_reference_frame_1, tmp_reference_frame_3);
-        for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+        for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
             // v3 = s_(m+1) - s_m
             v3[i_atom] = tmp_reference_frame_3[i_atom] - rot_v3.q.rotate(tmp_reference_frame_1[i_atom]);
         }
@@ -759,7 +761,7 @@ void colvar::gzpathCV::apply_force(colvarvalue const &force) {
             for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                 (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
             }
-        } 
+        }
         else {
             colvarvalue tmp_cv_grad_v1 = -1.0 * dzdv1[i_cv];
             colvarvalue tmp_cv_grad_v2 =  1.0 * dzdv2[i_cv];

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -1,13 +1,5 @@
 // -*- c++ -*-
 
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
-
 #include <sstream>
 #include <iostream>
 #include <algorithm>

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -857,3 +857,18 @@ int colvarparse::check_braces(std::string const &conf,
   }
   return (brace_count != 0) ? INPUT_ERROR : COLVARS_OK;
 }
+
+void colvarparse::split_string(const std::string& data, const std::string& delim, std::vector<std::string>& dest) {
+    size_t index = 0, new_index = 0;
+    std::string tmpstr;
+    while (index != data.length()) {
+        new_index = data.find(delim, index);
+        if (new_index != std::string::npos) tmpstr = data.substr(index, new_index - index);
+        else tmpstr = data.substr(index, data.length());
+        if (!tmpstr.empty()) {
+            dest.push_back(tmpstr);
+        }
+        if (new_index == std::string::npos) break;
+        index = new_index + 1;
+    }
+}

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 
 #include <sstream>
 #include <iostream>
@@ -47,6 +54,28 @@ bool colvarparse::get_key_string_value(std::string const &conf,
     cvm::error("Error: found more than one instance of \""+
                std::string(key)+"\".\n", INPUT_ERROR);
   }
+
+  return b_found_any;
+}
+
+bool colvarparse::get_key_string_multi_value(std::string const &conf,
+                                             char const *key, std::vector<std::string>& data)
+{
+  bool b_found = false, b_found_any = false;
+  size_t save_pos = 0, found_count = 0;
+
+  data.clear();
+
+  do {
+    std::string data_this = "";
+    b_found = key_lookup(conf, key, &data_this, &save_pos);
+    if (b_found) {
+      if (!b_found_any)
+        b_found_any = true;
+      found_count++;
+      data.push_back(data_this);
+    }
+  } while (b_found);
 
   return b_found_any;
 }

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -205,7 +205,7 @@ protected:
   bool get_key_string_value(std::string const &conf,
                             char const *key, std::string &data);
 
-  /// Get multiple strings of a same keyword
+  /// Get multiple strings from repeated instances of a same keyword
   bool get_key_string_multi_value(std::string const &conf,
                                   char const *key, std::vector<std::string>& data);
 
@@ -318,6 +318,12 @@ public:
   /// \param conf The configuration string \param start_pos Start the count
   /// from this position
   static int check_braces(std::string const &conf, size_t const start_pos);
+
+  /// \brief Split a string with a specified delimiter into a vector
+  /// \param data The string to be splitted
+  /// \param delim A delimiter
+  /// \param dest A destination vector to store the splitted results
+  static void split_string(const std::string& data, const std::string& delim, std::vector<std::string>& dest);
 
 protected:
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -1,12 +1,5 @@
 // -*- c++ -*-
 
-// This file is part of the Collective Variables module (Colvars).
-// The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
-// Please update all Colvars source files before making any changes.
-// If you wish to distribute your changes, please submit them to the
-// Colvars repository at GitHub.
-
 #ifndef COLVARPARSE_H
 #define COLVARPARSE_H
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARPARSE_H
 #define COLVARPARSE_H
 
@@ -204,6 +211,10 @@ protected:
   /// Get the string value of a keyword, and save it for later parsing
   bool get_key_string_value(std::string const &conf,
                             char const *key, std::string &data);
+
+  /// Get multiple strings of a same keyword
+  bool get_key_string_multi_value(std::string const &conf,
+                                  char const *key, std::vector<std::string>& data);
 
   /// Template for single-value keyword parsers
   template<typename TYPE>

--- a/src/geometric_path.h
+++ b/src/geometric_path.h
@@ -7,6 +7,13 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 
 #include <vector>
 #include <cmath>
@@ -33,6 +40,7 @@ protected:
     scalar_type v1v4;
     scalar_type f;
     scalar_type dx;
+    scalar_type s;
     scalar_type z;
     scalar_type zz;
     std::vector<element_type> v1;
@@ -52,6 +60,8 @@ protected:
     long min_frame_index_2;
     long min_frame_index_3;
     long sign;
+    double M;
+    double m;
 public:
     GeometricPathBase(size_t vector_size, const element_type& element = element_type(), size_t total_frames = 1, bool p_use_second_closest_frame = true, bool p_use_third_closest_frame = false, bool p_use_z_square = false);
     GeometricPathBase(size_t vector_size, const std::vector<element_type>& elements, size_t total_frames = 1, bool p_use_second_closest_frame = true, bool p_use_third_closest_frame = false, bool p_use_z_square = false);
@@ -104,6 +114,8 @@ void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t 
     use_second_closest_frame = p_use_second_closest_frame;
     use_third_closest_frame = p_use_third_closest_frame;
     use_z_square = p_use_z_square;
+    M = static_cast<scalar_type>(total_frames - 1);
+    m = static_cast<scalar_type>(1.0);
 }
 
 template <typename element_type, typename scalar_type, path_sz path_type>
@@ -133,6 +145,8 @@ void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t 
     use_second_closest_frame = p_use_second_closest_frame;
     use_third_closest_frame = p_use_third_closest_frame;
     use_z_square = p_use_z_square;
+    M = static_cast<scalar_type>(total_frames - 1);
+    m = static_cast<scalar_type>(1.0);
 }
 
 template <typename element_type, typename scalar_type, path_sz path_type>
@@ -177,6 +191,7 @@ void GeometricPathBase<element_type, scalar_type, path_type>::determineClosestFr
     min_frame_index_1 = frame_index[0];                                                         // s_m
     min_frame_index_2 = use_second_closest_frame ? frame_index[1] : min_frame_index_1 - sign;   // s_(m-1)
     min_frame_index_3 = use_third_closest_frame ? frame_index[2] : min_frame_index_1 + sign;    // s_(m+1)
+    m = static_cast<double>(frame_index[0]);
 }
 
 template <typename element_type, typename scalar_type, path_sz path_type>
@@ -211,6 +226,9 @@ void GeometricPathBase<element_type, scalar_type, path_type>::computeValue() {
         } else {
             z = std::sqrt(std::fabs(zz));
         }
+    }
+    if (path_type == path_sz::S) {
+        s = m/M + static_cast<double>(sign) * ((f - 1) / (2 * M));
     }
 }
 

--- a/src/geometric_path.h
+++ b/src/geometric_path.h
@@ -1,0 +1,251 @@
+#ifndef GEOMETRICPATHCV_H
+#define GEOMETRICPATHCV_H
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
+
+#include <vector>
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <algorithm>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace GeometricPathCV {
+
+enum path_sz {S, Z};
+void split_string(const std::string& data, const std::string& delim, std::vector<std::string>& dest);
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+class GeometricPathBase {
+protected:
+    scalar_type v1v1;
+    scalar_type v2v2;
+    scalar_type v3v3;
+    scalar_type v4v4;
+    scalar_type v1v3;
+    scalar_type v1v4;
+    scalar_type f;
+    scalar_type dx;
+    scalar_type z;
+    scalar_type zz;
+    std::vector<element_type> v1;
+    std::vector<element_type> v2;
+    std::vector<element_type> v3;
+    std::vector<element_type> v4;
+    std::vector<element_type> dfdv1;
+    std::vector<element_type> dfdv2;
+    std::vector<element_type> dzdv1;
+    std::vector<element_type> dzdv2;
+    std::vector<scalar_type> frame_distances;
+    std::vector<size_t> frame_index;
+    bool use_second_closest_frame;
+    bool use_third_closest_frame;
+    bool use_z_square;
+    long min_frame_index_1;
+    long min_frame_index_2;
+    long min_frame_index_3;
+    long sign;
+public:
+    GeometricPathBase(size_t vector_size, const element_type& element = element_type(), size_t total_frames = 1, bool p_use_second_closest_frame = true, bool p_use_third_closest_frame = false, bool p_use_z_square = false);
+    GeometricPathBase(size_t vector_size, const std::vector<element_type>& elements, size_t total_frames = 1, bool p_use_second_closest_frame = true, bool p_use_third_closest_frame = false, bool p_use_z_square = false);
+    GeometricPathBase() {}
+    virtual ~GeometricPathBase() {}
+    virtual void initialize(size_t vector_size, const element_type& element = element_type(), size_t total_frames = 1, bool p_use_second_closest_frame = true, bool p_use_third_closest_frame = false, bool p_use_z_square = false);
+    virtual void initialize(size_t vector_size, const std::vector<element_type>& elements, size_t total_frames = 1, bool p_use_second_closest_frame = true, bool p_use_third_closest_frame = false, bool p_use_z_square = false);
+    virtual void prepareVectors();
+    virtual void updateReferenceDistances();
+    virtual void compute();
+    virtual void determineClosestFrames();
+    virtual void computeValue();
+    virtual void computeDerivatives();
+};
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+GeometricPathBase<element_type, scalar_type, path_type>::GeometricPathBase(size_t vector_size, const element_type& element, size_t total_frames, bool p_use_second_closest_frame, bool p_use_third_closest_frame, bool p_use_z_square) {
+    initialize(vector_size, element, total_frames, p_use_second_closest_frame, p_use_third_closest_frame, p_use_z_square);
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+GeometricPathBase<element_type, scalar_type, path_type>::GeometricPathBase(size_t vector_size, const std::vector<element_type>& elements, size_t total_frames, bool p_use_second_closest_frame, bool p_use_third_closest_frame, bool p_use_z_square) {
+    initialize(vector_size, elements, total_frames, p_use_second_closest_frame, p_use_third_closest_frame, p_use_z_square);
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t vector_size, const element_type& element, size_t total_frames, bool p_use_second_closest_frame, bool p_use_third_closest_frame, bool p_use_z_square) {
+    v1v1 = scalar_type();
+    v2v2 = scalar_type();
+    v3v3 = scalar_type();
+    v4v4 = scalar_type();
+    v1v3 = scalar_type();
+    v1v4 = scalar_type();
+    f = scalar_type();
+    dx = scalar_type();
+    z = scalar_type();
+    zz = scalar_type();
+    sign = 0;
+    v1.resize(vector_size, element);
+    v2.resize(vector_size, element);
+    v3.resize(vector_size, element);
+    v4.resize(vector_size, element);
+    dfdv1.resize(vector_size, element);
+    dfdv2.resize(vector_size, element);
+    dzdv1.resize(vector_size, element);
+    dzdv2.resize(vector_size, element);
+    frame_distances.resize(total_frames);
+    frame_index.resize(total_frames);
+    std::iota(frame_index.begin(), frame_index.end(), 0);
+    use_second_closest_frame = p_use_second_closest_frame;
+    use_third_closest_frame = p_use_third_closest_frame;
+    use_z_square = p_use_z_square;
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t vector_size, const std::vector<element_type>& elements, size_t total_frames, bool p_use_second_closest_frame, bool p_use_third_closest_frame, bool p_use_z_square) {
+    v1v1 = scalar_type();
+    v2v2 = scalar_type();
+    v3v3 = scalar_type();
+    v4v4 = scalar_type();
+    v1v3 = scalar_type();
+    v1v4 = scalar_type();
+    f = scalar_type();
+    dx = scalar_type();
+    z = scalar_type();
+    zz = scalar_type();
+    sign = 0;
+    v1 = elements;
+    v2 = elements;
+    v3 = elements;
+    v4 = elements;
+    dfdv1 = elements;
+    dfdv2 = elements;
+    dzdv1 = elements;
+    dzdv2 = elements;
+    frame_distances.resize(total_frames);
+    frame_index.resize(total_frames);
+    std::iota(frame_index.begin(), frame_index.end(), 0);
+    use_second_closest_frame = p_use_second_closest_frame;
+    use_third_closest_frame = p_use_third_closest_frame;
+    use_z_square = p_use_z_square;
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::prepareVectors() {
+    std::cout << "Warning: you should not call the prepareVectors() in base class!\n";
+    std::cout << std::flush;
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::updateReferenceDistances() {
+    std::cout << "Warning: you should not call the updateReferenceDistances() in base class!\n";
+    std::cout << std::flush;
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::compute() {
+    computeValue();
+    computeDerivatives();
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::determineClosestFrames() {
+    // Find the closest and the second closest frames
+    std::sort(frame_index.begin(), frame_index.end(), [this](size_t i1, size_t i2){return frame_distances[i1] < frame_distances[i2];});
+    // Determine the sign
+    sign = static_cast<long>(frame_index[0]) - static_cast<long>(frame_index[1]);
+    if (sign > 1) {
+        // sigma(z) is on the left side of the closest frame
+        sign = 1;
+    } else if (sign < -1) {
+        // sigma(z) is on the right side of the closest frame
+        sign = -1;
+    }
+    if (std::abs(static_cast<long>(frame_index[0]) - static_cast<long>(frame_index[1])) > 1) {
+        std::cout << "Warning: Geometrical pathCV(s) relies on the assumption that the second closest frame is the neibouring frame\n";
+        std::cout << "         Please check your configuration or increase restraint on z(σ)\n";
+        for (size_t i_frame = 0; i_frame < frame_index.size(); ++i_frame) {
+            std::string frame_info_line = std::string{"Frame index: "} + std::to_string(frame_index[i_frame]) + std::string{" ; optimal RMSD = "} + std::to_string(frame_distances[frame_index[i_frame]]) + std::string{"\n"};
+            std::cout << frame_info_line;
+        }
+    }
+    min_frame_index_1 = frame_index[0];                                                         // s_m
+    min_frame_index_2 = use_second_closest_frame ? frame_index[1] : min_frame_index_1 - sign;   // s_(m-1)
+    min_frame_index_3 = use_third_closest_frame ? frame_index[2] : min_frame_index_1 + sign;    // s_(m+1)
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::computeValue() {
+    updateReferenceDistances();
+    determineClosestFrames();
+    prepareVectors();
+    v1v1 = scalar_type();
+    v2v2 = scalar_type();
+    v3v3 = scalar_type();
+    v1v3 = scalar_type();
+    if (path_type == path_sz::Z) {
+        v1v4 = scalar_type();
+        v4v4 = scalar_type();
+    }
+    for (size_t i_elem = 0; i_elem < v1.size(); ++i_elem) {
+        v1v1 += v1[i_elem] * v1[i_elem];
+        v2v2 += v2[i_elem] * v2[i_elem];
+        v3v3 += v3[i_elem] * v3[i_elem];
+        v1v3 += v1[i_elem] * v3[i_elem];
+        if (path_type == path_sz::Z) {
+            v1v4 += v1[i_elem] * v4[i_elem];
+            v4v4 += v4[i_elem] * v4[i_elem];
+        }
+    }
+    f = (std::sqrt(v1v3 * v1v3 - v3v3 * (v1v1 - v2v2)) - v1v3) / v3v3;
+    if (path_type == path_sz::Z) {
+        dx = 0.5 * (f - 1);
+        zz = v1v1 + 2 * dx * v1v4 + dx * dx * v4v4;
+        if (use_z_square) {
+            z = zz;
+        } else {
+            z = std::sqrt(std::fabs(zz));
+        }
+    }
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void GeometricPathBase<element_type, scalar_type, path_type>::computeDerivatives() {
+    const scalar_type factor1 = 1.0 / (2.0 * v3v3 * std::sqrt(v1v3 * v1v3 - v3v3 * (v1v1 - v2v2)));
+    const scalar_type factor2 = 1.0 / v3v3;
+    for (size_t i_elem = 0; i_elem < v1.size(); ++i_elem) {
+        // Compute the derivative of f with vector v1
+        dfdv1[i_elem] = factor1 * (2.0 * v1v3 * v3[i_elem] - 2.0 * v3v3 * v1[i_elem]) - factor2 * v3[i_elem];
+        // Compute the derivative of f with respect to vector v2
+        dfdv2[i_elem] = factor1 * (2.0 * v3v3 * v2[i_elem]);
+        // dZ(v1(r), v2(r), v3) / dr = ∂Z/∂v1 * dv1/dr + ∂Z/∂v2 * dv2/dr
+        // dv1/dr = [fitting matrix 1][-1, ..., -1]
+        // dv2/dr = [fitting matrix 2][1, ..., 1]
+        // ∂Z/∂v1 = 1/(2*z) * (2v1 + (f-1)v4 + (v1⋅v4)∂f/∂v1 + v4^2 * 1/4 * 2(f-1) * ∂f/∂v1)
+        // ∂Z/∂v2 = 1/(2*z) * ((v1⋅v4)∂f/∂v2 + v4^2 * 1/4 * 2(f-1) * ∂f/∂v2)
+        if (path_type == path_sz::Z) {
+            if (use_z_square) {
+                dzdv1[i_elem] = 2.0 * v1[i_elem] + (f-1) * v4[i_elem] + v1v4 * dfdv1[i_elem] + v4v4 * 0.25 * 2.0 * (f-1) * dfdv1[i_elem];
+                dzdv2[i_elem] = v1v4 * dfdv2[i_elem] + v4v4 * 0.25 * 2.0 * (f-1) * dfdv2[i_elem];
+            } else {
+                if (z > static_cast<scalar_type>(0)) {
+                    dzdv1[i_elem] = (1.0 / (2.0 * z)) * (2.0 * v1[i_elem] + (f-1) * v4[i_elem] + v1v4 * dfdv1[i_elem] + v4v4 * 0.25 * 2.0 * (f-1) * dfdv1[i_elem]);
+                    dzdv2[i_elem] = (1.0 / (2.0 * z)) * (v1v4 * dfdv2[i_elem] + v4v4 * 0.25 * 2.0 * (f-1) * dfdv2[i_elem]);
+                } else {
+                    // workaround at z = 0
+                    dzdv1[i_elem] = 0;
+                    dzdv2[i_elem] = 0;
+                }
+            }
+        }
+    }
+}
+
+}
+
+#endif

--- a/src/geometric_path.h
+++ b/src/geometric_path.h
@@ -1,3 +1,4 @@
+#if (__cplusplus >= 201103L)
 #ifndef GEOMETRICPATHCV_H
 #define GEOMETRICPATHCV_H
 // This file is part of the Collective Variables module (Colvars).
@@ -26,7 +27,7 @@
 
 namespace GeometricPathCV {
 
-enum path_sz {S, Z};
+enum class path_sz {S, Z};
 void split_string(const std::string& data, const std::string& delim, std::vector<std::string>& dest);
 
 template <typename element_type, typename scalar_type, path_sz path_type>
@@ -266,4 +267,5 @@ void GeometricPathBase<element_type, scalar_type, path_type>::computeDerivatives
 
 }
 
-#endif
+#endif // GEOMETRICPATHCV_H
+#endif // C++11 Checking


### PR DESCRIPTION
This commit implements the path collective variables proposed by Leines and Ensing (Path Finding on High-Dimensional Free Energy Landscapes. Phys. Rev. Lett. 2012, 109 (2), 020601. https://doi.org/10.1103/PhysRevLett.109.020601.)
The colvars `gspath` and `gzpath` compute the progress on the path and the distance from the path which is defined in atomic Cartesian coordinate space.
The colvars `gspathCV` and `gzpathCV` compute the progress on the path and the distance from the path which is defined in CV space.
Examples of usage is on https://github.com/HanatoK/colvars/wiki/Geometric-Path-Collective-Variables .
There is another helper colvar named `subColvar` which implements linear combination of other colvars which will be useful when defining `gspathCV` and `gzpathCV`.