### PR TITLE
Parrinello's (arithmetic) pathCV in CV space.

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2272,7 +2272,7 @@ In the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} block all vec
 \item %
   \key
     {pathFile}{%
-    \texttt{gspathCV} and \texttt{gspathCV}}{%
+    \texttt{gspathCV} and \texttt{gzpathCV}}{%
     The file name of the path file.}{%
     UNIX filename}{%
 		The path is defined by the \texttt{pathFile}. The lines of the \texttt{pathFile} matches the total number of reference frames. The columns of the \texttt{pathFile} matches the number of CVs in this block and are seperated by space.
@@ -2345,6 +2345,116 @@ The usage of \texttt{gzpathCV} and \texttt{gspathCV} is illustrated below:
 \-~~~~\}\\
 \-~~\}\\
 \}}
+
+
+\cvsubsec{Arithmetic path collective variables in CV space}{sec:cvc_apathCV}
+
+The arithmetic path collective variable in CV space uses the same formula as the one proposed by Branduardi\cite{Branduardi2007} et al., except that it computes $s$ and $z$ in CV space instead of RMSDs in Cartesian space. Moreover, this implementation allows different coefficients for each CV components as described in \cite{Hovan2019}. Assuming a path is composed of $N$ reference frames and defined in an $M$-dimensional CV space, then the equations of $s$ and $z$ of the path are 
+
+\begin{equation}
+s = \frac{\sum_{i=1}^{N} i \exp\left(-\lambda\sum_{j=1}^{M} c_j^2 \left(x_j-x_{i,j}\right)^2\right)}{\sum_{i=1}^{N} \exp\left(-\lambda\sum_{j=1}^{M} c_j^2 \left(x_j-x_{i,j}\right)^2\right)}
+\end{equation}
+
+\begin{equation}
+z = -\frac{1}{\lambda} \ln \left(\sum_{i=1}^{N} \exp\left(-\lambda\sum_{j=1}^{M} c_j^2 \left(x_j-x_{i,j}\right) \right)\right)
+\end{equation}
+where $c_j$ is the coefficient(weight) of the $j$-th CV, $x_{i,j}$ is the value of $j$-th CV of $i$-th reference frame and $x_{j}$ is the value of $j$-th CV of current frame. $\lambda$ is a parameter to smooth the variation of $s$ and $z$.
+
+\cvsubsubsec{\texttt{aspathCV}: progress along a path defined in CV space.}{sec:cvc_aspathCV}
+
+This colvar component computes the $s$ variable.
+
+\labelkey{colvar|aspathCV}
+
+\begin{cvcoptions}
+\item %
+  \keydef
+    {weights}{%
+    \texttt{aspathCV} and \texttt{azpathCV}}{%
+    Coefficients of the collective variables}{%
+    space-seperated numbers in a \texttt{\{...\}} block}{%
+    \texttt{\{1.0 ...\}}}{%
+    Define the coefficients. The $j$-th value in the \texttt{\{...\}} block corresponds the $c_{j}$ in the equations.
+  }
+
+\item %
+  \keydef
+    {lambda}{%
+    \texttt{aspathCV} and \texttt{azpathCV}}{%
+    Smoothness of the variation of $s$ and $z$}{%
+    decimal}{%
+    inverse of the mean square displacements of successive reference frames}{%
+    The value of $\lambda$ in the equations.
+  }
+
+\item %
+  \key
+    {pathFile}{%
+    \texttt{aspathCV} and \texttt{azpathCV}}{%
+    The file name of the path file.}{%
+    UNIX filename}{%
+		The path is defined by the \texttt{pathFile}. The lines of the \texttt{pathFile} matches the total number of reference frames. The columns of the \texttt{pathFile} matches the number of CVs in this block and are seperated by space.
+    }
+
+\end{cvcoptions}
+
+\cvsubsubsec{\texttt{azpathCV}: distance from a path defined in CV space.}{sec:cvc_azpathCV}
+
+This colvar component computes the $z$ variable. Options are the same as in \ref{sec:cvc_aspathCV}.
+
+The usage of \texttt{azpathCV} and \texttt{aspathCV} is illustrated below:
+
+\bigskip
+{%
+% verbatim can't appear within commands
+\noindent\ttfamily colvar \{\\
+\-~~\# Progress along the path\\
+\-~~name as\\
+\-~~\# Path defined by the CV space of two dihedral angles\\
+\-~~aspathCV \{\\
+\-~~~~pathFile ./path.txt\\
+\-~~~~weights \{1.0 1.0\}\\
+\-~~~~lambda 0.005\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 001\\
+\-~~~~~~group1 \{atomNumbers \{5\}\}\\
+\-~~~~~~group2 \{atomNumbers \{7\}\}\\
+\-~~~~~~group3 \{atomNumbers \{9\}\}\\
+\-~~~~~~group4 \{atomNumbers \{15\}\}\\
+\-~~~~\}\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 002\\
+\-~~~~~~group1 \{atomNumbers \{7\}\}\\
+\-~~~~~~group2 \{atomNumbers \{9\}\}\\
+\-~~~~~~group3 \{atomNumbers \{15\}\}\\
+\-~~~~~~group4 \{atomNumbers \{17\}\}\\
+\-~~~~\}\\
+\-~~\}\\
+\}\\
+\noindent\ttfamily colvar \{\\
+\-~~\# Distance from the path\\
+\-~~name az\\
+\-~~azpathCV \{\\
+\-~~~~pathFile ./path.txt\\
+\-~~~~weights \{1.0 1.0\}\\
+\-~~~~lambda 0.005\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 001\\
+\-~~~~~~group1 \{atomNumbers \{5\}\}\\
+\-~~~~~~group2 \{atomNumbers \{7\}\}\\
+\-~~~~~~group3 \{atomNumbers \{9\}\}\\
+\-~~~~~~group4 \{atomNumbers \{15\}\}\\
+\-~~~~\}\\
+\-~~~~dihedral \{\\
+\-~~~~~~name 002\\
+\-~~~~~~group1 \{atomNumbers \{7\}\}\\
+\-~~~~~~group2 \{atomNumbers \{9\}\}\\
+\-~~~~~~group3 \{atomNumbers \{15\}\}\\
+\-~~~~~~group4 \{atomNumbers \{17\}\}\\
+\-~~~~\}\\
+\-~~\}\\
+\}}
+
 
 
 \cvsubsec{Shared keywords for all components}{sec:cvc_common}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2275,7 +2275,7 @@ In the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} block all vec
     \texttt{gspathCV} and \texttt{gzpathCV}}{%
     The file name of the path file.}{%
     UNIX filename}{%
-		The path is defined by the \texttt{pathFile}. The lines of the \texttt{pathFile} matches the total number of reference frames. The columns of the \texttt{pathFile} matches the number of CVs in this block and are seperated by space.
+		Defines the nodes or images that constitutes the path in CV space. The CVs of an image are listed in a line of \texttt{pathFile} using space-seperated format. Lines from top to button in \texttt{pathFile} corresponds images from initial to last.
     }
 
 \end{cvcoptions}
@@ -2393,7 +2393,7 @@ This colvar component computes the $s$ variable.
     \texttt{aspathCV} and \texttt{azpathCV}}{%
     The file name of the path file.}{%
     UNIX filename}{%
-		The path is defined by the \texttt{pathFile}. The lines of the \texttt{pathFile} matches the total number of reference frames. The columns of the \texttt{pathFile} matches the number of CVs in this block and are seperated by space.
+		Defines the nodes or images that constitutes the path in CV space. The CVs of an image are listed in a line of \texttt{pathFile} using space-seperated format. Lines from top to button in \texttt{pathFile} corresponds images from initial to last.
     }
 
 \end{cvcoptions}

--- a/doc/colvars-refman.bib
+++ b/doc/colvars-refman.bib
@@ -370,3 +370,12 @@ year = {2014}
     volume = {109},
     pages = {020601},
 }
+
+@ARTICLE{Hovan2019,
+    author = {L. Hovan, F. Comitani and F. L. Gervasio},
+    title = {Defining an Optimal Metric for the Path Collective Variables},
+    journal = {J. Chem. Theory Comput.},
+    year = {2019},
+    volume = {15},
+    pages = {25-32},
+}

--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -7761,6 +7761,10 @@ obj/colvarcomp_gpath.o: \
 	obj/.exists \
 	colvars/src/colvarcomp_gpath.cpp
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
+obj/colvarcomp_apath.o: \
+	obj/.exists \
+	colvars/src/colvarcomp_apath.cpp
+	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_apath.cpp
 obj/colvardeps.o: \
 	obj/.exists \
 	colvars/src/colvardeps.cpp \

--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -7759,12 +7759,36 @@ obj/colvarcomp_rotations.o: \
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_rotations.o $(COPTC) colvars/src/colvarcomp_rotations.cpp
 obj/colvarcomp_gpath.o: \
 	obj/.exists \
-	colvars/src/colvarcomp_gpath.cpp
+	colvars/src/colvarcomp_gpath.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvar.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
 obj/colvarcomp_apath.o: \
 	obj/.exists \
-	colvars/src/colvarcomp_apath.cpp
-	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_apath.cpp
+	colvars/src/colvarcomp_apath.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvar.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
+	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_apath.o $(COPTC) colvars/src/colvarcomp_apath.cpp
 obj/colvardeps.o: \
 	obj/.exists \
 	colvars/src/colvardeps.cpp \

--- a/namd/colvars/src/Makefile.namd
+++ b/namd/colvars/src/Makefile.namd
@@ -14,6 +14,7 @@ COLVARSLIB = \
 	$(DSTDIR)/colvarcomp_protein.o \
 	$(DSTDIR)/colvarcomp_rotations.o \
 	$(DSTDIR)/colvarcomp_gpath.o \
+	$(DSTDIR)/colvarcomp_apath.o \
 	$(DSTDIR)/colvardeps.o \
 	$(DSTDIR)/colvargrid.o \
 	$(DSTDIR)/colvarmodule.o \

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -789,6 +789,8 @@ int colvar::init_components(std::string const &conf)
   error_code |= init_components_type<linearCombination>(conf, "linear combination of other collective variables", "subColvar");
   error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
   error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
+  error_code |= init_components_type<aspathCV>(conf, "arithmetic path collective variables (s) for other CVs", "aspathCV");
+  error_code |= init_components_type<azpathCV>(conf, "arithmetic path collective variables (s) for other CVs", "azpathCV");
 
   if (!cvcs.size() || (error_code != COLVARS_OK)) {
     cvm::error("Error: no valid components were provided "

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -570,6 +570,8 @@ public:
   class CVBasedPath;
   class gspathCV;
   class gzpathCV;
+  class aspathCV;
+  class azpathCV;
 
   // non-scalar components
   class distance_vec;

--- a/src/colvar_arithmeticpath.h
+++ b/src/colvar_arithmeticpath.h
@@ -1,0 +1,124 @@
+#ifndef ARITHMETICPATHCV_H
+#define ARITHMETICPATHCV_H
+
+#include <vector>
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+namespace ArithmeticPathCV {
+
+using std::vector;
+
+enum path_sz {S, Z};
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+class ArithmeticPathBase {
+public:
+    ArithmeticPathBase() {}
+    virtual ~ArithmeticPathBase() {}
+    virtual void initialize(size_t p_num_elements, size_t p_total_frames, double p_lambda, const vector<element_type>& p_element, const vector<double>& p_weights);
+    virtual void updateReferenceDistances();
+    virtual void computeValue();
+    virtual void computeDerivatives();
+    virtual void compute();
+protected:
+    scalar_type lambda;
+    vector<scalar_type> weights;
+    size_t num_elements;
+    size_t total_frames;
+    vector<vector<element_type>> frame_element_distances;
+    scalar_type s;
+    scalar_type z;
+    vector<element_type> dsdx;
+    vector<element_type> dzdx;
+private:
+    // intermediate variables
+    vector<scalar_type> s_numerator_frame;
+    vector<scalar_type> s_denominator_frame;
+    scalar_type numerator_s;
+    scalar_type denominator_s;
+    scalar_type normalization_factor;
+};
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void ArithmeticPathBase<element_type, scalar_type, path_type>::initialize(size_t p_num_elements, size_t p_total_frames, double p_lambda, const vector<element_type>& p_element, const vector<double>& p_weights) {
+    lambda = p_lambda;
+    weights = p_weights;
+    num_elements = p_num_elements;
+    total_frames = p_total_frames;
+    frame_element_distances.resize(total_frames, vector<element_type>(num_elements));
+    s = scalar_type(0);
+    z = scalar_type(0);
+    dsdx = p_element;
+    dzdx = p_element;
+    s_numerator_frame.resize(total_frames, scalar_type(0));
+    s_denominator_frame.resize(total_frames, scalar_type(0));
+    numerator_s = scalar_type(0);
+    denominator_s = scalar_type(0);
+    normalization_factor = 1.0 / static_cast<scalar_type>(total_frames - 1);
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void ArithmeticPathBase<element_type, scalar_type, path_type>::computeValue() {
+    updateReferenceDistances();
+    numerator_s = scalar_type(0);
+    denominator_s = scalar_type(0);
+    for (size_t i_frame = 0; i_frame < frame_element_distances.size(); ++i_frame) {
+        scalar_type exponent_tmp = scalar_type(0);
+        for (size_t j_elem = 0; j_elem < num_elements; ++j_elem) {
+            exponent_tmp += weights[j_elem] * frame_element_distances[i_frame][j_elem] * weights[j_elem] * frame_element_distances[i_frame][j_elem];
+        }
+        exponent_tmp = exponent_tmp * -1.0 * lambda;
+        if (exponent_tmp > -708.4) {
+            exponent_tmp = std::exp(exponent_tmp);
+        } else {
+            exponent_tmp = 0;
+        }
+        numerator_s += static_cast<scalar_type>(i_frame) * exponent_tmp;
+        denominator_s += exponent_tmp;
+        s_numerator_frame[i_frame] = static_cast<scalar_type>(i_frame) * exponent_tmp;
+        s_denominator_frame[i_frame] = exponent_tmp;
+    }
+    s = numerator_s / denominator_s * normalization_factor;
+    z = -1.0 / lambda * std::log(denominator_s);
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void ArithmeticPathBase<element_type, scalar_type, path_type>::updateReferenceDistances() {
+    std::cout << "Warning: you should not call the updateReferenceDistances() in base class!\n";
+    std::cout << std::flush;
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void ArithmeticPathBase<element_type, scalar_type, path_type>::compute() {
+    computeValue();
+    computeDerivatives();
+}
+
+template <typename element_type, typename scalar_type, path_sz path_type>
+void ArithmeticPathBase<element_type, scalar_type, path_type>::computeDerivatives() {
+    for (size_t j_elem = 0; j_elem < num_elements; ++j_elem) {
+        element_type dsdxj_numerator_part1;
+        element_type dsdxj_numerator_part2;
+        element_type dzdxj_numerator;
+        for (size_t i_frame = 0; i_frame < frame_element_distances.size(); ++i_frame) {
+            scalar_type derivative_tmp = -2.0 * lambda * weights[j_elem] * weights[j_elem] * frame_element_distances[i_frame][j_elem];
+            dsdxj_numerator_part1 += s_numerator_frame[i_frame] * derivative_tmp;
+            dsdxj_numerator_part2 += s_denominator_frame[i_frame] * derivative_tmp;
+            dzdxj_numerator += s_denominator_frame[i_frame] * derivative_tmp;
+        }
+        dsdxj_numerator_part1 *= denominator_s;
+        dsdxj_numerator_part2 *= numerator_s;
+        if (std::abs(dsdxj_numerator_part1 - dsdxj_numerator_part2) < std::numeric_limits<scalar_type>::min()) {
+            dsdx[j_elem] = 0;
+        } else {
+            dsdx[j_elem] = (dsdxj_numerator_part1 - dsdxj_numerator_part2) / (denominator_s * denominator_s) * normalization_factor;
+        }
+        dzdx[j_elem] = -1.0 / lambda * dzdxj_numerator / denominator_s;
+    }
+}
+
+}
+
+#endif // ARITHMETICPATHCV_H

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1432,7 +1432,7 @@ private:
     cvm::rotation rot_v3;
 protected:
     virtual void prepareVectors();
-    virtual void updateReferenceDistances();
+    virtual void updateDistanceToReferenceFrames();
 public:
     gspath(std::string const &conf);
     virtual ~gspath() {}
@@ -1454,7 +1454,7 @@ private:
     cvm::rotation rot_v4;
 protected:
     virtual void prepareVectors();
-    virtual void updateReferenceDistances();
+    virtual void updateDistanceToReferenceFrames();
 public:
     gzpath(std::string const &conf);
     virtual ~gzpath() {}
@@ -1502,7 +1502,7 @@ protected:
 protected:
     virtual void computeDistanceToReferenceFrames(std::vector<cvm::real>& result);
     /// Helper function to determine the distance between reference frames
-    virtual void distanceBetweenReferenceFrames(std::vector<cvm::real>& result) const;
+    virtual void computeDistanceBetweenReferenceFrames(std::vector<cvm::real>& result) const;
     cvm::real getPolynomialFactorOfCVGradient(size_t i_cv) const;
 public:
     CVBasedPath(std::string const &conf);
@@ -1520,7 +1520,7 @@ class colvar::gspathCV
   : public colvar::CVBasedPath, public GeometricPathCV::GeometricPathBase<colvarvalue, cvm::real, GeometricPathCV::path_sz::S>
 {
 protected:
-    virtual void updateReferenceDistances();
+    virtual void updateDistanceToReferenceFrames();
     virtual void prepareVectors();
 public:
     gspathCV(std::string const &conf);
@@ -1536,7 +1536,7 @@ class colvar::gzpathCV
   : public colvar::CVBasedPath, public GeometricPathCV::GeometricPathBase<colvarvalue, cvm::real, GeometricPathCV::path_sz::Z>
 {
 protected:
-    virtual void updateReferenceDistances();
+    virtual void updateDistanceToReferenceFrames();
     virtual void prepareVectors();
 public:
     gzpathCV(std::string const &conf);
@@ -1552,7 +1552,7 @@ class colvar::aspathCV
   : public colvar::CVBasedPath, public ArithmeticPathCV::ArithmeticPathBase<colvarvalue, cvm::real, ArithmeticPathCV::path_sz::S>
 {
 protected:
-    virtual void updateReferenceDistances();
+    virtual void updateDistanceToReferenceFrames();
 public:
     aspathCV(std::string const &conf);
     virtual ~aspathCV();
@@ -1566,7 +1566,7 @@ class colvar::azpathCV
   : public colvar::CVBasedPath, public ArithmeticPathCV::ArithmeticPathBase<colvarvalue, cvm::real, ArithmeticPathCV::path_sz::Z>
 {
 protected:
-    virtual void updateReferenceDistances();
+    virtual void updateDistanceToReferenceFrames();
 public:
     azpathCV(std::string const &conf);
     virtual ~azpathCV();

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -16,6 +16,7 @@
 #include "colvarmodule.h"
 #include "colvar.h"
 #include "colvaratoms.h"
+#include "colvar_arithmeticpath.h"
 
 #if (__cplusplus >= 201103L)
 #include "colvar_geometricpath.h"
@@ -1401,7 +1402,7 @@ class colvar::CartesianBasedPath
   : public colvar::cvc
 {
 protected:
-    virtual void computeReferenceDistance(std::vector<cvm::real>& result);
+    virtual void computeDistanceToReferenceFrames(std::vector<cvm::real>& result);
     /// Selected atoms
     cvm::atom_group *atoms;
     /// Fitting options
@@ -1499,7 +1500,9 @@ protected:
     /// Total number of reference frames
     size_t total_reference_frames;
 protected:
-    virtual void computeReferenceDistance(std::vector<cvm::real>& result);
+    virtual void computeDistanceToReferenceFrames(std::vector<cvm::real>& result);
+    /// Helper function to determine the distance between reference frames
+    virtual void distanceBetweenReferenceFrames(std::vector<cvm::real>& result) const;
     cvm::real getPolynomialFactorOfCVGradient(size_t i_cv) const;
 public:
     CVBasedPath(std::string const &conf);
@@ -1538,6 +1541,35 @@ protected:
 public:
     gzpathCV(std::string const &conf);
     virtual ~gzpathCV();
+    virtual void calc_value();
+    virtual void calc_gradients();
+    virtual void apply_force(colvarvalue const &force);
+};
+
+
+
+class colvar::aspathCV
+  : public colvar::CVBasedPath, public ArithmeticPathCV::ArithmeticPathBase<colvarvalue, cvm::real, ArithmeticPathCV::path_sz::S>
+{
+protected:
+    virtual void updateReferenceDistances();
+public:
+    aspathCV(std::string const &conf);
+    virtual ~aspathCV();
+    virtual void calc_value();
+    virtual void calc_gradients();
+    virtual void apply_force(colvarvalue const &force);
+};
+
+
+class colvar::azpathCV
+  : public colvar::CVBasedPath, public ArithmeticPathCV::ArithmeticPathBase<colvarvalue, cvm::real, ArithmeticPathCV::path_sz::Z>
+{
+protected:
+    virtual void updateReferenceDistances();
+public:
+    azpathCV(std::string const &conf);
+    virtual ~azpathCV();
     virtual void calc_value();
     virtual void calc_gradients();
     virtual void apply_force(colvarvalue const &force);
@@ -1588,6 +1620,20 @@ public:
 };
 
 class colvar::gzpathCV
+  : public colvar::componentDisabled
+{
+public:
+    gzpathCV(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::aspathCV
+  : public colvar::componentDisabled
+{
+public:
+    gspathCV(std::string const &conf) : componentDisabled(conf) {}
+};
+
+class colvar::azpathCV
   : public colvar::componentDisabled
 {
 public:

--- a/src/colvarcomp_apath.cpp
+++ b/src/colvarcomp_apath.cpp
@@ -20,7 +20,7 @@ colvar::aspathCV::aspathCV(std::string const &conf): CVBasedPath(conf) {
     x.type(colvarvalue::type_scalar);
     use_explicit_gradients = true;
     std::vector<cvm::real> rmsd_between_refs(total_reference_frames - 1, 0.0);
-    distanceBetweenReferenceFrames(rmsd_between_refs);
+    computeDistanceBetweenReferenceFrames(rmsd_between_refs);
     cvm::real mean_square_displacements = 0.0;
     for (size_t i_frame = 1; i_frame < total_reference_frames; ++i_frame) {
         cvm::log(std::string("Distance between frame ") + cvm::to_str(i_frame) + " and " + cvm::to_str(i_frame + 1) + " is " + cvm::to_str(rmsd_between_refs[i_frame - 1]) + std::string("\n"));
@@ -40,7 +40,7 @@ colvar::aspathCV::aspathCV(std::string const &conf): CVBasedPath(conf) {
     }
 }
 
-void colvar::aspathCV::updateReferenceDistances() {
+void colvar::aspathCV::updateDistanceToReferenceFrames() {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         cv[i_cv]->calc_value();
     }
@@ -109,7 +109,7 @@ colvar::azpathCV::azpathCV(std::string const &conf): CVBasedPath(conf) {
     x.type(colvarvalue::type_scalar);
     use_explicit_gradients = true;
     std::vector<cvm::real> rmsd_between_refs(total_reference_frames - 1, 0.0);
-    distanceBetweenReferenceFrames(rmsd_between_refs);
+    computeDistanceBetweenReferenceFrames(rmsd_between_refs);
     cvm::real mean_square_displacements = 0.0;
     for (size_t i_frame = 1; i_frame < total_reference_frames; ++i_frame) {
         cvm::log(std::string("Distance between frame ") + cvm::to_str(i_frame) + " and " + cvm::to_str(i_frame + 1) + " is " + cvm::to_str(rmsd_between_refs[i_frame - 1]) + std::string("\n"));
@@ -129,7 +129,7 @@ colvar::azpathCV::azpathCV(std::string const &conf): CVBasedPath(conf) {
     }
 }
 
-void colvar::azpathCV::updateReferenceDistances() {
+void colvar::azpathCV::updateDistanceToReferenceFrames() {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         cv[i_cv]->calc_value();
     }
@@ -182,7 +182,7 @@ void colvar::azpathCV::apply_force(colvarvalue const &force) {
             }
         } else {
             cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
-            colvarvalue cv_force = dzdx[i_cv] * force.real_value * factor_polynomial;
+            const colvarvalue cv_force = dzdx[i_cv] * force.real_value * factor_polynomial;
             cv[i_cv]->apply_force(cv_force);
         }
     }

--- a/src/colvarcomp_apath.cpp
+++ b/src/colvarcomp_apath.cpp
@@ -1,0 +1,193 @@
+#if (__cplusplus >= 201103L)
+
+#include <numeric>
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+
+#include "colvarmodule.h"
+#include "colvarvalue.h"
+#include "colvarparse.h"
+#include "colvar.h"
+#include "colvarcomp.h"
+
+colvar::aspathCV::aspathCV(std::string const &conf): CVBasedPath(conf) {
+    function_type = "aspathCV";
+    cvm::log(std::string("Total number of frames: ") + cvm::to_str(total_reference_frames) + std::string("\n"));
+    std::vector<cvm::real> p_weights(cv.size(), 1.0);
+    get_keyval(conf, "weights", p_weights, std::vector<cvm::real>(cv.size(), 1.0));
+    x.type(colvarvalue::type_scalar);
+    use_explicit_gradients = true;
+    std::vector<cvm::real> rmsd_between_refs(total_reference_frames - 1, 0.0);
+    distanceBetweenReferenceFrames(rmsd_between_refs);
+    cvm::real mean_square_displacements = 0.0;
+    for (size_t i_frame = 1; i_frame < total_reference_frames; ++i_frame) {
+        cvm::log(std::string("Distance between frame ") + cvm::to_str(i_frame) + " and " + cvm::to_str(i_frame + 1) + " is " + cvm::to_str(rmsd_between_refs[i_frame - 1]) + std::string("\n"));
+        mean_square_displacements += rmsd_between_refs[i_frame - 1] * rmsd_between_refs[i_frame - 1];
+    }
+    mean_square_displacements /= cvm::real(total_reference_frames - 1);
+    cvm::real suggested_lambda = 1.0 / mean_square_displacements;
+    cvm::real p_lambda;
+    get_keyval(conf, "lambda", p_lambda, suggested_lambda);
+    ArithmeticPathCV::ArithmeticPathBase<colvarvalue, cvm::real, ArithmeticPathCV::path_sz::S>::initialize(cv.size(), total_reference_frames, p_lambda, ref_cv[0], p_weights);
+    cvm::log(std::string("Lambda is ") + cvm::to_str(lambda) + std::string("\n"));
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
+            use_explicit_gradients = false;
+        }
+        cvm::log(std::string("The weight of CV ") + cvm::to_str(i_cv) + std::string(" is ") + cvm::to_str(weights[i_cv]) + std::string("\n"));
+    }
+}
+
+void colvar::aspathCV::updateReferenceDistances() {
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        cv[i_cv]->calc_value();
+    }
+    for (size_t i_frame = 0; i_frame < ref_cv.size(); ++i_frame) {
+        for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+            colvarvalue ref_cv_value(ref_cv[i_frame][i_cv]);
+            colvarvalue current_cv_value(cv[i_cv]->value());
+            if (current_cv_value.type() == colvarvalue::type_scalar) {
+                frame_element_distances[i_frame][i_cv] = 0.5 * cv[i_cv]->dist2_lgrad(cv[i_cv]->sup_coeff * (cvm::pow(current_cv_value.real_value, cv[i_cv]->sup_np)), ref_cv_value.real_value);
+            } else {
+                frame_element_distances[i_frame][i_cv] = 0.5 * cv[i_cv]->dist2_lgrad(cv[i_cv]->sup_coeff * current_cv_value, ref_cv_value);
+            }
+        }
+    }
+}
+
+void colvar::aspathCV::calc_value() {
+    computeValue();
+    x = s;
+}
+
+void colvar::aspathCV::calc_gradients() {
+    computeDerivatives();
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        cv[i_cv]->calc_gradients();
+        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+            cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
+            for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
+                for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
+                    for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+                        (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = dsdx[i_cv][j_elem] * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+                    }
+                }
+            }
+        
+        }
+    }
+}
+
+void colvar::aspathCV::apply_force(colvarvalue const &force) {
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable_com)
+        ) {
+            for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
+                (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
+            }
+        } else {
+            cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
+            colvarvalue cv_force = dsdx[i_cv] * force.real_value * factor_polynomial;
+            cv[i_cv]->apply_force(cv_force);
+        }
+    }
+}
+
+colvar::aspathCV::~aspathCV() {}
+
+colvar::azpathCV::azpathCV(std::string const &conf): CVBasedPath(conf) {
+    function_type = "azpathCV";
+    cvm::log(std::string("Total number of frames: ") + cvm::to_str(total_reference_frames) + std::string("\n"));
+    std::vector<cvm::real> p_weights(cv.size(), 1.0);
+    get_keyval(conf, "weights", p_weights, std::vector<cvm::real>(cv.size(), 1.0));
+    x.type(colvarvalue::type_scalar);
+    use_explicit_gradients = true;
+    std::vector<cvm::real> rmsd_between_refs(total_reference_frames - 1, 0.0);
+    distanceBetweenReferenceFrames(rmsd_between_refs);
+    cvm::real mean_square_displacements = 0.0;
+    for (size_t i_frame = 1; i_frame < total_reference_frames; ++i_frame) {
+        cvm::log(std::string("Distance between frame ") + cvm::to_str(i_frame) + " and " + cvm::to_str(i_frame + 1) + " is " + cvm::to_str(rmsd_between_refs[i_frame - 1]) + std::string("\n"));
+        mean_square_displacements += rmsd_between_refs[i_frame - 1] * rmsd_between_refs[i_frame - 1];
+    }
+    mean_square_displacements /= cvm::real(total_reference_frames - 1);
+    cvm::real suggested_lambda = 1.0 / mean_square_displacements;
+    cvm::real p_lambda;
+    get_keyval(conf, "lambda", p_lambda, suggested_lambda);
+    ArithmeticPathCV::ArithmeticPathBase<colvarvalue, cvm::real, ArithmeticPathCV::path_sz::Z>::initialize(cv.size(), total_reference_frames, p_lambda, ref_cv[0], p_weights);
+    cvm::log(std::string("Lambda is ") + cvm::to_str(lambda) + std::string("\n"));
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
+            use_explicit_gradients = false;
+        }
+        cvm::log(std::string("The weight of CV ") + cvm::to_str(i_cv) + std::string(" is ") + cvm::to_str(weights[i_cv]) + std::string("\n"));
+    }
+}
+
+void colvar::azpathCV::updateReferenceDistances() {
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        cv[i_cv]->calc_value();
+    }
+    for (size_t i_frame = 0; i_frame < ref_cv.size(); ++i_frame) {
+        for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+            colvarvalue ref_cv_value(ref_cv[i_frame][i_cv]);
+            colvarvalue current_cv_value(cv[i_cv]->value());
+            if (current_cv_value.type() == colvarvalue::type_scalar) {
+                frame_element_distances[i_frame][i_cv] = 0.5 * cv[i_cv]->dist2_lgrad(cv[i_cv]->sup_coeff * (cvm::pow(current_cv_value.real_value, cv[i_cv]->sup_np)), ref_cv_value.real_value);
+            } else {
+                frame_element_distances[i_frame][i_cv] = 0.5 * cv[i_cv]->dist2_lgrad(cv[i_cv]->sup_coeff * current_cv_value, ref_cv_value);
+            }
+        }
+    }
+}
+
+void colvar::azpathCV::calc_value() {
+    computeValue();
+    x = z;
+}
+
+void colvar::azpathCV::calc_gradients() {
+    computeDerivatives();
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        cv[i_cv]->calc_gradients();
+        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+            cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
+            for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
+                for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
+                    for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+                        (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = dzdx[i_cv][j_elem] * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+                    }
+                }
+            }
+        
+        }
+    }
+}
+
+void colvar::azpathCV::apply_force(colvarvalue const &force) {
+    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
+            !cv[i_cv]->is_enabled(f_cvc_scalable_com)
+        ) {
+            for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
+                (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
+            }
+        } else {
+            cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
+            colvarvalue cv_force = dzdx[i_cv] * force.real_value * factor_polynomial;
+            cv[i_cv]->apply_force(cv_force);
+        }
+    }
+}
+
+colvar::azpathCV::~azpathCV() {}
+
+#endif

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -145,7 +145,7 @@ colvar::gspath::gspath(std::string const &conf): CartesianBasedPath(conf) {
     cvm::log(std::string("Geometric pathCV(s) loaded ") + cvm::to_str(reference_frames.size()) + std::string(" frames.\n"));
 }
 
-void colvar::gspath::updateReferenceDistances() {
+void colvar::gspath::updateDistanceToReferenceFrames() {
     computeDistanceToReferenceFrames(frame_distances);
 }
 
@@ -289,7 +289,7 @@ colvar::gzpath::gzpath(std::string const &conf): CartesianBasedPath(conf) {
     cvm::log(std::string("Geometric pathCV(z) loaded ") + cvm::to_str(reference_frames.size()) + std::string(" frames.\n"));
 }
 
-void colvar::gzpath::updateReferenceDistances() {
+void colvar::gzpath::updateDistanceToReferenceFrames() {
     computeDistanceToReferenceFrames(frame_distances);
 }
 
@@ -551,6 +551,9 @@ colvar::CVBasedPath::CVBasedPath(std::string const &conf): cvc(conf) {
             ++total_reference_frames;
         }
     }
+    if (total_reference_frames <= 1) {
+	cvm::error("Error: there is only 1 or 0 reference frame, which doesn't constitute a path.\n");
+    }
     x.type(colvarvalue::type_scalar);
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
@@ -586,7 +589,7 @@ void colvar::CVBasedPath::computeDistanceToReferenceFrames(std::vector<cvm::real
     }
 }
 
-void colvar::CVBasedPath::distanceBetweenReferenceFrames(std::vector<cvm::real>& result) const {
+void colvar::CVBasedPath::computeDistanceBetweenReferenceFrames(std::vector<cvm::real>& result) const {
     if (ref_cv.size() < 2) return;
     for (size_t i_frame = 1; i_frame < ref_cv.size(); ++i_frame) {
         cvm::real dist_ij = 0.0;
@@ -648,7 +651,7 @@ colvar::gspathCV::gspathCV(std::string const &conf): CVBasedPath(conf) {
 
 colvar::gspathCV::~gspathCV() {}
 
-void colvar::gspathCV::updateReferenceDistances() {
+void colvar::gspathCV::updateDistanceToReferenceFrames() {
     computeDistanceToReferenceFrames(frame_distances);
 }
 
@@ -790,7 +793,7 @@ colvar::gzpathCV::gzpathCV(std::string const &conf): CVBasedPath(conf) {
 colvar::gzpathCV::~gzpathCV() {
 }
 
-void colvar::gzpathCV::updateReferenceDistances() {
+void colvar::gzpathCV::updateDistanceToReferenceFrames() {
     computeDistanceToReferenceFrames(frame_distances);
 }
 


### PR DESCRIPTION
This pull request implements Parrinello's pathCV in collective variable space. It also allows the use of different weights for the CVs, as described in http://dx.doi.org/10.1021/acs.jctc.8b00563 . To distinguish this implementation from the `pathCV.tcl` script which does similar computation in Cartesian space, the names of this component are `aspathCV` and `azpathCV`.

Example:
```
colvar {
    name apath_s_dihed

    aspathCV {
        weights {1.0 1.0 1.0}
        lambda 0.006
        dihedral {
            name 001
            group1 {atomNumbers {5}}
            group2 {atomNumbers {7}}
            group3 {atomNumbers {9}}
            group4 {atomNumbers {15}}
        } 
        dihedral {
            name 002
            group1 {atomNumbers {15}}
            group2 {atomNumbers {17}}
            group3 {atomNumbers {19}}
            group4 {atomNumbers {25}}
        }
        dihedral {
            name 003
            group1 {atomNumbers {25}}
            group2 {atomNumbers {27}}
            group3 {atomNumbers {29}}
            group4 {atomNumbers {35}}
        }
        pathFile ./path.txt
    }
}

colvar {
    name apath_z_dihed

    azpathCV {
        weights {1.0 1.0 1.0}
        lambda 0.006
        dihedral {
            name 001
            group1 {atomNumbers {5}}
            group2 {atomNumbers {7}}
            group3 {atomNumbers {9}}
            group4 {atomNumbers {15}}
        } 
        dihedral {
            name 002
            group1 {atomNumbers {15}}
            group2 {atomNumbers {17}}
            group3 {atomNumbers {19}}
            group4 {atomNumbers {25}}
        }
        dihedral {
            name 003
            group1 {atomNumbers {25}}
            group2 {atomNumbers {27}}
            group3 {atomNumbers {29}}
            group4 {atomNumbers {35}}
        }
        pathFile ./path.txt
    }
}
```
The weights have default values of 1.0 for all CVs and lambda is default to the inverse of mean square displacement between neighbouring reference frames. The format of `pathFile` is the same as the one in `gspathCV` and `gzpathCV`.
