### PR TITLE
Include header in all files rather than patching them upon install

### DIFF
--- a/colvartools/abf_data.cpp
+++ b/colvartools/abf_data.cpp
@@ -1,5 +1,14 @@
+// -*- c++ -*-
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
 
 #include "abf_data.h"
+
 #include <fstream>
 #include <string>
 #include <cstring>

--- a/colvartools/abf_data.h
+++ b/colvartools/abf_data.h
@@ -1,5 +1,12 @@
 /// \file integrate.h General headers for ABF_integrate
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <iostream>
 #include <vector>
 

--- a/colvartools/abf_integrate.cpp
+++ b/colvartools/abf_integrate.cpp
@@ -1,3 +1,12 @@
+// -*- c++ -*-
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 /****************************************************************
  * abf_integrate                                                *
  * Integrate n-dimensional PMF from discrete gradient grid      *

--- a/devel-tools/update-header-cpp.patch
+++ b/devel-tools/update-header-cpp.patch
@@ -1,7 +1,7 @@
 2a3,9
 > // This file is part of the Collective Variables module (Colvars).
 > // The original version of Colvars and its updates are located at:
-> // https://github.com/colvars/colvars
+> // https://github.com/Colvars/colvars
 > // Please update all Colvars source files before making any changes.
 > // If you wish to distribute your changes, please submit them to the
 > // Colvars repository at GitHub.

--- a/devel-tools/update-header-tex.patch
+++ b/devel-tools/update-header-tex.patch
@@ -1,7 +1,7 @@
 0a1,7
 > % This file is part of the Collective Variables module (Colvars).
 > % The original version of Colvars and its updates are located at:
-> % https://github.com/colvars/colvars
+> % https://github.com/Colvars/colvars
 > % Please update all Colvars source files before making any changes.
 > % If you wish to distribute your changes, please submit them to the
 > % Colvars repository at GitHub.

--- a/doc/colvars-refman-css.tex
+++ b/doc/colvars-refman-css.tex
@@ -1,3 +1,10 @@
+% This file is part of the Collective Variables module (Colvars).
+% The original version of Colvars and its updates are located at:
+% https://github.com/Colvars/colvars
+% Please update all Colvars source files before making any changes.
+% If you wish to distribute your changes, please submit them to the
+% Colvars repository at GitHub.
+
 \Css{
 @media only screen and (max-width: 959px) {
 .inner {

--- a/doc/colvars-refman-lammps.tex
+++ b/doc/colvars-refman-lammps.tex
@@ -1,3 +1,10 @@
+% This file is part of the Collective Variables module (Colvars).
+% The original version of Colvars and its updates are located at:
+% https://github.com/Colvars/colvars
+% Please update all Colvars source files before making any changes.
+% If you wish to distribute your changes, please submit them to the
+% Colvars repository at GitHub.
+
 
 \newcommand{\LAMMPS}{}
 \newcommand{\MDENGINE}{LAMMPS}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1,3 +1,10 @@
+% This file is part of the Collective Variables module (Colvars).
+% The original version of Colvars and its updates are located at:
+% https://github.com/Colvars/colvars
+% Please update all Colvars source files before making any changes.
+% If you wish to distribute your changes, please submit them to the
+% Colvars repository at GitHub.
+
 \cvnamdugonly{
 \section{Collective Variable-based Calculations (Colvars)}
 \label{section:colvars}

--- a/doc/colvars-refman-namd.tex
+++ b/doc/colvars-refman-namd.tex
@@ -1,3 +1,10 @@
+% This file is part of the Collective Variables module (Colvars).
+% The original version of Colvars and its updates are located at:
+% https://github.com/Colvars/colvars
+% Please update all Colvars source files before making any changes.
+% If you wish to distribute your changes, please submit them to the
+% Colvars repository at GitHub.
+
 
 \newcommand{\NAMD}{}
 \newcommand{\MDENGINE}{NAMD}

--- a/doc/colvars-refman-vmd.tex
+++ b/doc/colvars-refman-vmd.tex
@@ -1,3 +1,10 @@
+% This file is part of the Collective Variables module (Colvars).
+% The original version of Colvars and its updates are located at:
+% https://github.com/Colvars/colvars
+% Please update all Colvars source files before making any changes.
+% If you wish to distribute your changes, please submit them to the
+% Colvars repository at GitHub.
+
 
 \newcommand{\VMD}{}
 \newcommand{\MDENGINE}{VMD}

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -1,3 +1,10 @@
+% This file is part of the Collective Variables module (Colvars).
+% The original version of Colvars and its updates are located at:
+% https://github.com/Colvars/colvars
+% Please update all Colvars source files before making any changes.
+% If you wish to distribute your changes, please submit them to the
+% Colvars repository at GitHub.
+
 \documentclass[11pt]{article}
 \usepackage[margin=1in]{geometry}
 

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -2,7 +2,7 @@
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
+// https://github.com/Colvars/colvars
 // Please update all Colvars source files before making any changes.
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.h
@@ -2,7 +2,7 @@
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
+// https://github.com/Colvars/colvars
 // Please update all Colvars source files before making any changes.
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.

--- a/lammps/src/USER-COLVARS/fix_colvars.cpp
+++ b/lammps/src/USER-COLVARS/fix_colvars.cpp
@@ -2,7 +2,7 @@
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
+// https://github.com/Colvars/colvars
 // Please update all Colvars source files before making any changes.
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.

--- a/lammps/src/USER-COLVARS/fix_colvars.h
+++ b/lammps/src/USER-COLVARS/fix_colvars.h
@@ -2,7 +2,7 @@
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
-// https://github.com/colvars/colvars
+// https://github.com/Colvars/colvars
 // Please update all Colvars source files before making any changes.
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <errno.h>
 
 #include "common.h"

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARPROXY_NAMD_H
 #define COLVARPROXY_NAMD_H
 

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <list>
 #include <vector>
 #include <algorithm>

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVAR_H
 #define COLVAR_H
 

--- a/src/colvar_UIestimator.h
+++ b/src/colvar_UIestimator.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVAR_UIESTIMATOR_H
 #define COLVAR_UIESTIMATOR_H
 

--- a/src/colvar_geometricpath.h
+++ b/src/colvar_geometricpath.h
@@ -1,5 +1,12 @@
 #ifndef GEOMETRICPATHCV_H
 #define GEOMETRICPATHCV_H
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 
 #include "colvarmodule.h"
 

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <list>
 #include <vector>
 #include <algorithm>

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARATOMS_H
 #define COLVARATOMS_H
 

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarproxy.h"
 #include "colvarvalue.h"

--- a/src/colvarbias.h
+++ b/src/colvarbias.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARBIAS_H
 #define COLVARBIAS_H
 

--- a/src/colvarbias_abf.cpp
+++ b/src/colvarbias_abf.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarproxy.h"
 #include "colvar.h"

--- a/src/colvarbias_abf.h
+++ b/src/colvarbias_abf.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARBIAS_ABF_H
 #define COLVARBIAS_ABF_H
 

--- a/src/colvarbias_alb.cpp
+++ b/src/colvarbias_alb.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <cstdlib>
 
 #include "colvarmodule.h"

--- a/src/colvarbias_alb.h
+++ b/src/colvarbias_alb.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARBIAS_ALB_H
 #define COLVARBIAS_ALB_H
 

--- a/src/colvarbias_histogram.cpp
+++ b/src/colvarbias_histogram.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarproxy.h"
 #include "colvar.h"

--- a/src/colvarbias_histogram.h
+++ b/src/colvarbias_histogram.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARBIAS_HISTOGRAM_H
 #define COLVARBIAS_HISTOGRAM_H
 

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <iostream>
 #include <sstream>
 #include <fstream>

--- a/src/colvarbias_meta.h
+++ b/src/colvarbias_meta.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARBIAS_META_H
 #define COLVARBIAS_META_H
 

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarproxy.h"
 #include "colvarvalue.h"

--- a/src/colvarbias_restraint.h
+++ b/src/colvarbias_restraint.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARBIAS_RESTRAINT_H
 #define COLVARBIAS_RESTRAINT_H
 

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <algorithm>
 
 #include "colvarmodule.h"

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARCOMP_H
 #define COLVARCOMP_H
 

--- a/src/colvarcomp_angles.cpp
+++ b/src/colvarcomp_angles.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvar.h"
 #include "colvarcomp.h"

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarparse.h"
 #include "colvaratoms.h"

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 #include "colvarparse.h"

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -1,5 +1,12 @@
 #if (__cplusplus >= 201103L)
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <numeric>
 #include <algorithm>
 #include <cmath>

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <algorithm>
 
 #include "colvarmodule.h"

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 #include "colvarparse.h"

--- a/src/colvardeps.cpp
+++ b/src/colvardeps.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 
 #include "colvarmodule.h"
 #include "colvarproxy.h"

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARDEPS_H
 #define COLVARDEPS_H
 

--- a/src/colvargrid.cpp
+++ b/src/colvargrid.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 #include "colvarparse.h"

--- a/src/colvargrid.h
+++ b/src/colvargrid.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARGRID_H
 #define COLVARGRID_H
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <sstream>
 #include <cstring>
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARMODULE_H
 #define COLVARMODULE_H
 

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <sstream>
 #include <iostream>
 #include <algorithm>

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARPARSE_H
 #define COLVARPARSE_H
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #if !defined(WIN32) || defined(__CYGWIN__)
 #include <unistd.h>
 #endif

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARPROXY_H
 #define COLVARPROXY_H
 

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,3 +1,11 @@
 #ifndef COLVARS_VERSION
 #define COLVARS_VERSION "2019-10-09"
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #endif

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <cstdlib>
 #include <cstring>
 

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARSCRIPT_H
 //#define COLVARSCRIPT_H // Delay definition until later
 

--- a/src/colvartypes.cpp
+++ b/src/colvartypes.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <cstdlib>
 #include <cstring>
 

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARTYPES_H
 #define COLVARTYPES_H
 

--- a/src/colvarvalue.cpp
+++ b/src/colvarvalue.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <vector>
 #include <sstream>
 #include <iostream>

--- a/src/colvarvalue.h
+++ b/src/colvarvalue.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARVALUE_H
 #define COLVARVALUE_H
 

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -50,9 +50,6 @@ fi
 # Infer source path from name of script
 source=$(dirname "$0")
 
-cpp_patch=${source}/devel-tools/update-header-cpp.patch
-tex_patch=${source}/devel-tools/update-header-tex.patch
-
 # Check general validity of target path
 target="$1"
 if [ ! -d "${target}" ]
@@ -183,7 +180,7 @@ then
   for src in ${source}/src/*.h ${source}/src/*.cpp
   do \
     tgt=$(basename ${src})
-    condcopy "${src}" "${target}/lib/colvars/${tgt}" "${cpp_patch}"
+    condcopy "${src}" "${target}/lib/colvars/${tgt}"
   done
 
   # Update makefiles for library
@@ -207,7 +204,7 @@ then
                ${source}/lammps/src/USER-COLVARS/fix_colvars.h
     do \
       tgt=$(basename ${src})
-      condcopy "${src}" "${target}/src/USER-COLVARS/${tgt}" "${cpp_patch}"
+      condcopy "${src}" "${target}/src/USER-COLVARS/${tgt}"
     done
     for src in ${source}/lammps/src/USER-COLVARS/Install.sh \
                ${source}/lammps/src/USER-COLVARS/group_ndx.cpp \
@@ -295,7 +292,7 @@ then
   for src in ${source}/src/*.h ${source}/src/*.cpp
   do \
     tgt=$(basename ${src})
-    condcopy "${src}" "${target}/colvars/src/${tgt}" "${cpp_patch}"
+    condcopy "${src}" "${target}/colvars/src/${tgt}"
   done
   condcopy "${source}/namd/colvars/src/Makefile.namd" \
            "${target}/colvars/src/Makefile.namd"
@@ -307,7 +304,7 @@ then
   for src in ${source}/colvartools/*h ${source}/colvartools/*cpp
   do \
     tgt=$(basename ${src})
-    condcopy "${src}" "${target}/lib/abf_integrate/${tgt}" "${cpp_patch}"
+    condcopy "${src}" "${target}/lib/abf_integrate/${tgt}"
   done
   condcopy "${source}/colvartools/Makefile" \
            "${target}/lib/abf_integrate/Makefile"
@@ -319,16 +316,16 @@ then
       ${source}/namd/src/colvarproxy_namd.C
   do \
     tgt=$(basename ${src})
-    condcopy "${src}" "${target}/src/${tgt}" "${cpp_patch}"
+    condcopy "${src}" "${target}/src/${tgt}"
   done
 
   # Copy doc files
   condcopy "${source}/doc/colvars-refman.bib" \
            "${target}/ug/ug_colvars.bib"
   condcopy "${source}/doc/colvars-refman-main.tex" \
-           "${target}/ug/ug_colvars.tex" "${tex_patch}"
+           "${target}/ug/ug_colvars.tex"
   condcopy "${source}/namd/ug/ug_colvars_macros.tex" \
-           "${target}/ug/ug_colvars_macros.tex" "${tex_patch}"
+           "${target}/ug/ug_colvars_macros.tex"
   condcopy "${source}/doc/colvars_diagram.pdf" \
            "${target}/ug/figures/colvars_diagram.pdf"
   condcopy "${source}/doc/colvars_diagram.eps" \
@@ -376,21 +373,21 @@ then
   for src in ${source}/src/*.h
   do \
     tgt=$(basename ${src})
-    condcopy "${src}" "${target}/src/${tgt}" "${cpp_patch}"
+    condcopy "${src}" "${target}/src/${tgt}"
   done
   # Update code-independent sources
   for src in ${source}/src/*.cpp
   do \
     tgt=$(basename ${src%.cpp})
-    condcopy "${src}" "${target}/src/${tgt}.C" "${cpp_patch}"
+    condcopy "${src}" "${target}/src/${tgt}.C"
   done
 
   condcopy "${source}/doc/colvars-refman.bib" \
            "${target}/doc/ug_colvars.bib"
   condcopy "${source}/doc/colvars-refman-main.tex" \
-           "${target}/doc/ug_colvars.tex" "${tex_patch}"
+           "${target}/doc/ug_colvars.tex"
   condcopy "${source}/vmd/doc/ug_colvars_macros.tex" \
-           "${target}/doc/ug_colvars_macros.tex" "${tex_patch}"
+           "${target}/doc/ug_colvars_macros.tex"
   condcopy "${source}/doc/colvars_diagram.pdf" \
            "${target}/doc/pictures/colvars_diagram.pdf"
   condcopy "${source}/doc/colvars_diagram.eps" \
@@ -403,7 +400,7 @@ then
       ${source}/vmd/src/colvarproxy_vmd.C  
   do \
     tgt=$(basename ${src})
-    condcopy "${src}" "${target}/src/${tgt}" "${cpp_patch}"
+    condcopy "${src}" "${target}/src/${tgt}"
   done
 
   condcopy "${source}/vmd/src/colvars_files.pl" "${target}/src/colvars_files.pl"

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <tcl.h>
 
 #include "VMDApp.h"

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #ifndef COLVARPROXY_VMD_H
 #define COLVARPROXY_VMD_H
 


### PR DESCRIPTION
Mostly for ease of maintenance: errors or warnings while building correspond to the same line numbers in a target package as well as the original repository.