### PR TITLE
Some cleanup of replica communication routines

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -4734,7 +4734,39 @@ The following options define the configuration for the ``well-tempered'' metadyn
 
 
 \cvsubsubsec{Multiple-walker metadynamics}{sec:colvarbias_meta_mr}
-The following options define metadynamics calculations with multiple replicas that share a common history (multiple-walker metadynamics) \cite{Raiteri2006}:
+Metadynamics calculations can be performed concurrently by multiple replicas that share a common history.
+This variant of the method is called multiple-walker metadynamics \cite{Raiteri2006}: the Gaussian hills of all replicas are periodically combined into a single biasing potential, intended to converge to a single PMF.
+
+In the implementation here described~\cite{Fiorin2013}, replicas communicate through files.
+This arrangement allows launching the replicas either (1) as a bundle (i.e.{} a single job in a cluster's queueing system) or (2) as fully independent runs (i.e.{} as separate jobs for the queueing system).
+One advantage of the use case (1) is that an identical Colvars configuration can be used for all replicas (otherwise, \texttt{replicaID} needs to be manually set to a different string for each replica).
+However, the use case (2) is less demanding in terms of high-performance computing resources: a typical scenario would be a computer cluster (including virtual servers from a cloud provider) where not all nodes are connected to each other at high speed, and thus each replica runs on a small group of nodes or a single node.
+
+Whichever way the replicas are started (coupled or not), a shared filesystem is needed so that each replica can read the files created by the others: paths to these files are stored in the shared file \texttt{replicasRegistry}.
+This file, and those listed in it, are read every \texttt{replicaUpdateFrequency} steps.
+Each time the Colvars state file is written (for example, \texttt{colvarsRestartFrequency} steps), the file named:\\
+\outputName\texttt{.colvars.}\emph{name}\texttt{.}\emph{replicaID}\texttt{.state}\\
+is written as well; this file contains only the state of the metadynamics bias, which the other replicas will read in turn.
+In between the times when this file is modified/replaced, new hills are also temporarily written to the file named:\\
+\outputName\texttt{.colvars.}\emph{name}\texttt{.}\emph{replicaID}\texttt{.hills}\\
+Both files are only used for communication, and may be deleted after the replica begins writing files with a new \outputName.\\
+
+\noindent\textbf{Example:} Multiple-walker metadynamics with file-based communication.\\
+{\noindent\ttfamily
+\-metadynamics \{\\
+\-\-~~name mymtd\\
+\-\-~~colvars x\\
+\-\-~~hillWeight 0.001\\
+\-\-~~newHillFrequency 1000\\
+\-\-~~hillWidth 3.0\\
+\-\-~~\\
+\-\-~~multipleReplicas       on\\
+\-\-~~replicasRegistry       /shared-folder/mymtd-replicas.txt\\
+\-\-~~replicaUpdateFrequency 50000  \# Best if larger than newHillFrequency\\
+\-\}\\
+}
+
+The following are the multiple-walkers related options:
 
 \begin{itemize}
 
@@ -4745,88 +4777,51 @@ The following options define metadynamics calculations with multiple replicas th
     Enable multiple-walker metadynamics}{%
     boolean}{%
     \texttt{off}}{%
-    If this option is \texttt{on}, multiple replicas of the
-    same system can be run at the same time. Their hills are shared periodically,
-    and combined to obtain a single PMF.  Replicas are
-    identified by the value of \texttt{replicaID}.  Communication is
-    done by files: each replica must be able to read the files
-    created by the others, whose paths are communicated through the file
-    \texttt{replicasRegistry}.  This file, and the files listed in it,
-    are read every \texttt{replicaUpdateFrequency} steps.  Every time
-    the colvars state file is written
-    (\texttt{colvarsRestartFrequency}), the file:\\
-    ``\outputName\texttt{.colvars.}\emph{name}\texttt{.}\emph{replicaID}\texttt{.state}''
-    is also written, containing
-    the state of the metadynamics bias for \texttt{replicaID}.  In the
-    time steps between \texttt{colvarsRestartFrequency}, new hills are
-    temporarily written to the file:\\
-    ``\outputName\texttt{.colvars.}\emph{name}\texttt{.}\emph{replicaID}\texttt{.hills}'',
-    which serves as communication
-    buffer.  These files are only required for communication, and may be
-    deleted after a new MD run is started with a different
-    \texttt{outputName}.  }
+    This option turns on multiple-walker communication between replicas. }
   
 \item %
   \key
-    {replicaID}{%
-    \texttt{metadynamics}}{%
-    Set the identifier for this replica}{%
-    string}{%
-    If \texttt{multipleReplicas} is \texttt{on}, this option sets a
-    unique identifier for this replica.  All replicas should use
-    identical collective variable configurations, except for the value
-    of this option.}
-  
-\item %
-  \keydef
     {replicasRegistry}{%
     \texttt{metadynamics}}{%
     Multiple replicas database file}{%
     UNIX filename}{%
-    ``\emph{name}\texttt{.replica\_files.txt}''}{%
-    If \texttt{multipleReplicas} is \texttt{on}, this option sets the
-    path to the replicas' database file.
-    % Each line in this file
-    % contains one \texttt{replicaID}, and the absolute path to a file
-    % listing the state file and the hills-file for that replica (see
-    % \texttt{multipleReplicas}).  All these files are generated
-    % automatically, but it is advisable that at least
-    % \texttt{replicasRegistry} is written by hand to avoid race
-    % conditions (multiple replicas writing concurrently to the same
-    % file).
+    If \texttt{multipleReplicas} is \texttt{on}, this option sets the path to the replicas' shared database file.
+    It is best to use an absolute path (especially when running individual replicas in separate folders).
+  }
+
+\item %
+  \key
+    {replicaUpdateFrequency}{%
+    \texttt{metadynamics}}{%
+    How often hills are shared between replicas}{%
+    positive integer}{%
+    If \texttt{multipleReplicas} is \texttt{on}, this option sets the number of steps after which each replica tries to read the other replicas' files.
+    On a networked file system, it is best to use a number of steps that corresponds to at least a minute of wall time.
   }
 
 \item %
   \keydef
-    {replicaUpdateFrequency}{%
+    {replicaID}{%
     \texttt{metadynamics}}{%
-    How often hills are communicated between
-    replicas}{%
-    positive integer}{%
-    \texttt{newHillFrequency}}{%
-    If \texttt{multipleReplicas} is \texttt{on}, this option sets the
-    number of steps after which each replica (re)reads the other
-    replicas' files.  The lowest meaningful value of this number is
-    \texttt{newHillFrequency}.  If access to the file system is
-    significantly affecting the simulation performance, this number can
-    be increased, at the price of reduced synchronization between
-    replicas.  Values higher than \texttt{colvarsRestartFrequency} may
-    not improve performance significantly.}
+    Set the identifier for this replica}{%
+    string}{%
+    replica index (only if a shared communicator is used)}{%
+    If \texttt{multipleReplicas} is \texttt{on}, this option sets a unique identifier for this replicas.
+    When the replicas are launched in a single command (i.e.{} they share a parallel communicator and are tightly synchronized) this value is optional, and defaults to the replica's numeric index (starting at zero).
+    However, when the replicas are launched as independent runs this option is required.
+}
 
 \item %
   \keydef
-    {dumpPartialFreeEnergyFile}{%
+    {writePartialFreeEnergyFile}{%
     \texttt{metadynamics}}{%
     Periodically write the contribution to the
     PMF from this replica}{%
     boolean}{%
-    \texttt{on}}{%
-    When \texttt{multipleReplicas} is \texttt{on}, the file
-    \outputName\texttt{.pmf} contains the combined PMF from all
-    replicas, provided that \texttt{useGrids} is \texttt{on} (default).
-    Enabling this option produces an additional file
-    \outputName\texttt{.partial.pmf}, which can be useful to
-    quickly monitor the contribution of each replica to the PMF.}
+    \texttt{off}}{%
+    If \texttt{multipleReplicas} is \texttt{on}, enabling this option produces  an additional file \outputName\texttt{.partial.pmf}, which can be useful to monitor the contribution of each replica to the total PMF (which is written to the file \outputName\texttt{.pmf}).
+    \textbf{Note:} the name of this file is chosen for consistency and convenience, \emph{but its content is not a PMF} and it is not expected to converge, even if the total PMF does.
+}
 
 \end{itemize}
 
@@ -4834,30 +4829,6 @@ The following options define metadynamics calculations with multiple replicas th
 \cvsubsubsec{Compatibility and post-processing}{sec:colvarbias_meta_post}
 The following options may be useful only for applications that go beyond the calculation of a PMF by metadynamics:
 \begin{itemize}
-
-\item %
-  \keydef
-    {name}{%
-    \texttt{metadynamics}}{%
-    Name of this metadynamics instance}{%
-    string}{%
-    ``\texttt{meta}'' + rank number}{%
-    This option sets the name for this metadynamics instance.  While it
-    is not advisable to use more than one metadynamics instance within
-    the same simulation, this allows to distinguish each instance from
-    the others.  If there is more than one metadynamics instance, the
-    name of this bias is included in the metadynamics output file names, such as e.g.~the \texttt{.pmf} file.}
-
-% \item %
-%   \keydef
-%     {gridsUpdateFrequency}{%
-%     \texttt{metadynamics}}{%
-%  Frequency of update of the grids}{%
-%     positive integer}{%
-%     \texttt{newHillFrequency}}{%
-%     When \texttt{useGrids} is \texttt{on}, all the newly created hills
-%     are projected onto the two grids every
-%     \texttt{gridsUpdateFrequency} steps.}
 
 \item %
   \keydef
@@ -4881,11 +4852,11 @@ The following options may be useful only for applications that go beyond the cal
     boolean}{%
     \texttt{off}}{%
     If this option is \texttt{on}, a logfile is written by the
-    \texttt{metadynamics} bias, with the name
-    ``\outputName\texttt{.colvars.$<$name$>$.hills.traj}'', which
+    \texttt{metadynamics} bias, with the name:\\
+    ``\outputName\texttt{.colvars.$<$name$>$.hills.traj}'',\\ which
     can be useful to follow the time series of the hills.  When
-    \texttt{multipleReplicas} is \texttt{on}, its name changes to\\
-    ``\outputName\texttt{.colvars.$<$name$>$.$<$replicaID$>$.hills.traj}''.
+    \texttt{multipleReplicas} is \texttt{on}, its name changes to:\\
+    ``\outputName\texttt{.colvars.$<$name$>$.$<$replicaID$>$.hills.traj}''.\\
     This file can be used to quickly visualize the positions of all
     added hills, in case \texttt{newHillFrequency} does not coincide
     with \texttt{colvarsRestartFrequency}.}

--- a/lammps/lib/colvars/Makefile.common
+++ b/lammps/lib/colvars/Makefile.common
@@ -44,6 +44,7 @@ COLVARS_SRCS = \
         colvarmodule.cpp \
         colvarparse.cpp \
         colvarproxy.cpp \
+        colvarproxy_replicas.cpp \
         colvarscript.cpp \
         colvartypes.cpp \
         colvarvalue.cpp

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -340,7 +340,7 @@ int colvarproxy_lammps::backup_file(char const *filename)
 
 int colvarproxy_lammps::replica_enabled()
 {
-  return (inter_comm != MPI_COMM_NULL);
+  return (inter_comm != MPI_COMM_NULL) ? COLVARS_OK : COLVARS_NOT_IMPLEMENTED;
 }
 
 

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.cpp
@@ -110,7 +110,7 @@ colvarproxy_lammps::colvarproxy_lammps(LAMMPS_NS::LAMMPS *lmp,
     restart_output_prefix_str.erase(restart_output_prefix_str.rfind(".*"),2);
 
   // initialize multi-replica support, if available
-  if (replica_enabled()) {
+  if (replica_enabled() == COLVARS_OK) {
     MPI_Comm_rank(inter_comm, &inter_me);
     MPI_Comm_size(inter_comm, &inter_num);
   }
@@ -337,6 +337,24 @@ int colvarproxy_lammps::backup_file(char const *filename)
 
 
 // multi-replica support
+
+int colvarproxy_lammps::replica_enabled()
+{
+  return (inter_comm != MPI_COMM_NULL);
+}
+
+
+int colvarproxy_lammps::replica_index()
+{
+  return inter_me;
+}
+
+
+int colvarproxy_lammps::num_replicas()
+{
+  return inter_num;
+}
+
 
 void colvarproxy_lammps::replica_comm_barrier()
 {

--- a/lammps/src/USER-COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/USER-COLVARS/colvarproxy_lammps.h
@@ -48,13 +48,6 @@ class colvarproxy_lammps : public colvarproxy {
   bool total_force_requested;
   bool do_exit;
 
-  // std::vector<int>          colvars_atoms;
-  // std::vector<size_t>       colvars_atoms_ncopies;
-  // std::vector<struct commdata> positions;
-  // std::vector<struct commdata> total_forces;
-  // std::vector<struct commdata> applied_forces;
-  // std::vector<struct commdata> previous_applied_forces;
-
   std::vector<int>          atoms_types;
 
   MPI_Comm inter_comm;     // MPI comm with 1 root proc from each world
@@ -98,9 +91,6 @@ class colvarproxy_lammps : public colvarproxy {
   // read additional config from string
   void add_config_string(const std::string &config);
 
-  // implementation of pure methods from base class
- public:
-
   inline cvm::real unit_angstrom() { return my_angstrom; };
   inline cvm::real boltzmann() { return my_boltzmann; };
   inline cvm::real temperature() { return t_target; };
@@ -127,26 +117,12 @@ class colvarproxy_lammps : public colvarproxy {
 
   inline std::vector<int> *modify_atom_types() { return &atoms_types; }
 
-  // implementation of optional methods from base class
- public:
+  virtual int replica_enabled();
+  virtual int replica_index();
+  virtual int num_replicas();
 
-  // Multi-replica support
-  // Indicate if multi-replica support is available and active
-  virtual bool replica_enabled() { return (inter_comm != MPI_COMM_NULL); }
-
-  // Index of this replica
-  virtual int replica_index() { return inter_me; }
-
-  // Total number of replica
-  virtual int replica_num() { return inter_num; }
-
-  // Synchronize replica
   virtual void replica_comm_barrier();
-
-  // Receive data from other replica
   virtual int replica_comm_recv(char* msg_data, int buf_len, int src_rep);
-
-  // Send data to other replica
   virtual int replica_comm_send(char* msg_data, int msg_len, int dest_rep);
 };
 

--- a/namd/Make.depends
+++ b/namd/Make.depends
@@ -2603,9 +2603,6 @@ obj/ComputeMgr.o: \
 	src/colvarproxy_namd_version.h \
 	src/Random.h \
 	colvars/src/colvarvalue.h \
-	src/DataExchanger.h \
-	inc/DataExchanger.decl.h \
-	src/Pointer.h \
 	src/DeviceCUDA.h \
 	inc/ComputeMgr.def.h
 	$(CXX) $(CXXFLAGS) $(COPTO)obj/ComputeMgr.o $(COPTC) src/ComputeMgr.C
@@ -4860,9 +4857,6 @@ obj/colvarproxy_namd.o: \
 	src/GlobalMaster.h \
 	src/Random.h \
 	colvars/src/colvarvalue.h \
-	src/DataExchanger.h \
-	inc/DataExchanger.decl.h \
-	src/Pointer.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvarbias.h \
 	colvars/src/colvar.h
@@ -7478,6 +7472,8 @@ obj/colvar.o: \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvarbias.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvar.o $(COPTC) colvars/src/colvar.cpp
@@ -7592,7 +7588,9 @@ obj/colvarcomp.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp.o $(COPTC) colvars/src/colvarcomp.cpp
 obj/colvarcomp_angles.o: \
 	obj/.exists \
@@ -7606,7 +7604,9 @@ obj/colvarcomp_angles.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_angles.o $(COPTC) colvars/src/colvarcomp_angles.cpp
 obj/colvarcomp_coordnums.o: \
 	obj/.exists \
@@ -7620,7 +7620,9 @@ obj/colvarcomp_coordnums.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvardeps.h \
 	colvars/src/colvar.h \
-	colvars/src/colvarcomp.h
+	colvars/src/colvarcomp.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_coordnums.o $(COPTC) colvars/src/colvarcomp_coordnums.cpp
 obj/colvarcomp_distances.o: \
 	obj/.exists \
@@ -7634,7 +7636,9 @@ obj/colvarcomp_distances.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_distances.o $(COPTC) colvars/src/colvarcomp_distances.cpp
 obj/colvarcomp_protein.o: \
 	obj/.exists \
@@ -7648,7 +7652,9 @@ obj/colvarcomp_protein.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_protein.o $(COPTC) colvars/src/colvarcomp_protein.cpp
 obj/colvarcomp_rotations.o: \
 	obj/.exists \
@@ -7662,12 +7668,42 @@ obj/colvarcomp_rotations.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarproxy.h
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_rotations.o $(COPTC) colvars/src/colvarcomp_rotations.cpp
 obj/colvarcomp_gpath.o: \
 	obj/.exists \
-	colvars/src/colvarcomp_gpath.cpp
+	colvars/src/colvarcomp_gpath.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvar.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
+obj/colvarcomp_apath.o: \
+	obj/.exists \
+	colvars/src/colvarcomp_apath.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvar.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
+	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_apath.o $(COPTC) colvars/src/colvarcomp_apath.cpp
 obj/colvardeps.o: \
 	obj/.exists \
 	colvars/src/colvardeps.cpp \
@@ -7692,6 +7728,8 @@ obj/colvargrid.o: \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h \
 	colvars/src/colvargrid.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvargrid.o $(COPTC) colvars/src/colvargrid.cpp
 obj/colvarmodule.o: \
@@ -7715,7 +7753,9 @@ obj/colvarmodule.o: \
 	colvars/src/colvarbias_restraint.h \
 	colvars/src/colvarscript.h \
 	colvars/src/colvaratoms.h \
-	colvars/src/colvarcomp.h
+	colvars/src/colvarcomp.h \
+	colvars/src/colvar_arithmeticpath.h \
+	colvars/src/colvar_geometricpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarmodule.o $(COPTC) colvars/src/colvarmodule.cpp
 obj/colvarparse.o: \
 	obj/.exists \
@@ -7741,6 +7781,15 @@ obj/colvarproxy.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvaratoms.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarproxy.o $(COPTC) colvars/src/colvarproxy.cpp
+obj/colvarproxy_replicas.o: \
+	obj/.exists \
+	colvars/src/colvarproxy_replicas.cpp \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarvalue.h
+	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarproxy_replicas.o $(COPTC) colvars/src/colvarproxy_replicas.cpp
 obj/colvarscript.o: \
 	obj/.exists \
 	colvars/src/colvarscript.cpp \

--- a/namd/colvars/src/Makefile.namd
+++ b/namd/colvars/src/Makefile.namd
@@ -20,6 +20,7 @@ COLVARSLIB = \
 	$(DSTDIR)/colvarmodule.o \
 	$(DSTDIR)/colvarparse.o \
 	$(DSTDIR)/colvarproxy.o \
+	$(DSTDIR)/colvarproxy_replicas.o \
 	$(DSTDIR)/colvarscript.o \
 	$(DSTDIR)/colvartypes.o \
 	$(DSTDIR)/colvarvalue.o

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -24,10 +24,6 @@
 #include "colvarproxy.h"
 #include "colvarvalue.h"
 
-// For replica exchange
-#include "converse.h"
-#include "DataExchanger.h"
-
 /// \brief Communication between colvars and NAMD (implementation of
 /// \link colvarproxy \endlink)
 class colvarproxy_namd : public colvarproxy, public GlobalMaster {
@@ -175,60 +171,12 @@ public:
 
 #endif // #if CMK_SMP && USE_CKLOOP
 
-  // Replica communication functions.
-  bool replica_enabled() {
-#if CMK_HAS_PARTITION
-    return true;
-#else
-    return false;
-#endif
-  }
-
-  int replica_index() {
-    return CmiMyPartition();
-  }
-
-  int replica_num() {
-    return CmiNumPartitions();
-  }
-
-  void replica_comm_barrier() {
-    replica_barrier();
-  }
-
-  int replica_comm_recv(char* msg_data, int buf_len, int src_rep) {
-    DataMessage *recvMsg = NULL;
-    replica_recv(&recvMsg, src_rep, CkMyPe());
-    CmiAssert(recvMsg != NULL);
-    int retval = recvMsg->size;
-    if (buf_len >= retval) {
-      memcpy(msg_data,recvMsg->data,retval);
-    } else {
-      retval = 0;
-    }
-    CmiFree(recvMsg);
-    return retval;
-  }
-
-  int replica_comm_send(char* msg_data, int msg_len, int dest_rep) {
-    replica_send(msg_data, msg_len, dest_rep, CkMyPe());
-    return msg_len;
-  }
-
-  int replica_comm_send()
-  {
-    return COLVARS_OK;
-  }
-
-  int replica_comm_async_send()
-  {
-    return COLVARS_OK;
-  }
-
-  inline size_t restart_frequency()
-  {
-    return restart_frequency_s;
-  }
+  virtual int replica_enabled();
+  virtual int replica_index();
+  virtual int replica_num();
+  virtual void replica_comm_barrier();
+  virtual int replica_comm_recv(char* msg_data, int buf_len, int src_rep);
+  virtual int replica_comm_send(char* msg_data, int msg_len, int dest_rep);
 
   int init_atom(int atom_number);
   int check_atom_id(int atom_number);

--- a/src/colvarbias_meta.h
+++ b/src/colvarbias_meta.h
@@ -41,6 +41,7 @@ public:
   virtual ~colvarbias_meta();
 
   virtual int init(std::string const &conf);
+  virtual int init_replicas_params(std::string const &conf);
   virtual int init_well_tempered_params(std::string const &conf);
   virtual int init_ebmeta_params(std::string const &conf);
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1911,39 +1911,6 @@ cvm::real cvm::rand_gaussian(void)
 }
 
 
-
-bool cvm::replica_enabled()
-{
-  return proxy->replica_enabled();
-}
-
-int cvm::replica_index()
-{
-  return proxy->replica_index();
-}
-
-int cvm::replica_num()
-{
-  return proxy->replica_num();
-}
-
-void cvm::replica_comm_barrier()
-{
-  return proxy->replica_comm_barrier();
-}
-
-int cvm::replica_comm_recv(char* msg_data, int buf_len, int src_rep)
-{
-  return proxy->replica_comm_recv(msg_data,buf_len,src_rep);
-}
-
-int cvm::replica_comm_send(char* msg_data, int msg_len, int dest_rep)
-{
-  return proxy->replica_comm_send(msg_data,msg_len,dest_rep);
-}
-
-
-
 template<typename T> std::string _to_str(T const &x,
                                          size_t width, size_t prec)
 {

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -678,15 +678,6 @@ public:
     return 5;
   }
 
-
-  // Replica exchange commands.
-  static bool replica_enabled();
-  static int replica_index();
-  static int replica_num();
-  static void replica_comm_barrier();
-  static int replica_comm_recv(char* msg_data, int buf_len, int src_rep);
-  static int replica_comm_send(char* msg_data, int msg_len, int dest_rep);
-
   /// \brief Get the distance between two atomic positions with pbcs handled
   /// correctly
   static rvector position_distance(atom_pos const &pos1,

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -456,51 +456,6 @@ int colvarproxy_smp::smp_unlock()
 
 
 
-colvarproxy_replicas::colvarproxy_replicas() {}
-
-
-colvarproxy_replicas::~colvarproxy_replicas() {}
-
-
-bool colvarproxy_replicas::replica_enabled()
-{
-  return false;
-}
-
-
-int colvarproxy_replicas::replica_index()
-{
-  return 0;
-}
-
-
-int colvarproxy_replicas::replica_num()
-{
-  return 1;
-}
-
-
-void colvarproxy_replicas::replica_comm_barrier() {}
-
-
-int colvarproxy_replicas::replica_comm_recv(char* /* msg_data */,
-                                            int /* buf_len */,
-                                            int /* src_rep */)
-{
-  return COLVARS_NOT_IMPLEMENTED;
-}
-
-
-int colvarproxy_replicas::replica_comm_send(char* /* msg_data */,
-                                            int /* msg_len */,
-                                            int /* dest_rep */)
-{
-  return COLVARS_NOT_IMPLEMENTED;
-}
-
-
-
-
 colvarproxy_script::colvarproxy_script()
 {
   script = NULL;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -446,15 +446,15 @@ public:
   virtual ~colvarproxy_replicas();
 
   /// \brief Indicate if multi-replica support is available and active
-  virtual bool replica_enabled();
+  virtual int replica_enabled();
 
   /// \brief Index of this replica
   virtual int replica_index();
 
-  /// \brief Total number of replica
-  virtual int replica_num();
+  /// \brief Total number of replicas
+  virtual int num_replicas();
 
-  /// \brief Synchronize replica
+  /// \brief Synchronize replica with others
   virtual void replica_comm_barrier();
 
   /// \brief Receive data from other replica

--- a/src/colvarproxy_replicas.cpp
+++ b/src/colvarproxy_replicas.cpp
@@ -1,0 +1,56 @@
+// -*- c++ -*-
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
+#include "colvarmodule.h"
+#include "colvarproxy.h"
+
+
+colvarproxy_replicas::colvarproxy_replicas() {}
+
+
+colvarproxy_replicas::~colvarproxy_replicas() {}
+
+
+int colvarproxy_replicas::replica_enabled()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_replicas::replica_index()
+{
+  return 0;
+}
+
+
+int colvarproxy_replicas::num_replicas()
+{
+  return 1;
+}
+
+
+void colvarproxy_replicas::replica_comm_barrier() {}
+
+
+int colvarproxy_replicas::replica_comm_recv(char* /* msg_data */,
+                                            int /* buf_len */,
+                                            int /* src_rep */)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+int colvarproxy_replicas::replica_comm_send(char* /* msg_data */,
+                                            int /* msg_len */,
+                                            int /* dest_rep */)
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+

--- a/vmd/src/colvars_files.pl
+++ b/vmd/src/colvars_files.pl
@@ -32,6 +32,7 @@ $colvars_defines = " -DVMDCOLVARS";
                     'colvarmodule.C',
                     'colvarparse.C',
                     'colvarproxy.C',
+                    'colvarproxy_replicas.C',
                     'colvarproxy_vmd.C',
                     'colvarscript.C',
                     'colvartypes.C',


### PR DESCRIPTION
Significant changes in the metadynamics bias: 
- Use the replica communication layer (if present) to set `replicaID` for metadynamics
- `replicasRegistry` and `replicaUpdateFrequency` are now mandatory
- And yes! The documentation section contains an example now!

Minor changes:
- `dumpPartialFreeEnergyFile` is now `writePartialFreeEnergyFile`; the former is still recognized silently for a bit
- `dumpFreeEnergyFile` is no longer supported (has been deprecated for many years in favor of `writeFreeEnergyFile`)
- `saveFreeEnergyFile` is no longer supported (has been deprecated 3 years in favor of `keepFreeEnergyFiles`)
