### PR TITLE
Reduce compiler warnings

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -680,7 +680,7 @@ int colvar::init_output_flags(std::string const &conf)
 // read the configuration and set up corresponding instances, for
 // each type of component implemented
 template<typename def_class_name> int colvar::init_components_type(std::string const &conf,
-                                                                   char const *def_desc,
+                                                                   char const * /* def_desc */,
                                                                    char const *def_config_key)
 {
   size_t def_count = 0;
@@ -1245,7 +1245,7 @@ int colvar::collect_cvc_data()
 }
 
 
-int colvar::check_cvc_range(int first_cvc, size_t num_cvcs)
+int colvar::check_cvc_range(int first_cvc, size_t /* num_cvcs */)
 {
   if ((first_cvc < 0) || (first_cvc >= ((int) cvcs.size()))) {
     cvm::error("Error: trying to address a component outside the "

--- a/src/colvar_geometricpath.h
+++ b/src/colvar_geometricpath.h
@@ -121,7 +121,7 @@ void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t 
 }
 
 template <typename element_type, typename scalar_type, path_sz path_type>
-void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t vector_size, const std::vector<element_type>& elements, size_t total_frames, bool p_use_second_closest_frame, bool p_use_third_closest_frame, bool p_use_z_square) {
+void GeometricPathBase<element_type, scalar_type, path_type>::initialize(size_t /* vector_size */, const std::vector<element_type>& elements, size_t total_frames, bool p_use_second_closest_frame, bool p_use_third_closest_frame, bool p_use_z_square) {
     v1v1 = scalar_type();
     v2v2 = scalar_type();
     v3v3 = scalar_type();

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -309,7 +309,7 @@ int colvarbias::end_of_step()
 }
 
 
-int colvarbias::change_configuration(std::string const &conf)
+int colvarbias::change_configuration(std::string const & /* conf */)
 {
   cvm::error("Error: change_configuration() not implemented.\n",
              COLVARS_NOT_IMPLEMENTED);
@@ -317,7 +317,7 @@ int colvarbias::change_configuration(std::string const &conf)
 }
 
 
-cvm::real colvarbias::energy_difference(std::string const &conf)
+cvm::real colvarbias::energy_difference(std::string const & /* conf */)
 {
   cvm::error("Error: energy_difference() not implemented.\n",
              COLVARS_NOT_IMPLEMENTED);
@@ -336,7 +336,7 @@ int colvarbias::current_bin()
   cvm::error("Error: current_bin() not implemented.\n");
   return COLVARS_NOT_IMPLEMENTED;
 }
-int colvarbias::bin_count(int bin_index)
+int colvarbias::bin_count(int /* bin_index */)
 {
   cvm::error("Error: bin_count() not implemented.\n");
   return COLVARS_NOT_IMPLEMENTED;
@@ -646,7 +646,7 @@ std::string const colvarbias_ti::get_state_params() const
 }
 
 
-int colvarbias_ti::set_state_params(std::string const &state_conf)
+int colvarbias_ti::set_state_params(std::string const & /* state_conf */)
 {
   return COLVARS_OK;
 }

--- a/src/colvarbias_alb.cpp
+++ b/src/colvarbias_alb.cpp
@@ -405,8 +405,8 @@ cvm::real colvarbias_alb::restraint_potential(cvm::real k,
 
 
 colvarvalue colvarbias_alb::restraint_force(cvm::real k,
-                                            colvar const *x,
-                                            colvarvalue const &xcenter) const
+                                            colvar const * /* x */,
+                                            colvarvalue const & /* xcenter */) const
 {
   return k;
 }

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -915,7 +915,7 @@ void colvarbias_meta::project_hills(colvarbias_meta::hill_iter  h_first,
 
 void colvarbias_meta::recount_hills_off_grid(colvarbias_meta::hill_iter  h_first,
                                              colvarbias_meta::hill_iter  h_last,
-                                             colvar_grid_scalar         *he)
+                                             colvar_grid_scalar         * /* he */)
 {
   hills_off_grid.clear();
 

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -174,7 +174,7 @@ int colvarbias_restraint_k::change_configuration(std::string const &conf)
 
 
 
-colvarbias_restraint_moving::colvarbias_restraint_moving(char const *key)
+colvarbias_restraint_moving::colvarbias_restraint_moving(char const * /* key */)
 {
   target_nstages = 0;
   target_nsteps = 0L;

--- a/src/colvarbias_restraint.h
+++ b/src/colvarbias_restraint.h
@@ -26,10 +26,10 @@ public:
   virtual int update();
 
   /// Load new configuration - force constant and/or centers only
-  virtual int change_configuration(std::string const &conf) { return COLVARS_NOT_IMPLEMENTED; }
+  virtual int change_configuration(std::string const & /* conf */) { return COLVARS_NOT_IMPLEMENTED; }
 
   /// Calculate change in energy from using alternate configuration
-  virtual cvm::real energy_difference(std::string const &conf) { return 0.0; }
+  virtual cvm::real energy_difference(std::string const & /* conf */) { return 0.0; }
 
   virtual std::string const get_state_params() const;
   virtual int set_state_params(std::string const &conf);
@@ -107,7 +107,7 @@ public:
   // Note: despite the diamond inheritance, most of this function gets only executed once
   virtual int init(std::string const &conf);
   virtual int update() { return COLVARS_OK; }
-  virtual int change_configuration(std::string const &conf) { return COLVARS_NOT_IMPLEMENTED; }
+  virtual int change_configuration(std::string const & /* conf */) { return COLVARS_NOT_IMPLEMENTED; }
 
   virtual std::string const get_state_params() const;
   virtual int set_state_params(std::string const &conf);
@@ -149,7 +149,7 @@ public:
   colvarbias_restraint_centers_moving(char const *key);
   virtual int init(std::string const &conf);
   virtual int update();
-  virtual int change_configuration(std::string const &conf) { return COLVARS_NOT_IMPLEMENTED; }
+  virtual int change_configuration(std::string const & /* conf */) { return COLVARS_NOT_IMPLEMENTED; }
 
   virtual std::string const get_state_params() const;
   virtual int set_state_params(std::string const &conf);
@@ -188,7 +188,7 @@ public:
   colvarbias_restraint_k_moving(char const *key);
   virtual int init(std::string const &conf);
   virtual int update();
-  virtual int change_configuration(std::string const &conf) { return COLVARS_NOT_IMPLEMENTED; }
+  virtual int change_configuration(std::string const & /* conf */) { return COLVARS_NOT_IMPLEMENTED; }
 
   virtual std::string const get_state_params() const;
   virtual int set_state_params(std::string const &conf);

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -537,7 +537,7 @@ colvarvalue colvar::cvc::dist2_rgrad(colvarvalue const &x1,
 }
 
 
-void colvar::cvc::wrap(colvarvalue &x_unwrapped) const
+void colvar::cvc::wrap(colvarvalue & /* x_unwrapped */) const
 {
   return;
 }

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1395,13 +1395,13 @@ class colvar::componentDisabled
   : public colvar::cvc
 {
 public:
-    componentDisabled(std::string const &conf) {
+    componentDisabled(std::string const & /* conf */) {
         cvm::error("Error: this component is not enabled in the current build; please see https://colvars.github.io/README-c++11.html");
     }
     virtual ~componentDisabled() {}
     virtual void calc_value() {}
     virtual void calc_gradients() {}
-    virtual void apply_force(colvarvalue const &force) {}
+    virtual void apply_force(colvarvalue const & /* force */) {}
 };
 
 

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -219,7 +219,7 @@ public:
   /// Implements possible actions to be carried out
   /// when a given feature is enabled
   /// Base function does nothing, can be overloaded
-  virtual void do_feature_side_effects(int id) {}
+  virtual void do_feature_side_effects(int /* id */) {}
 
   // NOTE that all feature enums should start with f_*_active
   enum features_biases {

--- a/src/colvargrid.h
+++ b/src/colvargrid.h
@@ -209,7 +209,8 @@ public:
   /// \brief "Almost copy-constructor": only copies configuration
   /// parameters from another grid, but doesn't reallocate stuff;
   /// setup() must be called after that;
-  colvar_grid(colvar_grid<T> const &g) : nd(g.nd),
+  colvar_grid(colvar_grid<T> const &g) : colvarparse(),
+					 nd(g.nd),
                                          nx(g.nx),
                                          mult(g.mult),
                                          data(),

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -156,7 +156,7 @@ template<>
 int colvarparse::_get_keyval_scalar_value_(std::string const &key_str,
                                            std::string const &data,
                                            bool &value,
-                                           bool const &def_value)
+                                           bool const & /* def_value */)
 {
   if ( (data == std::string("on")) ||
        (data == std::string("yes")) ||
@@ -176,8 +176,8 @@ int colvarparse::_get_keyval_scalar_value_(std::string const &key_str,
 
 template<typename TYPE>
 int colvarparse::_get_keyval_scalar_novalue_(std::string const &key_str,
-                                             TYPE &value,
-                                             Parse_Mode const &parse_mode)
+                                             TYPE & /* value */,
+                                             Parse_Mode const & /* parse_mode */)
 {
   return cvm::error("Error: improper or missing value "
                     "for \""+key_str+"\".\n", INPUT_ERROR);

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -532,8 +532,7 @@ int colvarproxy_script::run_force_callback()
 }
 
 
-int colvarproxy_script::run_colvar_callback(
-					    std::string const & /* name */,
+int colvarproxy_script::run_colvar_callback(std::string const & /* name */,
 					    std::vector<const colvarvalue *> const & /* cvcs */,
 					    colvarvalue & /* value */)
 {
@@ -541,8 +540,7 @@ int colvarproxy_script::run_colvar_callback(
 }
 
 
-int colvarproxy_script::run_colvar_gradient_callback(
-						     std::string const & /* name */,
+int colvarproxy_script::run_colvar_gradient_callback(std::string const & /* name */,
 						     std::vector<const colvarvalue *> const & /* cvcs */,
 						     std::vector<cvm::matrix2d<cvm::real> > & /* gradient */)
 {

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -41,7 +41,7 @@ colvarproxy_system::colvarproxy_system()
 colvarproxy_system::~colvarproxy_system() {}
 
 
-void colvarproxy_system::add_energy(cvm::real energy) {}
+void colvarproxy_system::add_energy(cvm::real /* energy */) {}
 
 
 void colvarproxy_system::request_total_force(bool yesno)
@@ -173,9 +173,9 @@ int colvarproxy_atoms::add_atom_slot(int atom_id)
 }
 
 
-int colvarproxy_atoms::init_atom(cvm::residue_id const &residue,
-                                 std::string const     &atom_name,
-                                 std::string const     &segment_id)
+int colvarproxy_atoms::init_atom(cvm::residue_id const & /* residue */,
+                                 std::string const     & /* atom_name */,
+                                 std::string const     & /* segment_id */)
 {
   cvm::error("Error: initializing an atom by name and residue number is currently not supported.\n",
              COLVARS_NOT_IMPLEMENTED);
@@ -204,9 +204,9 @@ void colvarproxy_atoms::clear_atom(int index)
 }
 
 
-int colvarproxy_atoms::load_atoms(char const *filename,
-                                  cvm::atom_group &atoms,
-                                  std::string const &pdb_field,
+int colvarproxy_atoms::load_atoms(char const * /* filename */,
+                                  cvm::atom_group & /* atoms */,
+                                  std::string const & /* pdb_field */,
                                   double)
 {
   return cvm::error("Error: loading atom identifiers from a file "
@@ -215,10 +215,10 @@ int colvarproxy_atoms::load_atoms(char const *filename,
 }
 
 
-int colvarproxy_atoms::load_coords(char const *filename,
-                                   std::vector<cvm::atom_pos> &pos,
-                                   std::vector<int> const &sorted_ids,
-                                   std::string const &pdb_field,
+int colvarproxy_atoms::load_coords(char const * /* filename */,
+                                   std::vector<cvm::atom_pos> & /* pos */,
+                                   std::vector<int> const & /* sorted_ids */,
+                                   std::string const & /* pdb_field */,
                                    double)
 {
   return cvm::error("Error: loading atomic coordinates from a file "
@@ -269,7 +269,7 @@ int colvarproxy_atom_groups::scalable_group_coms()
 }
 
 
-int colvarproxy_atom_groups::init_atom_group(std::vector<int> const &atoms_ids)
+int colvarproxy_atom_groups::init_atom_group(std::vector<int> const & /* atoms_ids */)
 {
   cvm::error("Error: initializing a group outside of the Colvars module "
              "is currently not supported.\n",
@@ -483,17 +483,17 @@ int colvarproxy_replicas::replica_num()
 void colvarproxy_replicas::replica_comm_barrier() {}
 
 
-int colvarproxy_replicas::replica_comm_recv(char* msg_data,
-                                            int buf_len,
-                                            int src_rep)
+int colvarproxy_replicas::replica_comm_recv(char* /* msg_data */,
+                                            int /* buf_len */,
+                                            int /* src_rep */)
 {
   return COLVARS_NOT_IMPLEMENTED;
 }
 
 
-int colvarproxy_replicas::replica_comm_send(char* msg_data,
-                                            int msg_len,
-                                            int dest_rep)
+int colvarproxy_replicas::replica_comm_send(char* /* msg_data */,
+                                            int /* msg_len */,
+                                            int /* dest_rep */)
 {
   return COLVARS_NOT_IMPLEMENTED;
 }
@@ -518,7 +518,7 @@ char const *colvarproxy_script::script_obj_to_str(unsigned char *obj)
 }
 
 
-std::vector<std::string> colvarproxy_script::script_obj_to_str_vector(unsigned char *obj)
+std::vector<std::string> colvarproxy_script::script_obj_to_str_vector(unsigned char * /* obj */)
 {
   cvm::error("Error: trying to print a script object without a scripting "
              "language interface.\n", BUG_ERROR);
@@ -533,18 +533,18 @@ int colvarproxy_script::run_force_callback()
 
 
 int colvarproxy_script::run_colvar_callback(
-      std::string const &name,
-      std::vector<const colvarvalue *> const &cvcs,
-      colvarvalue &value)
+					    std::string const & /* name */,
+					    std::vector<const colvarvalue *> const & /* cvcs */,
+					    colvarvalue & /* value */)
 {
   return COLVARS_NOT_IMPLEMENTED;
 }
 
 
 int colvarproxy_script::run_colvar_gradient_callback(
-      std::string const &name,
-      std::vector<const colvarvalue *> const &cvcs,
-      std::vector<cvm::matrix2d<cvm::real> > &gradient)
+						     std::string const & /* name */,
+						     std::vector<const colvarvalue *> const & /* cvcs */,
+						     std::vector<cvm::matrix2d<cvm::real> > & /* gradient */)
 {
   return COLVARS_NOT_IMPLEMENTED;
 }
@@ -569,7 +569,7 @@ void colvarproxy_tcl::init_tcl_pointers()
 }
 
 
-char const *colvarproxy_tcl::tcl_obj_to_str(unsigned char *obj)
+char const *colvarproxy_tcl::tcl_obj_to_str(unsigned char * /* obj */)
 {
 #if defined(COLVARS_TCL)
   return Tcl_GetString(reinterpret_cast<Tcl_Obj *>(obj));
@@ -599,9 +599,9 @@ int colvarproxy_tcl::tcl_run_force_callback()
 
 
 int colvarproxy_tcl::tcl_run_colvar_callback(
-                         std::string const &name,
-                         std::vector<const colvarvalue *> const &cvc_values,
-                         colvarvalue &value)
+					     std::string const & /* name */,
+					     std::vector<const colvarvalue *> const & /* cvc_values */,
+					     colvarvalue & /* value */)
 {
 #if defined(COLVARS_TCL)
 
@@ -636,9 +636,9 @@ int colvarproxy_tcl::tcl_run_colvar_callback(
 
 
 int colvarproxy_tcl::tcl_run_colvar_gradient_callback(
-                         std::string const &name,
-                         std::vector<const colvarvalue *> const &cvc_values,
-                         std::vector<cvm::matrix2d<cvm::real> > &gradient)
+						      std::string const & /* name */,
+						      std::vector<const colvarvalue *> const & /* cvc_values */,
+						      std::vector<cvm::matrix2d<cvm::real> > & /* gradient */)
 {
 #if defined(COLVARS_TCL)
 
@@ -776,7 +776,7 @@ int colvarproxy_io::close_output_stream(std::string const &output_name)
 }
 
 
-int colvarproxy_io::backup_file(char const *filename)
+int colvarproxy_io::backup_file(char const * /* filename */)
 {
   // TODO implement this using rename_file()
   return COLVARS_NOT_IMPLEMENTED;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -212,7 +212,7 @@ public:
   }
 
   /// Read the current velocity of the given atom
-  inline cvm::rvector get_atom_velocity(int index)
+  inline cvm::rvector get_atom_velocity(int /* index */)
   {
     cvm::error("Error: reading the current velocity of an atom "
                "is not yet implemented.\n",
@@ -355,7 +355,7 @@ public:
   }
 
   /// Read the current velocity of the given atom group
-  inline cvm::rvector get_atom_group_velocity(int index)
+  inline cvm::rvector get_atom_group_velocity(int /* index */)
   {
     cvm::error("Error: reading the current velocity of an atom group is not yet implemented.\n",
                COLVARS_NOT_IMPLEMENTED);

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -191,7 +191,7 @@ inline static colvarbias *colvarbias_obj(void *pobj)
 
 #ifdef COLVARSCRIPT_CPP
 #define CVSCRIPT_COMM_FN(COMM,N_ARGS_MIN,N_ARGS_MAX,ARGS,FN_BODY)       \
-  extern "C" int CVSCRIPT_COMM_FNAME(COMM)(void *pobj,                  \
+  extern "C" int CVSCRIPT_COMM_FNAME(COMM)(void * /* pobj */,		\
                                            int objc,                    \
                                            unsigned char *const objv[]) \
   {                                                                     \

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -191,7 +191,7 @@ inline static colvarbias *colvarbias_obj(void *pobj)
 
 #ifdef COLVARSCRIPT_CPP
 #define CVSCRIPT_COMM_FN(COMM,N_ARGS_MIN,N_ARGS_MAX,ARGS,FN_BODY)       \
-  extern "C" int CVSCRIPT_COMM_FNAME(COMM)(void * /* pobj */,		\
+  extern "C" int CVSCRIPT_COMM_FNAME(COMM)(void *pobj,                  \
                                            int objc,                    \
                                            unsigned char *const objv[]) \
   {                                                                     \


### PR DESCRIPTION
This change comments out parameter names where they are not used. That will reduce compiler warnings when compiling with `-Wall -Wextra` and signals to other developers that those arguments are currently not used. It cannot be applied to arguments with default values, so a few of those warnings remain. Also, I have not looked into lepton. This was tested with the standalone compilation test version.