### PR TITLE
biasActualColvar option to bypass extended-Lagragian for a bias

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -5297,6 +5297,21 @@ The \texttt{harmonicWalls} bias implements the following options:
 \item \dupkey{lambdaSchedule}{\texttt{harmonicWalls}}{sec:colvarbias_harmonic}{Harmonic restraints}
 \item \dupkey{outputAccumulatedWork}{\texttt{harmonicWalls}}{sec:colvarbias_harmonic}{Harmonic restraints}
 
+\item %
+  \labelkey{harmonicWalls|biasActualColvar}
+  \keydef
+    {biasActualColvar}{%
+    \texttt{harmonicWalls}}{%
+    Apply bias to extended-Lagrangian colvars, bypassing the extended coordinate}{%
+    boolean}{%
+    \texttt{on}}{%
+    This option is only relevant if the bias is applied to one or several extended-Lagrangian colvars, for example within an eABF (\ref{sec:eABF}) simulation.
+    Usually, biases use the value of the extended coordinate as a proxy for the actual colvar, and their biasing forces are applied to the extended coordinates as well.
+    If \texttt{biasActualColvar} is enabled, the bias behaves as if there were no extended coordinates, and always use the value of the underlying colvars, applying any biasing forces along the gradients of those variables.
+    By default, the \texttt{harmonicWalls} bias applies to the actual colvars, so that the distribution of the colvar between the walls is unaffected by the bias, which then applies a flat-bottom potential \emph{as a function of the colvar value}. This bias will affect the extended coordinate distribution near the walls.
+    If \texttt{biasActualColvar} is disabled, \texttt{harmonicWalls} applies a flat-bottom potential \emph{as a function of the extended coordinate}. Conversely, this bias will then modify the distribution of the actual colvar value near the walls.
+  }
+
 \end{itemize}
 
 \noindent\textbf{Example 1:} harmonic walls for one variable with two different force constants.

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -118,6 +118,9 @@ int colvarbias::init_dependencies() {
     require_feature_children(f_cvb_apply_force, f_cv_gradient);
 
     init_feature(f_cvb_bias_actual_colvar, "bias actual colvar even if extended-Lagrangian", f_type_user);
+    // The exclusion below prevents the inconsistency where biasing forces are applied onto
+    // the actual colvar, while total forces are measured on the extended coordinate
+    exclude_feature_self(f_cvb_bias_actual_colvar, f_cvb_get_total_force);
 
     init_feature(f_cvb_get_total_force, "obtain total force", f_type_dynamic);
     require_feature_children(f_cvb_get_total_force, f_cv_total_force);

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -320,8 +320,6 @@ void colvarbias::communicate_forces()
     } else {
       variables(i)->add_bias_force(cvm::real(time_step_factor) * colvar_forces[i]);
     }
-  }
-  for (i = 0; i < num_variables(); i++) {
     previous_colvar_forces[i] = colvar_forces[i];
   }
 }

--- a/src/colvarbias.h
+++ b/src/colvarbias.h
@@ -65,7 +65,7 @@ public:
   virtual int calc_forces(std::vector<colvarvalue> const *values);
 
   /// Send forces to the collective variables
-  virtual void communicate_forces();
+  void communicate_forces();
 
   /// Carry out operations needed before next step is run
   virtual int end_of_step();

--- a/src/colvarbias_abf.cpp
+++ b/src/colvarbias_abf.cpp
@@ -115,7 +115,7 @@ int colvarbias_abf::init(std::string const &conf)
     if (colvars[i]->value().type() != colvarvalue::type_scalar) {
       cvm::error("Error: ABF bias can only use scalar-type variables.\n");
     }
-    colvars[i]->enable(f_cv_grid);
+    colvars[i]->enable(f_cv_grid); // Could be a child dependency of a f_cvb_use_grids feature
     if (hide_Jacobian) {
       colvars[i]->enable(f_cv_hide_Jacobian);
     }

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -1078,23 +1078,6 @@ int colvarbias_restraint_harmonic_walls::update()
 }
 
 
-void colvarbias_restraint_harmonic_walls::communicate_forces()
-{
-  for (size_t i = 0; i < num_variables(); i++) {
-    if (cvm::debug()) {
-      cvm::log("Communicating a force to colvar \""+
-               variables(i)->name+"\".\n");
-    }
-    // Impulse-style multiple timestep
-    if (is_enabled(f_cvb_bias_actual_colvar)) {
-      variables(i)->add_bias_force_actual_value(cvm::real(time_step_factor) * colvar_forces[i]);
-    } else {
-      variables(i)->add_bias_force(cvm::real(time_step_factor) * colvar_forces[i]);
-    }
-  }
-}
-
-
 cvm::real colvarbias_restraint_harmonic_walls::colvar_distance(size_t i) const
 {
   colvar *cv = variables(i);

--- a/src/colvarbias_restraint.h
+++ b/src/colvarbias_restraint.h
@@ -258,7 +258,6 @@ public:
   colvarbias_restraint_harmonic_walls(char const *key);
   virtual int init(std::string const &conf);
   virtual int update();
-  virtual void communicate_forces();
   virtual std::string const get_state_params() const;
   virtual int set_state_params(std::string const &conf);
   virtual std::ostream & write_state_data(std::ostream &os);

--- a/src/colvardeps.cpp
+++ b/src/colvardeps.cpp
@@ -428,11 +428,11 @@ void colvardeps::require_feature_alt(int f, int g, int h, int i, int j) {
 
 void colvardeps::print_state() {
   size_t i;
-  cvm::log("Enabled features of \"" + description + "\" (with reference count)");
+  cvm::log("Features of \"" + description + "\" ON/OFF (refcount)");
   for (i = 0; i < feature_states.size(); i++) {
-    if (is_enabled(i))
-      cvm::log("- " + features()[i]->description + " ("
-        + cvm::to_str(feature_states[i].ref_count) + ")");
+    std::string onoff = is_enabled(i) ? "ON" : "OFF";
+    cvm::log("- " + features()[i]->description + "   " + onoff + " ("
+      + cvm::to_str(feature_states[i].ref_count) + ")");
   }
   cvm::increase_depth();
   for (i=0; i<children.size(); i++) {

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -229,6 +229,8 @@ public:
     f_cvb_awake,
     /// \brief will apply forces
     f_cvb_apply_force,
+    /// \brief force this bias to act on actual value for extended-Lagrangian coordinates
+    f_cvb_bias_actual_colvar,
     /// \brief requires total forces
     f_cvb_get_total_force,
     /// \brief whether this bias should record the accumulated work


### PR DESCRIPTION
This is a variant of #299 where the option is a feature of the `colvarbias` class. In practice it is functionally equivalent because the only implementation is in the harmonic_walls class, however this would generalize easily to other restraints as needed.

The default is off for the generic class, and set to on in the harmonic_walls derived class.

TODO before merging: documentation