### PR TITLE
Fix segfault at deleting CVBasedPath

### DIFF
--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -624,6 +624,7 @@ colvar::CVBasedPath::~CVBasedPath() {
     for (auto it = cv.begin(); it != cv.end(); ++it) {
         delete (*it);
     }
+    atom_groups.clear();
 }
 
 colvar::gspathCV::gspathCV(std::string const &conf): CVBasedPath(conf) {


### PR DESCRIPTION
`CVBasedPath` is actually a generalization of `dihedPC`, so adding `atom_groups.clear()` in the destructor should solve the segfault issue when deleting derived colvar components.  