### PR TITLE
Allow redefining existing index groups (warn when this happens)

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -518,7 +518,8 @@ The following keywords are available in the global context of the Colvars config
     UNIX filename}{%
     This option reads an index file (usually with a \texttt{.ndx}
     extension) as produced by the \texttt{make\_ndx} tool of GROMACS.
-    This keyword may be repeated to load multiple index files: the same group name cannot appear in multiple index files.
+    This keyword may be repeated to load multiple index files.
+    A group with the same name may appear multiple times, as long as it contains the same indices in identical order each time: an error is raised otherwise.
     \cvlammpsonly{In LAMMPS, the \texttt{group2ndx} command can be used to generate such file from existing groups.
     Note that the Colvars module reads the indices of atoms from the index file: therefore, the LAMMPS groups do not need to remain active during the simulation, and could be deleted right after issuing \texttt{group2ndx}.
 }

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -628,39 +628,42 @@ int cvm::atom_group::add_atom_numbers(std::string const &numbers_conf)
 
 int cvm::atom_group::add_index_group(std::string const &index_group_name)
 {
-  colvarmodule *cv = cvm::main();
+  std::vector<std::string> const &index_group_names =
+    cvm::main()->index_group_names;
+  std::vector<std::vector<int> *> const &index_groups =
+    cvm::main()->index_groups;
 
-  std::list<std::string>::iterator names_i = cv->index_group_names.begin();
-  std::list<std::vector<int> >::iterator index_groups_i = cv->index_groups.begin();
-  for ( ; names_i != cv->index_group_names.end() ; ++names_i, ++index_groups_i) {
-    if (*names_i == index_group_name)
+  size_t i_group = 0;
+  for ( ; i_group < index_groups.size(); i_group++) {
+    if (index_group_names[i_group] == index_group_name)
       break;
   }
 
-  if (names_i == cv->index_group_names.end()) {
-    cvm::error("Error: could not find index group "+
-               index_group_name+" among those provided by the index file.\n",
-               INPUT_ERROR);
-    return COLVARS_ERROR;
+  if (i_group >= index_group_names.size()) {
+    return cvm::error("Error: could not find index group "+
+                      index_group_name+" among those already provided.\n",
+                      INPUT_ERROR);
   }
 
-  atoms_ids.reserve(atoms_ids.size()+index_groups_i->size());
+  int error_code = COLVARS_OK;
+
+  std::vector<int> const &index_group = *(index_groups[i_group]);
+
+  atoms_ids.reserve(atoms_ids.size()+index_group.size());
 
   if (is_enabled(f_ag_scalable)) {
-    for (size_t i = 0; i < index_groups_i->size(); i++) {
-      add_atom_id((cvm::proxy)->check_atom_id((*index_groups_i)[i]));
+    for (size_t i = 0; i < index_group.size(); i++) {
+      error_code |=
+        add_atom_id((cvm::proxy)->check_atom_id(index_group[i]));
     }
   } else {
-    atoms.reserve(atoms.size()+index_groups_i->size());
-    for (size_t i = 0; i < index_groups_i->size(); i++) {
-      add_atom(cvm::atom((*index_groups_i)[i]));
+    atoms.reserve(atoms.size()+index_group.size());
+    for (size_t i = 0; i < index_group.size(); i++) {
+      error_code |= add_atom(cvm::atom(index_group[i]));
     }
   }
 
-  if (cvm::get_error())
-    return COLVARS_ERROR;
-
-  return COLVARS_OK;
+  return error_code;
 }
 
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1168,8 +1168,7 @@ int colvarmodule::reset()
   }
   colvars.clear();
 
-  index_groups.clear();
-  index_group_names.clear();
+  reset_index_groups();
 
   proxy->reset();
 
@@ -1726,32 +1725,40 @@ int cvm::read_index_file(char const *filename)
   while (is.good()) {
     char open, close;
     std::string group_name;
+    int index_of_group = -1;
     if ( (is >> open) && (open == '[') &&
          (is >> group_name) &&
          (is >> close) && (close == ']') ) {
-      for (std::list<std::string>::iterator names_i = index_group_names.begin();
-           names_i != index_group_names.end();
-           names_i++) {
-        if (*names_i == group_name) {
-          cvm::error("Error: the group name \""+group_name+
-                     "\" appears in multiple index files.\n",
-                     FILE_ERROR);
+      size_t i = 0;
+      for ( ; i < index_group_names.size(); i++) {
+        if (index_group_names[i] == group_name) {
+          cvm::log("Warning: re-defining the index group \""+group_name+
+                   "\"; the new definition will only affect "
+                   "variables defined after this point.\n");
+          index_of_group = i;
         }
       }
-      index_group_names.push_back(group_name);
-      index_groups.push_back(std::vector<int>());
+      if (index_of_group < 0) {
+        index_group_names.push_back(group_name);
+        index_groups.push_back(new std::vector<int>());
+        index_of_group = index_groups.size()-1;
+      }
     } else {
-      cvm::error("Error: in parsing index file \""+
-                 std::string(filename)+"\".\n",
-                 INPUT_ERROR);
+      return cvm::error("Error: in parsing index file \""+
+                        std::string(filename)+"\".\n",
+                        INPUT_ERROR);
     }
+
+    std::vector<int> *index_group = index_groups[index_of_group];
+    index_group->clear();
 
     int atom_number = 1;
     size_t pos = is.tellg();
     while ( (is >> atom_number) && (atom_number > 0) ) {
-      (index_groups.back()).push_back(atom_number);
+      index_group->push_back(atom_number);
       pos = is.tellg();
     }
+
     is.clear();
     is.seekg(pos, std::ios::beg);
     std::string delim;
@@ -1764,14 +1771,27 @@ int cvm::read_index_file(char const *filename)
     }
   }
 
-  cvm::log("The following index groups were read from the index file \""+
-           std::string(filename)+"\":\n");
-  std::list<std::string>::iterator names_i = index_group_names.begin();
-  std::list<std::vector<int> >::iterator lists_i = index_groups.begin();
-  for ( ; names_i != index_group_names.end() ; names_i++, lists_i++) {
-    cvm::log("  "+(*names_i)+" ("+cvm::to_str(lists_i->size())+" atoms).\n");
+  cvm::log("The following index groups are currently defined:\n");
+  size_t i = 0;
+  for ( ; i < index_group_names.size(); i++) {
+    cvm::log("  "+(index_group_names[i])+" ("+
+             cvm::to_str((index_groups[i])->size())+" atoms)\n");
   }
-  return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);
+
+  return COLVARS_OK;
+}
+
+
+int colvarmodule::reset_index_groups()
+{
+  size_t i = 0;
+  for ( ; i < index_groups.size(); i++) {
+    delete index_groups[i];
+    index_groups[i] = NULL;
+  }
+  index_group_names.clear();
+  index_groups.clear();
+  return COLVARS_OK;
 }
 
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1732,15 +1732,13 @@ int cvm::read_index_file(char const *filename)
       size_t i = 0;
       for ( ; i < index_group_names.size(); i++) {
         if (index_group_names[i] == group_name) {
-          cvm::log("Warning: re-defining the index group \""+group_name+
-                   "\"; the new definition will only affect "
-                   "variables defined after this point.\n");
+          // Found a group with the same name
           index_of_group = i;
         }
       }
       if (index_of_group < 0) {
         index_group_names.push_back(group_name);
-        index_groups.push_back(new std::vector<int>());
+        index_groups.push_back(NULL);
         index_of_group = index_groups.size()-1;
       }
     } else {
@@ -1749,15 +1747,35 @@ int cvm::read_index_file(char const *filename)
                         INPUT_ERROR);
     }
 
-    std::vector<int> *index_group = index_groups[index_of_group];
-    index_group->clear();
+    std::vector<int> *old_index_group = index_groups[index_of_group];
+    std::vector<int> *new_index_group = new std::vector<int>();
 
     int atom_number = 1;
     size_t pos = is.tellg();
     while ( (is >> atom_number) && (atom_number > 0) ) {
-      index_group->push_back(atom_number);
+      new_index_group->push_back(atom_number);
       pos = is.tellg();
     }
+
+    if (old_index_group != NULL) {
+      bool equal = false;
+      if (new_index_group->size() == old_index_group->size()) {
+        if (std::equal(new_index_group->begin(), new_index_group->end(),
+                       old_index_group->begin())) {
+          equal = true;
+        }
+      }
+      if (! equal) {
+        cvm::log("Warning: re-defining the index group \""+group_name+
+                 "\"; the new definition will only affect "
+                 "variables defined after this point.\n");
+      }
+      old_index_group->clear();
+      delete old_index_group;
+      old_index_group = NULL;
+    }
+
+    index_groups[index_of_group] = new_index_group;
 
     is.clear();
     is.seekg(pos, std::ios::beg);

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1766,13 +1766,16 @@ int cvm::read_index_file(char const *filename)
         }
       }
       if (! equal) {
-        cvm::log("Warning: re-defining the index group \""+group_name+
-                 "\"; the new definition will only affect "
-                 "variables defined after this point.\n");
+        new_index_group->clear();
+        delete new_index_group;
+        new_index_group = NULL;
+        return cvm::error("Error: the index group \""+group_name+
+                          "\" was redefined.\n", INPUT_ERROR);
+      } else {
+        old_index_group->clear();
+        delete old_index_group;
+        old_index_group = NULL;
       }
-      old_index_group->clear();
-      delete old_index_group;
-      old_index_group = NULL;
     }
 
     index_groups[index_of_group] = new_index_group;

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -683,14 +683,17 @@ public:
   static rvector position_distance(atom_pos const &pos1,
                                    atom_pos const &pos2);
 
-  /// \brief Names of groups from a Gromacs .ndx file to be read at startup
-  std::list<std::string> index_group_names;
+  /// \brief Names of groups from one or more Gromacs .ndx files
+  std::vector<std::string> index_group_names;
 
-  /// \brief Groups from a Gromacs .ndx file read at startup
-  std::list<std::vector<int> > index_groups;
+  /// \brief Groups from one or more Gromacs .ndx files
+  std::vector<std::vector<int> *> index_groups;
 
   /// \brief Read a Gromacs .ndx file
   int read_index_file(char const *filename);
+
+  /// Clear the index groups loaded so far
+  int reset_index_groups();
 
   /// \brief Select atom IDs from a file (usually PDB) \param filename name of
   /// the file \param atoms array into which atoms read from "filename" will be

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -269,9 +269,7 @@ extern "C" {
            "Clear the index groups loaded so far, allowing to replace them",
            0, 0,
            { },
-           cvm::main()->index_group_names.clear();
-           cvm::main()->index_groups.clear();
-           return COLVARS_OK;
+           return cvm::main()->reset_index_groups();
            )
 
   CVSCRIPT(cv_addenergy,


### PR DESCRIPTION
Fixes #255.

The only caveat is that what was an error is now a warning; the index group will be-redefined and the user be warned that the new definition will only apply to new variables.

I think it's best to use the most recent definition when there is a clash, but please chip in if you think otherwise.

Also fixes #215 indirectly. LAMMPS was taken care of by #216 and the GROMACS code is currently in #190.