### PR TITLE
Ignore a keyword if it has content to the left of it (regardless of braces)

### DIFF
--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -333,6 +333,12 @@ public:
 
 protected:
 
+  /// Characters allowed immediately to the left of a kewyord
+  std::string const keyword_delimiters_left;
+
+  /// Characters allowed immediately to the right of a kewyord
+  std::string const keyword_delimiters_right;
+
   /// \brief List of legal keywords for this object: this is updated
   /// by each call to colvarparse::get_keyval() or
   /// colvarparse::key_lookup()


### PR DESCRIPTION
When keyword `A` is used as part of the value of another keyword `B` on the same line and without braces, the parser will try to look for the value of keyword `A` in the same line.

This change fixes #311 by checking that there is no character other than the allowed keyword delimiters between the beginning of the line and the beginning of the keyword.

