### PR TITLE
Document compilation details that affect features

### DIFF
--- a/doc/colvars-refman-lammps.tex
+++ b/doc/colvars-refman-lammps.tex
@@ -31,9 +31,3 @@
 
 
 \input{colvars-refman.tex}
-
-
-% Emacs
-% Local Variables:
-% TeX-PDF-mode: t
-% End:

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -5706,3 +5706,22 @@ please be aware that \emph{several of these tutorials are not actively maintaine
 \cvnamdonly{\cvurl{https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html}}
 \cvlammpsonly{\cvurl{https://colvars.github.io/colvars-refman-lammps/colvars-refman-lammps.html}}
 \cvvmdonly{\cvurl{https://colvars.github.io/colvars-refman-vmd/colvars-refman-vmd.html}}
+
+
+\cvrefmanonly{
+
+\cvsec{Compilation notes}{sec:compilation_notes}
+
+The Colvars module is typically built using the recipes of each supported software package: for this reason, no installation instructions are needed, and the vast majority of the features described in this manual are supported in the most common builds of each package.
+This section lists the few cases where the choice of compilation settings affects features in the Colvars module.
+
+\begin{itemize}
+\item Scripting commands using the Tcl language (\cvurl{https://www.tcl.tk}) are supported in VMD and NAMD.  All precompiled builds of each code include Tcl, and it is highly recommended to enable Tcl support in any custom build, using precompiled Tcl libraries from the UIUC website.
+\item The Lepton library (\cvurl{https://simtk.org/projects/lepton}) used to implement the \texttt{customFunction} feature is currently included only in NAMD (always on) and in LAMMPS (on by default).
+\item Some features require compilation using the C++11 language standard.
+  Although it is becoming commonplace, this standard is not yet available on all scientific computing systems.
+  Deailed information can be found at:\\
+  \cvurl{https://colvars.github.io/README-c++11.html}
+\end{itemize}
+
+}

--- a/doc/colvars-refman-namd.tex
+++ b/doc/colvars-refman-namd.tex
@@ -31,9 +31,3 @@
 
 
 \input{colvars-refman.tex}
-
-
-% Emacs
-% Local Variables:
-% TeX-PDF-mode: t
-% End:

--- a/doc/colvars-refman-vmd.tex
+++ b/doc/colvars-refman-vmd.tex
@@ -31,9 +31,3 @@
 
 
 \input{colvars-refman.tex}
-
-
-% Emacs
-% Local Variables:
-% TeX-PDF-mode: t
-% End:

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -157,8 +157,3 @@
 
 
 \end{document}
-
-% Emacs
-% Local Variables:
-% TeX-PDF-mode: t
-% End:

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -662,7 +662,7 @@ int colvar::init_output_flags(std::string const &conf)
     bool temp;
     if (get_keyval(conf, "outputSystemForce", temp, false, colvarparse::parse_silent)) {
       cvm::error("Option outputSystemForce is deprecated: only outputTotalForce is supported instead.\n"
-                 "The two are NOT identical: see http://colvars.github.io/totalforce.html.\n", INPUT_ERROR);
+                 "The two are NOT identical: see https://colvars.github.io/totalforce.html.\n", INPUT_ERROR);
       return INPUT_ERROR;
     }
   }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -48,7 +48,7 @@ colvarmodule::colvarmodule(colvarproxy *proxy_in)
   cvm::log("Initializing the collective variables module, version "+
            cvm::to_str(COLVARS_VERSION)+".\n");
   cvm::log("Please cite Fiorin et al, Mol Phys 2013:\n "
-           "http://dx.doi.org/10.1080/00268976.2013.813594\n"
+           "https://dx.doi.org/10.1080/00268976.2013.813594\n"
            "in any publication based on this calculation.\n");
 
   if (proxy->smp_enabled() == COLVARS_OK) {

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -52,8 +52,16 @@ colvarmodule::colvarmodule(colvarproxy *proxy_in)
            "in any publication based on this calculation.\n");
 
   if (proxy->smp_enabled() == COLVARS_OK) {
-    cvm::log("SMP parallelism is available.\n");
+    cvm::log("SMP parallelism is enabled; if needed, use \"smp off\" to override this.\n");
   }
+
+#if (__cplusplus >= 201103L)
+  cvm::log("This version was built with the C++11 standard or higher.");
+#else
+  cvm::log("This version was built without the C++11 standard: some features are disabled.\n"
+    "Please see the following link for details:\n"
+    "https://colvars.github.io/README-c++11.html");
+#endif
 
   // set initial default values
 


### PR DESCRIPTION
Fixes #250.

Note that the message printing the C++11 standard used at build time is mostly useful in VMD, where C++11 is still rare, and LAMMPS, where it is becoming the new standard but isn't there yet.