### PR TITLE
Option to determine where to add harmonic-wall biases

### DIFF
--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -1055,6 +1055,8 @@ int colvarbias_restraint_harmonic_walls::init(std::string const &conf)
     }
   }
 
+  get_keyval(conf, "biasOnExtendedValue", b_bias_on_extended_value, false);
+
   return COLVARS_OK;
 }
 
@@ -1083,7 +1085,11 @@ void colvarbias_restraint_harmonic_walls::communicate_forces()
                variables(i)->name+"\".\n");
     }
     // Impulse-style multiple timestep
-    variables(i)->add_bias_force_actual_value(cvm::real(time_step_factor) * colvar_forces[i]);
+    if (b_bias_on_extended_value) {
+      variables(i)->add_bias_force(cvm::real(time_step_factor) * colvar_forces[i]);
+    } else {
+      variables(i)->add_bias_force_actual_value(cvm::real(time_step_factor) * colvar_forces[i]);
+    }
   }
 }
 

--- a/src/colvarbias_restraint.h
+++ b/src/colvarbias_restraint.h
@@ -280,6 +280,9 @@ protected:
   /// \brief If both walls are defined, use this k for the upper
   cvm::real upper_wall_k;
 
+  /// \brief Whether add biases on the extended DOF
+  bool b_bias_on_extended_value;
+
   virtual cvm::real colvar_distance(size_t i) const;
   virtual cvm::real restraint_potential(size_t i) const;
   virtual colvarvalue const restraint_force(size_t i) const;


### PR DESCRIPTION
Based on the disscussion of #245 and #252 , I feel that adding harmonic-wall restraints on the real CVs rather than the extended ones may cause some boundary effects in the extended-system-based algorithms (eABF, eMtD, meta-eABF, etc.). Plus, this kind of restraints feel unconfortable for me, since importance-sampling algorithms sometimes try to cancel the harmonic-wall potential.

I added an option "biasOnExtendedValue" for "harmonicWalls" to determine whether the harmonic-wall biases are added onto the extended degrees of freedom. The default value is no, which adapts the Colvars convention.

