### PR TITLE
Add CMake recipe for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,13 @@
 *.pyc
 
 # Executable
-colvartools/abf_integrate
+/colvartools/abf_integrate
 
 # Lepton library (copied or symlinked in compilation tests)
-src/lepton
+/lepton
 
 # Dependencies for compilation tests
-src/Makefile.deps
+/src/Makefile.deps
 
 # output files from reg tests
 *.diff

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(colvars CXX)
+get_filename_component(COLVARS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)
+
+#set(CMAKE_VERBOSE_MAKEFILE on)
+
+option(ENABLE_LEPTON "Build and link the Lepton library" OFF)
+
+file(GLOB COLVARS_SOURCES ${COLVARS_SOURCE_DIR}/src/[^.]*.cpp)
+
+if(ENABLE_LEPTON)
+  set(LEPTON_DIR ${COLVARS_SOURCE_DIR}/lepton)
+  set(CMAKE_CXX_STANDARD 11)
+  file(GLOB LEPTON_SOURCES ${LEPTON_DIR}/src/[^.]*.cpp)
+  add_library(lepton STATIC ${LEPTON_SOURCES})
+  target_include_directories(lepton PRIVATE ${LEPTON_DIR}/include)
+endif()
+
+add_library(colvars STATIC ${COLVARS_SOURCES})
+target_compile_options(colvars PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-pedantic -Wall>)
+
+if(ENABLE_LEPTON)
+  target_compile_options(colvars PRIVATE -DLEPTON)
+  target_include_directories(colvars PRIVATE ${LEPTON_DIR}/include)
+endif()
+
+message(STATUS "NOTE: this CMake recipe is useful for compilation tests only.")
+message(STATUS "      To use the library, please follow instead the build recipes of the packages that include it.")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 
 project(colvars CXX)
 get_filename_component(COLVARS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 2.8.12)
 project(colvars CXX)
 get_filename_component(COLVARS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUTE)
 
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 #set(CMAKE_VERBOSE_MAKEFILE on)
 
 option(ENABLE_LEPTON "Build and link the Lepton library" OFF)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -7,10 +7,23 @@ get_filename_component(COLVARS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. ABSOLUT
 
 option(ENABLE_LEPTON "Build and link the Lepton library" OFF)
 
+if(NOT DEFINED LEPTON_DIR)
+  set(LEPTON_DIR ${COLVARS_SOURCE_DIR}/lepton)
+else()
+  if(NOT EXISTS ${LEPTON_DIR})
+    message(FATAL_ERROR "Could not access ${LEPTON_DIR}")
+  endif()
+endif()
+if(EXISTS ${LEPTON_DIR})
+  set(ENABLE_LEPTON ON)
+endif()
+
 file(GLOB COLVARS_SOURCES ${COLVARS_SOURCE_DIR}/src/[^.]*.cpp)
 
 if(ENABLE_LEPTON)
-  set(LEPTON_DIR ${COLVARS_SOURCE_DIR}/lepton)
+  if(NOT EXISTS ${LEPTON_DIR})
+    message(FATAL_ERROR "With -DENABLE_LEPTON=ON, the lepton folder must be copied into ${COLVARS_SOURCE_DIR} or provided by -DLEPTON_DIR=xxx")
+  endif()
   set(CMAKE_CXX_STANDARD 11)
   file(GLOB LEPTON_SOURCES ${LEPTON_DIR}/src/[^.]*.cpp)
   add_library(lepton STATIC ${LEPTON_SOURCES})
@@ -18,7 +31,12 @@ if(ENABLE_LEPTON)
 endif()
 
 add_library(colvars STATIC ${COLVARS_SOURCES})
+
+# Note: -pedantic will raise at least a warning for long long
 target_compile_options(colvars PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-pedantic -Wall>)
+
+# The following line enables long long, but does so by setting std=c++11...
+#target_compile_features(colvars PRIVATE cxx_long_long_type)
 
 if(ENABLE_LEPTON)
   target_compile_options(colvars PRIVATE -DLEPTON)

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,13 +45,13 @@ COLVARS_INCFLAGS := $(COLVARS_DEBUG_INCFLAGS)
 COLVARS_SRCS := $(wildcard *.cpp)
 
 # Test if the Lepton source folder is present
-ifneq ($(wildcard lepton/src),)
+ifneq ($(wildcard ../lepton/src),)
 
-LEPTON_SRCS := $(wildcard lepton/src/*.cpp)
+LEPTON_SRCS := $(wildcard ../lepton/src/*.cpp)
 
 LEPTON_OBJS := $(LEPTON_SRCS:.cpp=.o)
 
-LEPTON_INCFLAGS := -Ilepton/include -DLEPTON
+LEPTON_INCFLAGS := -I../lepton/include -DLEPTON
 
 endif
 


### PR DESCRIPTION
- Change default location of Lepton in the top-level folder (more reasonable than inside `src`).

- Allows turning Lepton on or off explicitly with `-DENABLE_LEPTON=ON|OFF`, or implicitly by testing if the `${LEPTON_DIR}` path exists. `LEPTON_DIR` can be provided as a CMake flag, or left at its default location.  `CMAKE_CXX_STANDARD` is left at its default value for the compiler (`98` in most cases) and is raised to `11` when Lepton is enabled.
