### PR TITLE
Support different unit systems

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -168,6 +168,9 @@ If variables are modified, added or deleted interactively or by an external scri
 Starting the dashboard also enables trajectory animation using the left/right arrow keys within VMD's graphical window.
 Atomic coordinates can be modified using VMD's ``Mouse/Move'' functions, and the Colvars Module can then be updated by pressing F5 directly from the graphical window.
 
+A dropdown list allows for changing the current unit system if no variables are defined.
+If some variables are already defined, it is recommended to edit the configuration for all of
+them at once (eg. pressing Ctrl-a, then e), checking that all quantities are expressed in the desired set of units, and adding the \texttt{units} keyword (\ref{sec:units}).
 
 \cvsubsec{Loading / Saving configuration files}{sec:dashboard_load_save}
 
@@ -218,6 +221,38 @@ It creates a graphical representation of the atomic gradients of the selected va
 Here, we document the syntax of the commands and parameters used to set up and use the Colvars module in \MDENGINE{}.
 One of these parameters is the configuration file or the configuration text for the module itself, whose syntax is described in \ref{sec:colvars_config_syntax} and in the following sections.
 
+\cvsubsec{Units in the Colvars module}{sec:units}
+
+The ``internal units'' of the Colvars module are the units in which values are expected to be in the configuration file, and in which collective variable values, energies, etc. are expressed in the output and colvars trajectory files. 
+Generally \textbf{the Colvars module uses internally the same units as its back-end MD engine, with the exception of VMD}, where different unit sets are supported to allow for easy setup, visualization and analysis of Colvars simulations performed with any simulation engine.
+
+Note that \textbf{angles} are expressed in degrees, and derived quantites such as force constants are based on degrees as well. 
+Atomic coordinates read from \textbf{XYZ files} (and PDB files where applicable) are expected to be expressed in \AA{}ngstr\"om, no matter what unit system is in use by the back-end or the Colvars Module.
+
+To avoid errors due to reading configuration files written in a different unit system, it can be specified within the input:
+
+\begin{itemize}
+\item %
+\key
+  {units}{%
+  global}{%
+  Unit system to be used}{%
+  string}{%
+  A string defining the units to be used internally by Colvars.
+  \cvlammpsonly{Allowed values are the following LAMMPS unit styles:
+  \textit{real} (\AA, kcal/mol), \textit{metal} (\AA, eV), and \textit{electron} (Bohr, Hartree).
+  However only the unit system currently in use by LAMMPS is accepted:
+  other values will trigger an error.}
+  \cvnamdonly{In NAMD the only allowed value is NAMD's native units: \textit{real} (\AA, kcal/mol).}
+  \cvvmdonly{Allowed values are:  \textit{real} (\AA, kcal/mol), \textit{gromacs} (nm, kJ/mol), \textit{metal} (\AA, eV), and \textit{electron} (Bohr, Hartree).
+  In VMD, the default system of units for Colvars is VMD's native units: \textit{real} (\AA, kcal/mol).
+  However, the \texttt{units} keyword will switch to a different unit system than the
+  current one if no colvars were defined before reading the current configuration.
+  If colvars are already defined, \texttt{units} will refuse changing the unit system to avoid making the definition of those variables erroneous in the new system of units.
+  If needed this precaution can be overridden using the \texttt{cv units} scripting command
+  (\ref{sec:cv_command_general}).}
+  }
+\end{itemize}
 
 \cvnamdonly{
 \cvsubsec{NAMD parameters}{sec:colvars_mdengine_params}
@@ -389,7 +424,9 @@ The following sections explain the syntax of the various sub-commands of \texttt
 \item \texttt{config} \emph{$<$string$>$}: read configuration from the given string; both \texttt{config} and \texttt{configfile} subcommands may be invoked multiple times;
 \cvvmdonly{see \ref{sec:colvars_config_syntax} for the configuration syntax;}
 \item \texttt{reset}: delete all internal configuration and atom selections of the Colvars module;
+\item \texttt{units} [\emph{$<$style$>$}]: switch internal Colvars units to \emph{style} (see \ref{sec:units}); without argument, return the current style, or an empty string if it is the default.
 \item \texttt{version}: return the version of the Colvars module (see \ref{sec:colvars_config_changes} for any changes to older keywords).
+
 \end{itemize}
 
 \cvsubsubsec{Input and output commands}{sec:cv_command_io}

--- a/gromacs/src/colvarproxy_gromacs.cpp
+++ b/gromacs/src/colvarproxy_gromacs.cpp
@@ -115,6 +115,8 @@ void colvarproxy_gromacs::init(t_inputrec *gmx_inp, gmx_int64_t step) {
   force_script_defined = false;
   have_scripts = false;
 
+  angstrom_value = 0.1;
+
   // GROMACS random number generation.
   // Seed with the mdp parameter ld_seed, the Langevin dynamics seed.
   rando = gmx_rng_init(gmx_inp->ld_seed);

--- a/gromacs/src/colvarproxy_gromacs.cpp
+++ b/gromacs/src/colvarproxy_gromacs.cpp
@@ -210,7 +210,6 @@ void colvarproxy_gromacs::set_temper(double temper) {
 
 // GROMACS uses nanometers and kJ/mol internally
 cvm::real colvarproxy_gromacs::backend_angstrom_value() { return 0.1; }
-//cvm::real colvarproxy_gromacs::backend_kcal_mol_value() { return 4.184; }
 
 // From Gnu units
 // $ units -ts 'k' 'kJ/mol/K/avogadro'
@@ -313,7 +312,7 @@ int colvarproxy_gromacs::load_coords (char const *filename,
   return COLVARS_NOT_IMPLEMENTED;
 }
 
-int colvarproxy_gromacs::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+int colvarproxy_gromacs::set_unit_system(std::string const &units_in, bool /*check_only*/)
 {
   if (units_in != "gromacs") {
     cvm::error("Specified unit system \"" + units_in + "\" is unsupported in Gromacs. Supported units are \"gromacs\" (nm, kJ/mol).\n");

--- a/gromacs/src/colvarproxy_gromacs.cpp
+++ b/gromacs/src/colvarproxy_gromacs.cpp
@@ -206,13 +206,14 @@ void colvarproxy_gromacs::set_temper(double temper) {
   thermostat_temperature = temper;
 }
 
-// GROMACS uses nanometers.
-cvm::real colvarproxy_gromacs::unit_angstrom() { return 0.1; }
+// GROMACS uses nanometers and kJ/mol internally
+cvm::real colvarproxy_gromacs::backend_angstrom_value() { return 0.1; }
+//cvm::real colvarproxy_gromacs::backend_kcal_mol_value() { return 4.184; }
 
 // From Gnu units
 // $ units -ts 'k' 'kJ/mol/K/avogadro'
-// 0.0083144621
-cvm::real colvarproxy_gromacs::boltzmann() { return 0.0083144621; }
+// 0.0083144599 with v2.16 (older value 0.0083144621)
+cvm::real colvarproxy_gromacs::boltzmann() { return 0.0083144599; }
 
 // Temperature of the simulation (K)
 cvm::real colvarproxy_gromacs::temperature() {
@@ -308,6 +309,15 @@ int colvarproxy_gromacs::load_coords (char const *filename,
   cvm::error("Selecting collective variable atoms "
 		   "from a PDB file is currently not supported.\n");
   return COLVARS_NOT_IMPLEMENTED;
+}
+
+int colvarproxy_gromacs::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+{
+  if (units_in != "gromacs") {
+    cvm::error("Specified unit system \"" + units_in + "\" is unsupported in Gromacs. Supported units are \"gromacs\" (nm, kJ/mol).\n");
+    return COLVARS_ERROR;
+  }
+  return COLVARS_OK;
 }
 
 int colvarproxy_gromacs::backup_file (char const *filename)

--- a/gromacs/src/colvarproxy_gromacs.h
+++ b/gromacs/src/colvarproxy_gromacs.h
@@ -51,7 +51,8 @@ public:
   void add_energy (cvm::real energy);
 
   // **************** SYSTEM-WIDE PHYSICAL QUANTITIES ****************
-  cvm::real unit_angstrom();
+  cvm::real backend_angstrom_value();
+//  cvm::real backend_kcal_mol_value();
   cvm::real boltzmann();
   cvm::real temperature();
   cvm::real dt();
@@ -81,6 +82,8 @@ public:
   void fatal_error (std::string const &message);
   /// Print a message to the main log and exit normally
   void exit (std::string const &message);
+  /// Request to set the units used internally by Colvars
+  int set_unit_system(std::string const &units_in, bool colvars_defined);
   int backup_file (char const *filename);
   /// Read atom identifiers from a file \param filename name of
   /// the file (usually a PDB) \param atoms array to which atoms read

--- a/gromacs/src/colvarproxy_gromacs.h
+++ b/gromacs/src/colvarproxy_gromacs.h
@@ -52,7 +52,6 @@ public:
 
   // **************** SYSTEM-WIDE PHYSICAL QUANTITIES ****************
   cvm::real backend_angstrom_value();
-//  cvm::real backend_kcal_mol_value();
   cvm::real boltzmann();
   cvm::real temperature();
   cvm::real dt();
@@ -83,7 +82,7 @@ public:
   /// Print a message to the main log and exit normally
   void exit (std::string const &message);
   /// Request to set the units used internally by Colvars
-  int set_unit_system(std::string const &units_in, bool colvars_defined);
+  int set_unit_system(std::string const &units_in, bool check_only);
   int backup_file (char const *filename);
   /// Read atom identifiers from a file \param filename name of
   /// the file (usually a PDB) \param atoms array to which atoms read

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -131,6 +131,9 @@ void colvarproxy_lammps::init(const char *conf_file)
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
   my_angstrom  = _lmp->force->angstrom;
+  // Front-end unit is the same as back-end
+  angstrom_value = my_angstrom;
+
   // my_kcal_mol  = _lmp->force->qe2f / 23.060549;
   // force->qe2f is 1eV expressed in LAMMPS' energy unit (1 if unit is eV, 23 if kcal/mol)
   my_boltzmann = _lmp->force->boltz;

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -330,7 +330,7 @@ void colvarproxy_lammps::fatal_error(std::string const &message)
 }
 
 
-int colvarproxy_lammps::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+int colvarproxy_lammps::set_unit_system(std::string const &units_in, bool /*check_only*/)
 {
   std::string lmp_units = _lmp->update->unit_style;
   if (units_in != lmp_units) {

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -131,6 +131,8 @@ void colvarproxy_lammps::init(const char *conf_file)
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
   my_angstrom  = _lmp->force->angstrom;
+  // my_kcal_mol  = _lmp->force->qe2f / 23.060549;
+  // force->qe2f is 1eV expressed in LAMMPS' energy unit (1 if unit is eV, 23 if kcal/mol)
   my_boltzmann = _lmp->force->boltz;
   my_timestep  = _lmp->update->dt * _lmp->force->femtosecond;
 
@@ -322,6 +324,17 @@ void colvarproxy_lammps::fatal_error(std::string const &message)
   log(message);
   _lmp->error->one(FLERR,
                    "Fatal error in the collective variables module.\n");
+}
+
+
+int colvarproxy_lammps::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+{
+  std::string lmp_units = _lmp->update->unit_style;
+  if (units_in != lmp_units) {
+    cvm::error("Error: Specified unit system for Colvars \"" + units_in + "\" is incompatible with LAMMPS internal units (" + lmp_units + ").\n");
+    return COLVARS_ERROR;
+  }
+  return COLVARS_OK;
 }
 
 

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.h
@@ -92,7 +92,7 @@ class colvarproxy_lammps : public colvarproxy {
   void add_config_string(const std::string &config);
 
   // Request to set the units used internally by Colvars
-  int set_unit_system(std::string const &units_in, bool colvars_defined);
+  int set_unit_system(std::string const &units_in, bool check_only);
 
   inline cvm::real backend_angstrom_value() { return my_angstrom; };
 

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.h
@@ -91,7 +91,11 @@ class colvarproxy_lammps : public colvarproxy {
   // read additional config from string
   void add_config_string(const std::string &config);
 
-  inline cvm::real unit_angstrom() { return my_angstrom; };
+  // Request to set the units used internally by Colvars
+  int set_unit_system(std::string const &units_in, bool colvars_defined);
+
+  inline cvm::real backend_angstrom_value() { return my_angstrom; };
+
   inline cvm::real boltzmann() { return my_boltzmann; };
   inline cvm::real temperature() { return t_target; };
   inline cvm::real dt() { return my_timestep; }; // return _lmp->update->dt * _lmp->force->femtosecond; };

--- a/lammps/tests/interface/in.01k
+++ b/lammps/tests/interface/in.01k
@@ -1,0 +1,7 @@
+# LAMMPS test 01j: unwrap forced off
+# Validated: 27 November 2019-IBPC
+include inc.minimal_units
+fix f1 all colvars minimal_units.cfg unwrap no output 01j
+
+run 0 post no
+

--- a/lammps/tests/interface/inc.minimal_units
+++ b/lammps/tests/interface/inc.minimal_units
@@ -1,0 +1,20 @@
+# minimal system config: two groups of two atoms
+units electron
+atom_style atomic
+atom_modify map array # XXX this should not be needed
+
+pair_style lj/cut 5.0
+read_data data.minimal
+
+group g1 id 1 2
+group g2 id 3 4
+
+variable com1z equal xcm(g1,z)
+variable com2z equal xcm(g2,z)
+variable fcm1z equal fcm(g1,z)
+variable fcm2z equal fcm(g2,z)
+variable cveng equal f_f1
+
+thermo_style custom step pe v_com1z v_com2z v_fcm1z v_fcm2z v_cveng
+thermo 1
+

--- a/lammps/tests/interface/minimal_units.cfg
+++ b/lammps/tests/interface/minimal_units.cfg
@@ -1,0 +1,15 @@
+units real
+
+colvar {
+  name one
+
+  distance {
+    group2 {
+      atomNumbers 1 2
+    }
+    group1 {
+      atomNumbers 3 4
+    }
+  }
+}
+

--- a/lammps/tests/interface/ref/log.01k
+++ b/lammps/tests/interface/ref/log.01k
@@ -1,0 +1,60 @@
+# Validated: 26 May 2013-ICMS
+include inc.minimal_units
+# minimal system config: two groups of two atoms
+units electron
+atom_style atomic
+atom_modify map array # XXX this should not be needed
+
+pair_style lj/cut 5.0
+read_data data.minimal
+Reading data file ...
+  orthogonal box = (-5 -5 -10) to (5 5 10)
+  reading atoms ...
+  4 atoms
+  reading velocities ...
+  4 velocities
+
+group g1 id 1 2
+2 atoms in group g1
+group g2 id 3 4
+2 atoms in group g2
+
+variable com1z equal xcm(g1,z)
+variable com2z equal xcm(g2,z)
+variable fcm1z equal fcm(g1,z)
+variable fcm2z equal fcm(g2,z)
+variable cveng equal f_f1
+
+thermo_style custom step pe v_com1z v_com2z v_fcm1z v_fcm2z v_cveng
+thermo 1
+
+fix f1 all colvars minimal_units.cfg unwrap no output 01j
+
+run 0 post no
+Neighbor list info ...
+  update every 1 steps, delay 10 steps, check yes
+  max neighbors/atom: 2000, page size: 100000
+  master list distance cutoff = 7
+  ghost atom cutoff = 7
+  binsize = 3.5, bins = 3 3 6
+  1 neighbor lists, perpetual/occasional/extra = 1 0 0
+  (1) pair lj/cut, perpetual
+      attributes: half, newton on
+      pair build: half/bin/atomonly/newton
+      stencil: half/bin/3d/newton
+      bin: standard
+Setting up Verlet run ...
+  Unit style    : electron
+  Current step  : 0
+  Time step     : 0.001
+colvars: Creating proxy instance
+colvars: ----------------------------------------------------------------------
+colvars: Please cite Fiorin et al, Mol Phys 2013:
+colvars:  http://dx.doi.org/10.1080/00268976.2013.813594
+colvars: in any publication based on this calculation.
+colvars: ----------------------------------------------------------------------
+colvars: Reading new configuration from file "minimal_units.cfg":
+colvars: # units = "real"
+ERROR on proc 0: Fatal error in the collective variables module.
+ (../colvarproxy_lammps.cpp)
+Last command: run 0 post no

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1153,7 +1153,7 @@ int colvarproxy_namd::update_group_properties(int index)
 }
 
 
-int colvarproxy_namd::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+int colvarproxy_namd::set_unit_system(std::string const &units_in, bool /*check_only*/)
 {
   if (units_in != "real") {
     cvm::error("Error: Specified unit system \"" + units_in + "\" is unsupported in NAMD. Supported units are \"real\" (A, kcal/mol).\n");

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1151,6 +1151,16 @@ int colvarproxy_namd::update_group_properties(int index)
 }
 
 
+int colvarproxy_namd::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+{
+  if (units_in != "real") {
+    cvm::error("Error: Specified unit system \"" + units_in + "\" is unsupported in NAMD. Supported units are \"real\" (A, kcal/mol).\n");
+    return COLVARS_ERROR;
+  }
+  return COLVARS_OK;
+}
+
+
 #if CMK_SMP && USE_CKLOOP // SMP only
 
 void calc_colvars_items_smp(int first, int last, void *result, int paramNum, void *param)

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -43,6 +43,8 @@ colvarproxy_namd::colvarproxy_namd()
   total_force_requested = false;
   requestTotalForce(total_force_requested);
 
+  angstrom_value = 1.;
+
   // initialize pointers to NAMD configuration data
   simparams = Node::Object()->simParameters;
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -75,7 +75,7 @@ public:
   void log(std::string const &message);
   void error(std::string const &message);
   void fatal_error(std::string const &message);
-  int set_unit_system(std::string const &units_in, bool colvars_defined);
+  int set_unit_system(std::string const &units_in, bool check_only);
   void exit(std::string const &message);
   void add_energy(cvm::real energy);
   void request_total_force(bool yesno);
@@ -97,11 +97,6 @@ public:
   {
     return 1.0;
   }
-
-  // cvm::real backend_kcal_mol_value()
-  // {
-  //   return 1.0;
-  // }
 
   cvm::real boltzmann()
   {

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -75,6 +75,7 @@ public:
   void log(std::string const &message);
   void error(std::string const &message);
   void fatal_error(std::string const &message);
+  int set_unit_system(std::string const &units_in, bool colvars_defined);
   void exit(std::string const &message);
   void add_energy(cvm::real energy);
   void request_total_force(bool yesno);
@@ -92,10 +93,15 @@ public:
                                    std::vector<const colvarvalue *> const &cvcs,
                                    std::vector<cvm::matrix2d<cvm::real> > &gradient);
 
-  cvm::real unit_angstrom()
+  cvm::real backend_angstrom_value()
   {
     return 1.0;
   }
+
+  // cvm::real backend_kcal_mol_value()
+  // {
+  //   return 1.0;
+  // }
 
   cvm::real boltzmann()
   {

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -119,12 +119,12 @@ colvar::coordnum::coordnum(std::string const &conf)
   }
 
   bool const b_isotropic = get_keyval(conf, "cutoff", r0,
-                                      cvm::real(4.0 * cvm::unit_angstrom()));
+                                      cvm::real(4.0 * cvm::angstrom_value()));
 
   if (get_keyval(conf, "cutoff3", r0_vec,
-                 cvm::rvector(4.0 * cvm::unit_angstrom(),
-                              4.0 * cvm::unit_angstrom(),
-                              4.0 * cvm::unit_angstrom()))) {
+                 cvm::rvector(4.0 * cvm::angstrom_value(),
+                              4.0 * cvm::angstrom_value(),
+                              4.0 * cvm::angstrom_value()))) {
     if (b_isotropic) {
       cvm::error("Error: cannot specify \"cutoff\" and \"cutoff3\" "
                  "at the same time.\n",
@@ -326,7 +326,7 @@ colvar::h_bond::h_bond(std::string const &conf)
   atom_groups[0]->add_atom(acceptor);
   atom_groups[0]->add_atom(donor);
 
-  get_keyval(conf, "cutoff",   r0, (3.3 * cvm::unit_angstrom()));
+  get_keyval(conf, "cutoff",   r0, (3.3 * cvm::angstrom_value()));
   get_keyval(conf, "expNumer", en, 6);
   get_keyval(conf, "expDenom", ed, 8);
 
@@ -408,7 +408,7 @@ colvar::selfcoordnum::selfcoordnum(std::string const &conf)
 
   group1 = parse_group(conf, "group1");
 
-  get_keyval(conf, "cutoff", r0, cvm::real(4.0 * cvm::unit_angstrom()));
+  get_keyval(conf, "cutoff", r0, cvm::real(4.0 * cvm::angstrom_value()));
   get_keyval(conf, "expNumer", en, 6);
   get_keyval(conf, "expDenom", ed, 12);
 
@@ -561,7 +561,7 @@ colvar::groupcoordnum::groupcoordnum(std::string const &conf)
   }
 
   bool const b_scale = get_keyval(conf, "cutoff", r0,
-                                  cvm::real(4.0 * cvm::unit_angstrom()));
+                                  cvm::real(4.0 * cvm::angstrom_value()));
 
   if (get_keyval(conf, "cutoff3", r0_vec,
                  cvm::rvector(4.0, 4.0, 4.0), parse_silent)) {

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -97,6 +97,8 @@ colvar::coordnum::coordnum(std::string const &conf)
   function_type = "coordnum";
   x.type(colvarvalue::type_scalar);
 
+  colvarproxy *proxy = cvm::main()->proxy;
+
   group1 = parse_group(conf, "group1");
   group2 = parse_group(conf, "group2");
 
@@ -119,12 +121,12 @@ colvar::coordnum::coordnum(std::string const &conf)
   }
 
   bool const b_isotropic = get_keyval(conf, "cutoff", r0,
-                                      cvm::real(4.0 * cvm::angstrom_value()));
+                                      cvm::real(4.0 * proxy->angstrom_value));
 
   if (get_keyval(conf, "cutoff3", r0_vec,
-                 cvm::rvector(4.0 * cvm::angstrom_value(),
-                              4.0 * cvm::angstrom_value(),
-                              4.0 * cvm::angstrom_value()))) {
+                 cvm::rvector(4.0 * proxy->angstrom_value,
+                              4.0 * proxy->angstrom_value,
+                              4.0 * proxy->angstrom_value))) {
     if (b_isotropic) {
       cvm::error("Error: cannot specify \"cutoff\" and \"cutoff3\" "
                  "at the same time.\n",
@@ -311,9 +313,11 @@ colvar::h_bond::h_bond(std::string const &conf)
   function_type = "h_bond";
   x.type(colvarvalue::type_scalar);
 
-  int a_num, d_num;
-  get_keyval(conf, "acceptor", a_num, -1);
-  get_keyval(conf, "donor",    d_num, -1);
+  colvarproxy *proxy = cvm::main()->proxy;
+
+  int a_num = -1, d_num = -1;
+  get_keyval(conf, "acceptor", a_num, a_num);
+  get_keyval(conf, "donor",    d_num, a_num);
 
   if ( (a_num == -1) || (d_num == -1) ) {
     cvm::error("Error: either acceptor or donor undefined.\n");
@@ -326,7 +330,7 @@ colvar::h_bond::h_bond(std::string const &conf)
   atom_groups[0]->add_atom(acceptor);
   atom_groups[0]->add_atom(donor);
 
-  get_keyval(conf, "cutoff",   r0, (3.3 * cvm::angstrom_value()));
+  get_keyval(conf, "cutoff",   r0, (3.3 * proxy->angstrom_value));
   get_keyval(conf, "expNumer", en, 6);
   get_keyval(conf, "expDenom", ed, 8);
 
@@ -408,7 +412,7 @@ colvar::selfcoordnum::selfcoordnum(std::string const &conf)
 
   group1 = parse_group(conf, "group1");
 
-  get_keyval(conf, "cutoff", r0, cvm::real(4.0 * cvm::angstrom_value()));
+  get_keyval(conf, "cutoff", r0, cvm::real(4.0 * proxy->angstrom_value));
   get_keyval(conf, "expNumer", en, 6);
   get_keyval(conf, "expDenom", ed, 12);
 
@@ -561,7 +565,7 @@ colvar::groupcoordnum::groupcoordnum(std::string const &conf)
   }
 
   bool const b_scale = get_keyval(conf, "cutoff", r0,
-                                  cvm::real(4.0 * cvm::angstrom_value()));
+                                  cvm::real(4.0 * proxy->angstrom_value));
 
   if (get_keyval(conf, "cutoff3", r0_vec,
                  cvm::rvector(4.0, 4.0, 4.0), parse_silent)) {

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -409,6 +409,7 @@ colvar::selfcoordnum::selfcoordnum(std::string const &conf)
 {
   function_type = "selfcoordnum";
   x.type(colvarvalue::type_scalar);
+  colvarproxy *proxy = cvm::main()->proxy;
 
   group1 = parse_group(conf, "group1");
 
@@ -557,6 +558,7 @@ colvar::groupcoordnum::groupcoordnum(std::string const &conf)
 {
   function_type = "groupcoordnum";
   x.type(colvarvalue::type_scalar);
+  colvarproxy *proxy = cvm::main()->proxy;
 
   // group1 and group2 are already initialized by distance()
   if (group1->b_dummy || group2->b_dummy) {

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -91,7 +91,7 @@ colvar::alpha_angles::alpha_angles(std::string const &conf)
   {
     cvm::real r0;
     size_t en, ed;
-    get_keyval(conf, "hBondCutoff",   r0, (3.3 * cvm::unit_angstrom()));
+    get_keyval(conf, "hBondCutoff",   r0, (3.3 * cvm::angstrom_value()));
     get_keyval(conf, "hBondExpNumer", en, 6);
     get_keyval(conf, "hBondExpDenom", ed, 8);
 

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -30,6 +30,8 @@ colvar::alpha_angles::alpha_angles(std::string const &conf)
   enable(f_cvc_explicit_gradient);
   x.type(colvarvalue::type_scalar);
 
+  colvarproxy *proxy = cvm::main()->proxy;
+
   std::string segment_id;
   get_keyval(conf, "psfSegID", segment_id, std::string("MAIN"));
 
@@ -91,7 +93,7 @@ colvar::alpha_angles::alpha_angles(std::string const &conf)
   {
     cvm::real r0;
     size_t en, ed;
-    get_keyval(conf, "hBondCutoff",   r0, (3.3 * cvm::angstrom_value()));
+    get_keyval(conf, "hBondCutoff",   r0, (3.3 * proxy->angstrom_value));
     get_keyval(conf, "hBondExpNumer", en, 6);
     get_keyval(conf, "hBondExpDenom", ed, 8);
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1837,7 +1837,7 @@ int cvm::load_coords_xyz(char const *filename,
   unsigned int natoms;
   char symbol[256];
   std::string line;
-  cvm::real x, y, z;
+  cvm::real x = 0.0, y = 0.0, z = 0.0;
 
   if ( ! (xyz_is >> natoms) ) {
     cvm::error("Error: cannot parse XYZ file "
@@ -1886,11 +1886,6 @@ int cvm::load_coords_xyz(char const *filename,
 
 
 // Wrappers to proxy functions: these may go in the future
-
-cvm::real cvm::angstrom_value()
-{
-  return proxy->angstrom_value;
-}
 
 
 cvm::real cvm::boltzmann()

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1866,17 +1866,17 @@ int cvm::load_coords_xyz(char const *filename,
       xyz_is >> symbol;
       xyz_is >> x >> y >> z;
       // XYZ files are assumed to be in Angstrom (as eg. VMD will)
-      (*pos_i)[0] = proxy->angstrom_to_internal_unit(x);
-      (*pos_i)[1] = proxy->angstrom_to_internal_unit(y);
-      (*pos_i)[2] = proxy->angstrom_to_internal_unit(z);
+      (*pos_i)[0] = proxy->angstrom_to_internal(x);
+      (*pos_i)[1] = proxy->angstrom_to_internal(y);
+      (*pos_i)[2] = proxy->angstrom_to_internal(z);
     }
   } else {          // Use all positions
     for ( ; pos_i != pos->end() ; pos_i++) {
       xyz_is >> symbol;
       xyz_is >> x >> y >> z;
-      (*pos_i)[0] = proxy->angstrom_to_internal_unit(x);
-      (*pos_i)[1] = proxy->angstrom_to_internal_unit(y);
-      (*pos_i)[2] = proxy->angstrom_to_internal_unit(z);
+      (*pos_i)[0] = proxy->angstrom_to_internal(x);
+      (*pos_i)[1] = proxy->angstrom_to_internal(y);
+      (*pos_i)[2] = proxy->angstrom_to_internal(z);
     }
   }
   return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -266,9 +266,10 @@ int colvarmodule::parse_global_params(std::string const &conf)
   {
     std::string units;
     if (parse->get_keyval(conf, "units", units)) {
-      int error = proxy->set_unit_system(units, (colvars.size() != 0));
-      if (error) {
-        return error;
+      units = colvarparse::to_lower_cppstr(units);
+      int error_code = proxy->set_unit_system(units, (colvars.size() != 0));
+      if (error_code != COLVARS_OK) {
+        return error_code;
       }
     }
   }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -268,6 +268,15 @@ int colvarmodule::parse_global_params(std::string const &conf)
   // TODO document and then echo this keyword
   parse->get_keyval(conf, "logLevel", log_level_, log_level_,
                     colvarparse::parse_silent);
+  {
+    std::string units;
+    if (parse->get_keyval(conf, "units", units)) {
+      int error = proxy->set_unit_system(units, (colvars.size() != 0));
+      if (error) {
+        return error;
+      }
+    }
+  }
 
   {
     std::string index_file_name;
@@ -1868,9 +1877,9 @@ int cvm::load_coords_xyz(char const *filename,
 
 // Wrappers to proxy functions: these may go in the future
 
-cvm::real cvm::unit_angstrom()
+cvm::real cvm::angstrom_value()
 {
-  return proxy->unit_angstrom();
+  return proxy->angstrom_value;
 }
 
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1841,6 +1841,7 @@ int cvm::load_coords_xyz(char const *filename,
   unsigned int natoms;
   char symbol[256];
   std::string line;
+  cvm::real x, y, z;
 
   if ( ! (xyz_is >> natoms) ) {
     cvm::error("Error: cannot parse XYZ file "
@@ -1862,12 +1863,19 @@ int cvm::load_coords_xyz(char const *filename,
         next++;
       }
       xyz_is >> symbol;
-      xyz_is >> (*pos_i)[0] >> (*pos_i)[1] >> (*pos_i)[2];
+      xyz_is >> x >> y >> z;
+      // XYZ files are assumed to be in Angstrom (as eg. VMD will)
+      (*pos_i)[0] = proxy->angstrom_to_internal_unit(x);
+      (*pos_i)[1] = proxy->angstrom_to_internal_unit(y);
+      (*pos_i)[2] = proxy->angstrom_to_internal_unit(z);
     }
   } else {          // Use all positions
     for ( ; pos_i != pos->end() ; pos_i++) {
       xyz_is >> symbol;
-      xyz_is >> (*pos_i)[0] >> (*pos_i)[1] >> (*pos_i)[2];
+      xyz_is >> x >> y >> z;
+      (*pos_i)[0] = proxy->angstrom_to_internal_unit(x);
+      (*pos_i)[1] = proxy->angstrom_to_internal_unit(y);
+      (*pos_i)[2] = proxy->angstrom_to_internal_unit(z);
     }
   }
   return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1,5 +1,12 @@
 // -*- c++ -*-
 
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
 #include <sstream>
 #include <cstring>
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -610,7 +610,7 @@ public:
 
   /// \brief Value of the unit for atomic coordinates with respect to
   /// angstroms (used by some variables for hard-coded default values)
-  static real unit_angstrom();
+  static real angstrom_value();
 
   /// \brief Boltmann constant
   static real boltzmann();

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -608,9 +608,6 @@ public:
 
   // proxy functions
 
-  /// \brief Value of one Angstrom in the unit for atomic coordinates
-  static real angstrom_value();
-
   /// \brief Boltmann constant
   static real boltzmann();
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -716,11 +716,10 @@ public:
                          std::string const &pdb_field,
                          double pdb_field_value = 0.0);
 
-  /// \brief Load the coordinates for a group of atoms from an
-  /// XYZ file
-  static int load_coords_xyz(char const *filename,
-                             std::vector<rvector> *pos,
-                             atom_group *atoms);
+  /// Load coordinates into an atom group from an XYZ file (assumes Angstroms)
+  int load_coords_xyz(char const *filename,
+                      std::vector<rvector> *pos,
+                      atom_group *atoms);
 
   /// Frequency for collective variables trajectory output
   static size_t cv_traj_freq;
@@ -760,6 +759,9 @@ private:
 
   /// Thread-specific depth
   std::vector<size_t> depth_v;
+
+  /// Track how many times the XYZ reader has been used
+  int xyz_reader_use_count;
 
 public:
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -608,8 +608,7 @@ public:
 
   // proxy functions
 
-  /// \brief Value of the unit for atomic coordinates with respect to
-  /// angstroms (used by some variables for hard-coded default values)
+  /// \brief Value of one Angstrom in the unit for atomic coordinates
   static real angstrom_value();
 
   /// \brief Boltmann constant

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -134,6 +134,8 @@ cvm::rvector colvarproxy_system::position_distance(cvm::atom_pos const &pos1,
   return diff;
 }
 
+
+
 colvarproxy_atoms::colvarproxy_atoms()
 {
   updated_masses_ = updated_charges_ = false;

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -33,6 +33,7 @@
 
 
 colvarproxy_system::colvarproxy_system()
+  : angstrom_value(0.)
 {
   reset_pbc_lattice();
 }
@@ -132,8 +133,6 @@ cvm::rvector colvarproxy_system::position_distance(cvm::atom_pos const &pos1,
 
   return diff;
 }
-
-
 
 colvarproxy_atoms::colvarproxy_atoms()
 {
@@ -807,6 +806,9 @@ int colvarproxy::reset()
   int error_code = COLVARS_OK;
   error_code |= colvarproxy_atoms::reset();
   error_code |= colvarproxy_atom_groups::reset();
+  units.clear();
+  angstrom_value = 0.;
+  kcal_mol_value = 0.;
   return error_code;
 }
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -806,9 +806,6 @@ int colvarproxy::reset()
   int error_code = COLVARS_OK;
   error_code |= colvarproxy_atoms::reset();
   error_code |= colvarproxy_atom_groups::reset();
-  units.clear();
-  angstrom_value = 0.;
-  kcal_mol_value = 0.;
   return error_code;
 }
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -82,7 +82,7 @@ public:
   //virtual cvm::real backend_kcal_mol_value() = 0;
 
   /// \brief Convert a length from Angstrom to internal
-  inline cvm::real angstrom_to_internal_unit(cvm::real l) {
+  inline cvm::real angstrom_to_internal(cvm::real l) {
     return l * angstrom_value;
   }
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -48,23 +48,17 @@ public:
   /// Destructor
   virtual ~colvarproxy_system();
 
-  // **********************************************************************
-  // TODO FIXME unsolved: calls to back-end PBC functions assume back-end length unit!
-  // We can use different unit from back-end in VMD bc using PBC functions from colvarproxy base class
-  // or test and default to internal PBC functions if we have our own units?
-  // Possible performance cost? a couple floating-point ops per coordinate
-  // **********************************************************************
-
-  // Colvars internal units are user specified, because the module exchanges info in unknown
-  // composite dimensions with user input, while it only exchanges quantities of known
-  // dimension with the back-end (length and forces)
-
   /// \brief Name of the unit system used internally by Colvars (by default, that of the back-end).
   /// Supported depending on the back-end: real (A, kcal/mol), metal (A, eV), electron (Bohr, Hartree), gromacs (nm, kJ/mol)
+  /// Note: calls to back-end PBC functions assume back-end length unit
+  /// We use different unit from back-end in VMD bc using PBC functions from colvarproxy base class
+  /// Colvars internal units are user specified, because the module exchanges info in unknown
+  /// composite dimensions with user input, while it only exchanges quantities of known
+  /// dimension with the back-end (length and forces)
   std::string units;
 
   /// \brief Request to set the units used internally by Colvars
-  virtual int set_unit_system(std::string const &units, bool colvars_defined) = 0;
+  virtual int set_unit_system(std::string const &units, bool check_only) = 0;
 
   /// \brief Value of 1 Angstrom in the internal (front-end) Colvars unit for atomic coordinates
   /// * defaults to 0. in the base class; derived proxy classes must set it
@@ -77,9 +71,6 @@ public:
 
   /// \brief Value of 1 kcal/mol in the internal Colvars unit for energy
   cvm::real kcal_mol_value;
-
-  /// \brief Value of 1 kcal/mol in the backend's unit for energy
-  //virtual cvm::real backend_kcal_mol_value() = 0;
 
   /// \brief Convert a length from Angstrom to internal
   inline cvm::real angstrom_to_internal(cvm::real l) const

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -67,8 +67,8 @@ public:
   virtual int set_unit_system(std::string const &units, bool colvars_defined) = 0;
 
   /// \brief Value of 1 Angstrom in the internal (front-end) Colvars unit for atomic coordinates
-  /// * This defaults to the back-end unit
-  /// * can be user-specified once, and can only be changed when no variables are defined
+  /// * defaults to 0. in the base class; derived proxy classes must set it
+  /// * in VMD proxy, can only be changed when no variables are defined
   /// as user-defined values in composite units must be compatible with that system
   cvm::real angstrom_value;
 
@@ -83,9 +83,6 @@ public:
 
   /// \brief Convert a length from Angstrom to internal
   inline cvm::real angstrom_to_internal_unit(cvm::real l) {
-    if (angstrom_value == 0.) {
-      return l;
-    }
     return l * angstrom_value;
   }
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -68,9 +68,8 @@ public:
 
   /// \brief Value of 1 Angstrom in the internal (front-end) Colvars unit for atomic coordinates
   /// * This defaults to the back-end unit
-  /// * can be user-specified once, and can only be changed by resetting the module
+  /// * can be user-specified once, and can only be changed when no variables are defined
   /// as user-defined values in composite units must be compatible with that system
-  /// Attempts to change it will raise errors
   cvm::real angstrom_value;
 
   /// \brief Value of 1 Angstrom in the backend's unit for atomic coordinates
@@ -82,11 +81,21 @@ public:
   /// \brief Value of 1 kcal/mol in the backend's unit for energy
   //virtual cvm::real backend_kcal_mol_value() = 0;
 
-  /// \brief Convert a length from back-end unit to internal
+  /// \brief Convert a length from Angstrom to internal
   inline cvm::real angstrom_to_internal_unit(cvm::real l) {
-    if (angstrom_value == 0.) { return l; }
-    return l * angstrom_value / backend_angstrom_value();
+    if (angstrom_value == 0.) {
+      return l;
+    }
+    return l * angstrom_value;
   }
+
+  // /// \brief Convert a length from back-end unit to internal
+  // inline cvm::real back_end_to_internal_unit(cvm::real l) {
+  //   if (angstrom_value == 0.) {
+  //     return l / backend_angstrom_value();
+  //   }
+  //   return l * angstrom_value / backend_angstrom_value();
+  // }
 
   /// \brief Boltzmann constant in internal Colvars units
   virtual cvm::real boltzmann() = 0;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -83,7 +83,7 @@ public:
   //virtual cvm::real backend_kcal_mol_value() = 0;
 
   /// \brief Convert a length from back-end unit to internal
-  inline cvm::real length_to_internal_unit(cvm::real l) {
+  inline cvm::real angstrom_to_internal_unit(cvm::real l) {
     if (angstrom_value == 0.) { return l; }
     return l * angstrom_value / backend_angstrom_value();
   }

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -82,7 +82,8 @@ public:
   //virtual cvm::real backend_kcal_mol_value() = 0;
 
   /// \brief Convert a length from Angstrom to internal
-  inline cvm::real angstrom_to_internal(cvm::real l) {
+  inline cvm::real angstrom_to_internal(cvm::real l) const
+  {
     return l * angstrom_value;
   }
 

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -86,6 +86,7 @@ public:
     cv_printframe,
     cv_printframelabels,
     cv_frame,
+    cv_units,
     cv_colvar,
     cv_colvar_value,
     cv_colvar_update,
@@ -289,6 +290,14 @@ extern "C" {
            { "E (float) - Store the energy in this variable" },
            double *energy = reinterpret_cast<double *>(objv[2]);
            *energy = cvm::main()->total_bias_energy;
+           return COLVARS_OK;
+           )
+
+  CVSCRIPT(cv_units,
+           "Get the current Colvars unit system",
+           0, 0,
+           { },
+           script->set_str_result(cvm::proxy->units);
            return COLVARS_OK;
            )
 

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -295,10 +295,14 @@ extern "C" {
 
   CVSCRIPT(cv_units,
            "Get the current Colvars unit system",
-           0, 0,
+           0, 1,
            { },
-           script->set_str_result(cvm::proxy->units);
-           return COLVARS_OK;
+           if (objc < 3) {
+            script->set_str_result(cvm::proxy->units);
+            return COLVARS_OK;
+           } else {
+            return cvm::proxy->set_unit_system(script->obj_to_str(objv[2]) , false);
+           }
            )
 
 #ifndef COLVARSCRIPT_INIT_FN

--- a/vmd/cv_dashboard/Makefile
+++ b/vmd/cv_dashboard/Makefile
@@ -1,7 +1,7 @@
 .SILENT:
 
 VMFILES = cv_dashboard.tcl cv_dashboard_main.tcl cv_dashboard_editor.tcl cv_dashboard_plots.tcl pkgIndex.tcl templates
-VMVERSION = 1.1
+VMVERSION = 1.2
 DIR = $(PLUGINDIR)/noarch/tcl/cv_dashboard$(VMVERSION)
 
 bins:

--- a/vmd/cv_dashboard/Makefile.local
+++ b/vmd/cv_dashboard/Makefile.local
@@ -1,5 +1,5 @@
 
-VERSION=1.1
+VERSION=1.2
 PLUGINDIR=${HOME}/lib/vmd/plugins/noarch/tcl
 
 install:

--- a/vmd/cv_dashboard/cv_dashboard_editor.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_editor.tcl
@@ -11,7 +11,13 @@ proc ::cv_dashboard::add {} {
 
 # Colvar config editor window
 proc ::cv_dashboard::edit { {add false} } {
-  set cfg ""
+  # If a non-default unit system is in use, recall it in the config string
+  refresh_units
+  if { $::cv_dashboard::units == "" } {
+    set cfg ""
+  } else {
+    set cfg "units $::cv_dashboard::units\n\n"
+  }
 
   if $add {
     # do not remove existing vars
@@ -355,7 +361,6 @@ proc ::cv_dashboard::edit_apply {} {
     # that are not there - excluding those that were successfully redefined
     # for that, backup_cfg could be a name -> config map as used by apply_config
     apply_config $::cv_dashboard::backup_cfg
-    refresh_table
     # Do not destroy editor window (give user a chance to fix input)
     return
   }

--- a/vmd/cv_dashboard/cv_dashboard_editor.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_editor.tcl
@@ -247,7 +247,7 @@ proc ::cv_dashboard::atoms_from_sel { source } {
   if {[llength $seltext] == 0 } {
     return
   }
-  set sel [atomselect top $seltext]
+  set sel [atomselect $::cv_dashboard::mol $seltext]
   set serials [$sel get serial]
   $sel delete
 
@@ -379,10 +379,10 @@ proc ::cv_dashboard::edit_cancel {} {
 
 proc ::cv_dashboard::refresh_reps {} {
   set w .cv_dashboard_window
-  set numreps [molinfo top get numreps]
+  set numreps [molinfo $::cv_dashboard::mol get numreps]
   set reps [list]
   for {set i 0} {$i < $numreps} {incr i} {
-    lappend reps [lindex [molinfo top get [list [list selection $i]]] 0]
+    lappend reps [lindex [molinfo $::cv_dashboard::mol get [list [list selection $i]]] 0]
   }
   $w.editor.fl.helpers.reps configure -values $reps
 }

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -302,7 +302,18 @@ proc ::cv_dashboard::change_units {} {
   # Get up-to-date current setting
   refresh_units
   if {$new != $::cv_dashboard::units} {
-    run_cv config "units $new"
+    if {[run_cv list] == {}} {
+      cv units $new
+    } else {
+      tk_messageBox -icon error -title "Colvars Dashboard Error"\
+        -message "Cannot change units while colvars are defined.
+You can either:
+1) delete all colvars, or
+2) edit their configuration (<Ctrl-a> <e>), checking all parameters \
+for consistency with desired units, and add the following line:
+units $new"
+      return
+    }
   }
   # Refresh Combo box
   refresh_units

--- a/vmd/cv_dashboard/cv_dashboard_plots.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_plots.tcl
@@ -53,7 +53,7 @@ proc ::cv_dashboard::plot { { type timeline } } {
     return
   }
 
-  set nf [molinfo top get numframes]
+  set nf [molinfo $::cv_dashboard::mol get numframes]
   # Get list of values for all frames
   for {set f 0} {$f< $nf} {incr f} {
     run_cv frame $f
@@ -98,7 +98,7 @@ proc ::cv_dashboard::plot { { type timeline } } {
   }
 
   # Update frame to display frame marker in new plot
-  update_frame internal [molinfo top] w
+  update_frame internal $::cv_dashboard::mol w
 }
 
 
@@ -141,7 +141,7 @@ proc ::cv_dashboard::marker_clicked { index x y color marker } {
 # Change frame in reaction to user input (arrow keys)
 proc ::cv_dashboard::chg_frame { shift } {
 
-  set nf [molinfo top get numframes]
+  set nf [molinfo $::cv_dashboard::mol get numframes]
 
   if { $shift == "start" } {
     set f 0
@@ -182,11 +182,11 @@ proc ::cv_dashboard::zoom { factor } {
   if {$fmin < 0} { set fmin 0 }
 
   set fmax [expr { $f + $half_width }]
-  set max_f [expr [molinfo top get numframes] - 1]
+  set max_f [expr [molinfo $::cv_dashboard::mol get numframes] - 1]
   if {$fmax > $max_f} { set fmax $max_f }
 
   $plothandle configure -xmin $fmin -xmax $fmax -plot
-  update_frame internal [molinfo top] w
+  update_frame internal $::cv_dashboard::mol w
 }
 
 
@@ -208,7 +208,7 @@ proc ::cv_dashboard::fit_vertically {} {
     }
   }
   $plothandle configure -ymin $ymin -ymax $ymax -plot
-  update_frame internal [molinfo top] w
+  update_frame internal $::cv_dashboard::mol w
 }
 
 
@@ -217,7 +217,7 @@ proc ::cv_dashboard::fit_horizontally {} {
   variable ::cv_dashboard::plothandle
 
   $plothandle configure -xmin auto -xmax auto -ymin auto -ymax auto -plot
-  update_frame internal [molinfo top] w
+  update_frame internal $::cv_dashboard::mol w
 }
 
 

--- a/vmd/cv_dashboard/cv_dashboard_plots.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_plots.tcl
@@ -122,7 +122,7 @@ proc ::cv_dashboard::plot_clicked { x y } {
   animate goto [expr { ($x - $xplotmin) / $scalex + $xmin}]
   if { $::cv_dashboard::track_frame == 0 } {
     # frame change doesn't trigger refresh, so we refresh manually
-    refresh_table
+    refresh_values
   }
 }
 
@@ -133,7 +133,7 @@ proc ::cv_dashboard::marker_clicked { index x y color marker } {
   animate goto [expr {$index - 1 }]
   if { $::cv_dashboard::track_frame == 0 } {
     # frame change doesn't trigger refresh, so we refresh manually
-    refresh_table
+    refresh_values
   }
 }
 
@@ -158,7 +158,7 @@ proc ::cv_dashboard::chg_frame { shift } {
   animate goto $f
   if { $::cv_dashboard::track_frame == 0 } {
     # frame change doesn't trigger refresh, so we refresh manually
-    refresh_table
+    refresh_values
   }
 }
 

--- a/vmd/cv_dashboard/pkgIndex.tcl
+++ b/vmd/cv_dashboard/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded cv_dashboard 1.1  "set env(CV_DASHBOARD_DIR) [list $dir]; [list source [file join $dir cv_dashboard.tcl]]"
+package ifneeded cv_dashboard 1.2  "set env(CV_DASHBOARD_DIR) [list $dir]; [list source [file join $dir cv_dashboard.tcl]]"

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -268,9 +268,9 @@ int colvarproxy_vmd::update_input()
   // copy positions in the internal arrays
   float *vmdpos = (vmdmol->get_frame(vmdmol_frame))->pos;
   for (size_t i = 0; i < atoms_positions.size(); i++) {
-    atoms_positions[i] = cvm::atom_pos(length_to_internal_unit(vmdpos[atoms_ids[i]*3+0]),
-                                       length_to_internal_unit(vmdpos[atoms_ids[i]*3+1]),
-                                       length_to_internal_unit(vmdpos[atoms_ids[i]*3+2]));
+    atoms_positions[i] = cvm::atom_pos(angstrom_to_internal_unit(vmdpos[atoms_ids[i]*3+0]),
+                                       angstrom_to_internal_unit(vmdpos[atoms_ids[i]*3+1]),
+                                       angstrom_to_internal_unit(vmdpos[atoms_ids[i]*3+2]));
   }
 
 
@@ -281,9 +281,9 @@ int colvarproxy_vmd::update_input()
     float B[3];
     float C[3];
     ts->get_transform_vectors(A, B, C);
-    unit_cell_x.set(length_to_internal_unit(A[0]), length_to_internal_unit(A[1]), length_to_internal_unit(A[2]));
-    unit_cell_y.set(length_to_internal_unit(B[0]), length_to_internal_unit(B[1]), length_to_internal_unit(B[2]));
-    unit_cell_z.set(length_to_internal_unit(C[0]), length_to_internal_unit(C[1]), length_to_internal_unit(C[2]));
+    unit_cell_x.set(angstrom_to_internal_unit(A[0]), angstrom_to_internal_unit(A[1]), angstrom_to_internal_unit(A[2]));
+    unit_cell_y.set(angstrom_to_internal_unit(B[0]), angstrom_to_internal_unit(B[1]), angstrom_to_internal_unit(B[2]));
+    unit_cell_z.set(angstrom_to_internal_unit(C[0]), angstrom_to_internal_unit(C[1]), angstrom_to_internal_unit(C[2]));
   }
 
   if (ts->a_length + ts->b_length + ts->c_length < 1.0e-6) {

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -218,13 +218,18 @@ int colvarproxy_vmd::setup()
 }
 
 
-int colvarproxy_vmd::set_unit_system(std::string const &units_in, bool colvars_defined)
+int colvarproxy_vmd::set_unit_system(std::string const &units_in, bool check_only)
 {
-  // if colvars are already defined, just test for compatibility
-  if (colvars_defined && units_in != units) {
-    cvm::error("Specified unit system \"" + units_in + "\" is incompatible with previous setting \""
-                + units + "\".\nReset the Colvars Module or delete all variables to change the unit.\n");
-    return COLVARS_ERROR;
+  // if check_only is specified, just test for compatibility
+  // cvolvarmodule does that if new units are requested while colvars are already defined
+  if (check_only) {
+    if (units_in != units) {
+      cvm::error("Specified unit system \"" + units_in + "\" is incompatible with previous setting \""
+                  + units + "\".\nReset the Colvars Module or delete all variables to change the unit.\n");
+      return COLVARS_ERROR;
+    } else {
+      return COLVARS_OK;
+    }
   }
 
   if (units_in == "real") {

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -59,10 +59,15 @@ public:
   /// \brief Update mass, charge, etc
   int update_atomic_properties();
 
-  inline cvm::real unit_angstrom()
+  inline cvm::real backend_angstrom_value()
   {
     return 1.0;
   }
+
+  // cvm::real backend_kcal_mol_value()
+  // {
+  //   return 1.0;
+  // }
 
   inline cvm::real boltzmann()
   {
@@ -131,6 +136,7 @@ public:
   void log(std::string const &message);
   void error(std::string const &message);
   void fatal_error(std::string const &message);
+  int set_unit_system(std::string const &units_in, bool colvars_defined);
 
   // Callback functions
   int run_force_callback();

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -64,11 +64,6 @@ public:
     return 1.0;
   }
 
-  // cvm::real backend_kcal_mol_value()
-  // {
-  //   return 1.0;
-  // }
-
   inline cvm::real boltzmann()
   {
     return 0.001987191;
@@ -136,7 +131,7 @@ public:
   void log(std::string const &message);
   void error(std::string const &message);
   void fatal_error(std::string const &message);
-  int set_unit_system(std::string const &units_in, bool colvars_defined);
+  int set_unit_system(std::string const &units_in, bool check_only);
 
   // Callback functions
   int run_force_callback();


### PR DESCRIPTION
This is a minimal implementation, in that only VMD actually supports different units, while the MD engines just check that Colvars units are identical to their own internal convention.

- VMD accepts changing unit system only when no colvars are currently
defined to avoid conflicting units between different inputs.
- the VMD Dashboard supports switching units when applicable
- NAMD only accepts the unit system "real"
- Gromacs only accepts the unit system "gromacs" (to be done in gmx branch)
- LAMMPS only accepts its currently set unit system (added test)
