### PR TITLE
Add Makefile useful for compilation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@
 # Executable
 colvartools/abf_integrate
 
+# Lepton library (copied or symlinked in compilation tests)
+src/lepton
+
+# Dependencies for compilation tests
+src/Makefile.deps
+
 # output files from reg tests
 *.diff
 *.BAK

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,82 @@
+# -*- makefile -*-
+
+# This Makefile is useful for compilation tests only.  To use the library,
+# please use instead the build recipes of the packages that include it.
+
+COLVARS_LIB = libcolvars.a
+COLVARS_OBJ_DIR =
+
+.PHONY: default clean
+
+default: $(COLVARS_LIB)
+
+.SUFFIXES:
+.SUFFIXES: .cpp .o
+
+ifeq ($(CXX),)
+CXX := g++
+endif
+ifeq ($(CXXFLAGS),)
+CXXFLAGS := -std=c++11 -pedantic -g -O2
+ifneq ($(CXX),"CC")
+CXXFLAGS += -Wall
+endif
+endif
+
+ifeq ($(AR),)
+AR := ar
+ARFLAGS := -rscv
+endif
+ifeq ($(SHELL),)
+SHELL := /bin/sh
+endif
+
+
+# Detect debug settings
+ifeq ($(COLVARS_DEBUG),)
+COLVARS_DEBUG_INCFLAGS :=
+else
+COLVARS_DEBUG_INCFLAGS := -DCOLVARS_DEBUG
+endif
+
+COLVARS_INCFLAGS := $(COLVARS_DEBUG_INCFLAGS)
+
+
+COLVARS_SRCS := $(wildcard *.cpp)
+
+# Test if the Lepton source folder is present
+ifneq ($(wildcard lepton/src),)
+
+LEPTON_SRCS := $(wildcard lepton/src/*.cpp)
+
+LEPTON_OBJS := $(LEPTON_SRCS:.cpp=.o)
+
+LEPTON_INCFLAGS := -Ilepton/include -DLEPTON
+
+endif
+
+
+COLVARS_OBJS := $(COLVARS_SRCS:.cpp=.o) $(LEPTON_OBJS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $(COLVARS_INCFLAGS) $(LEPTON_INCFLAGS) -c -o $@ $<
+
+$(COLVARS_LIB):	Makefile.deps $(COLVARS_OBJS)
+	$(AR) $(ARFLAGS) $(COLVARS_LIB) $(COLVARS_OBJS) $(LEPTON_OBJS)
+
+Makefile.deps: $(COLVARS_SRCS)
+	@echo > $@
+	@for src in $^ ; do \
+	  obj=`basename $$src .cpp`.o ; \
+	  $(CXX) -MM $(COLVARS_INCFLAGS) $(LEPTON_INCFLAGS) \
+	    -MT '$$(COLVARS_OBJ_DIR)'$$obj $$src >> $@ ; \
+	  done
+
+include Makefile.deps
+
+# No explicit dependencies for Lepton: we assume its object files are always
+# newer than the corresponding source files
+
+clean:
+	-rm -f $(COLVARS_OBJS) $(COLVARS_LIB) Makefile.deps
+


### PR DESCRIPTION
This is a rather simple and fairly portable `Makefile` that builds and links the static library for the purpose of performing compilation tests more quickly.  For obvious reasons, `colvarproxy` interface files with other packages are not included in the build and therefore not covered.

Compilation flags have reasonable defaults for testing (e.g. `-std=c++11 -pedantic`) but can be overridden by environment variables.

Lepton is detected by the presence of a folder called `lepton` inside the `src` folder (similar to what is done in LAMMPS).

