### PR TITLE
Update NAMD Make.depends based on C++11-only dependencies

### DIFF
--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -7571,6 +7571,7 @@ obj/colvar.o: \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvarbias.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvar.o $(COPTC) colvars/src/colvar.cpp
@@ -7685,7 +7686,8 @@ obj/colvarcomp.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp.o $(COPTC) colvars/src/colvarcomp.cpp
 obj/colvarcomp_angles.o: \
 	obj/.exists \
@@ -7699,7 +7701,8 @@ obj/colvarcomp_angles.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_angles.o $(COPTC) colvars/src/colvarcomp_angles.cpp
 obj/colvarcomp_coordnums.o: \
 	obj/.exists \
@@ -7713,7 +7716,8 @@ obj/colvarcomp_coordnums.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvardeps.h \
 	colvars/src/colvar.h \
-	colvars/src/colvarcomp.h
+	colvars/src/colvarcomp.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_coordnums.o $(COPTC) colvars/src/colvarcomp_coordnums.cpp
 obj/colvarcomp_distances.o: \
 	obj/.exists \
@@ -7727,7 +7731,8 @@ obj/colvarcomp_distances.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_distances.o $(COPTC) colvars/src/colvarcomp_distances.cpp
 obj/colvarcomp_protein.o: \
 	obj/.exists \
@@ -7741,7 +7746,8 @@ obj/colvarcomp_protein.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_protein.o $(COPTC) colvars/src/colvarcomp_protein.cpp
 obj/colvarcomp_rotations.o: \
 	obj/.exists \
@@ -7755,11 +7761,23 @@ obj/colvarcomp_rotations.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_rotations.o $(COPTC) colvars/src/colvarcomp_rotations.cpp
 obj/colvarcomp_gpath.o: \
 	obj/.exists \
-	colvars/src/colvarcomp_gpath.cpp
+	colvars/src/colvarcomp_gpath.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvar.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
 obj/colvardeps.o: \
 	obj/.exists \
@@ -7785,6 +7803,7 @@ obj/colvargrid.o: \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
+	colvars/src/colvar_geometricpath.h \
 	colvars/src/colvargrid.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvargrid.o $(COPTC) colvars/src/colvargrid.cpp
 obj/colvarmodule.o: \
@@ -7808,7 +7827,8 @@ obj/colvarmodule.o: \
 	colvars/src/colvarbias_restraint.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarcomp.h
+	colvars/src/colvarcomp.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarmodule.o $(COPTC) colvars/src/colvarmodule.cpp
 obj/colvarparse.o: \
 	obj/.exists \


### PR DESCRIPTION
The NAMD Makefile target for `depends` does not currently handle files that are conditionally included based on `__cplusplus`, such as `colvar_geometricpath.h`.

For now I re-generated `Make.depends` by turning on `-std=c++11` manually and plan to submit it to NAMD Gerrit as-is.

For the future, options are:
- Regenerate `Make.depends` every time the Colvars version is updated in a NAMD source tree by patching the NAMD `Makefile` to achieve this.
- Modify upstream the NAMD `Makefile` to use at least `-std=c++0x` for `depends`.

