### PR TITLE
Colvars doc update and question regarding including in VMD/NAMD manual

### DIFF
--- a/doc/colvars-refman-lammps.tex
+++ b/doc/colvars-refman-lammps.tex
@@ -29,5 +29,10 @@
 % content that applies only to programs that use atom names (i.e. not LAMMPS)
 \newcommand{\cvnamebasedonly}[1]{}
 
+% File output prefixes
+\newcommand{\outputName}{\emph{output}}
+\newcommand{\restartName}{\emph{restart}}
+\newcommand{\inputName}{\emph{input}}
+
 
 \input{colvars-refman.tex}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -5960,7 +5960,10 @@ The following options allow to fine-tune this schedule:
 \cvscriptonly{
 \cvsec{Scripting interface (Tcl): list of commands}{sec:cvscript_tcl}
 This section lists all the commands used in \MDENGINE{} to control the behavior of the Colvars module from within a run script.
-\input{cvscript-tcl.tex}
+
+\cvrefmanonly{\input{cvscript-tcl.tex}}
+\cvnamdugonly{\input{ug_colvars_tclref_namd.tex}}
+\cvvmdugonly{\input{ug_colvars_tclref_vmd.tex}}
 }
 
 

--- a/doc/colvars-refman-namd.tex
+++ b/doc/colvars-refman-namd.tex
@@ -29,5 +29,10 @@
 % content that applies only to programs that use atom names (i.e. not LAMMPS)
 \newcommand{\cvnamebasedonly}[1]{#1}
 
+% File output prefixes
+\newcommand{\outputName}{\emph{outputName}}
+\newcommand{\restartName}{\emph{restartName}}
+\newcommand{\inputName}{\emph{inputName}}
+
 
 \input{colvars-refman.tex}

--- a/doc/colvars-refman-namd.tex
+++ b/doc/colvars-refman-namd.tex
@@ -23,6 +23,9 @@
 % only in programs were scripting is available
 \newcommand{\cvscriptonly}[1]{#1}
 
+% File containining the (auto-generated) Tcl interface reference doc
+\newcommand{\cvscripttclref}{cvscript-tcl.tex}
+
 % only in programs were Lepton is available
 \newcommand{\cvleptononly}[1]{#1}
 

--- a/doc/colvars-refman-vmd.tex
+++ b/doc/colvars-refman-vmd.tex
@@ -23,6 +23,9 @@
 % only in programs were scripting is available
 \newcommand{\cvscriptonly}[1]{#1}
 
+% File containining the (auto-generated) Tcl interface reference doc
+\newcommand{\cvscripttclref}{cvscript-tcl.tex}
+
 % only in programs were Lepton is available
 \newcommand{\cvleptononly}[1]{}
 

--- a/doc/colvars-refman-vmd.tex
+++ b/doc/colvars-refman-vmd.tex
@@ -29,5 +29,10 @@
 % content that applies only to programs that use atom names (i.e. not LAMMPS)
 \newcommand{\cvnamebasedonly}[1]{#1}
 
+% File output prefixes
+\newcommand{\outputName}{\emph{outputName}}
+\newcommand{\restartName}{\emph{restartName}}
+\newcommand{\inputName}{\emph{inputName}}
+
 
 \input{colvars-refman.tex}

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -88,14 +88,14 @@
 % use macros with context field to document keywords
 \newcommand{\key}[5]{%
   \index{#2!\texttt{#1}}
-  {\bf \large \tt #1 } $\langle\,$#3$\,\rangle$ \\%
+  {\bf Keyword \large \tt #1} $\langle\,$#3$\,\rangle$ \\%
   {\bf Context: } #2 \\%
   {\bf Acceptable values: } #4 \\%
   {\bf Description: } #5%
 }
 \newcommand{\keydef}[6]{%
   \index{#2!\texttt{#1}}
-  {\bf \large \tt #1 } $\langle\,$#3$\,\rangle$ \\%
+  {\bf Keyword \large \tt #1} $\langle\,$#3$\,\rangle$ \\%
   {\bf Context: } #2 \\%
   {\bf Acceptable values: } #4 \\%
   {\bf Default value: } #5 \\%
@@ -105,11 +105,11 @@
 \newcommand{\refkey}[2]{\hyperlink{#2}{\texttt{#1}}}
 \newcommand{\dupkey}[4]{%
   \index{#2!\texttt{#1}}
-  {\bf \large \tt #1:} see definition of \hyperlink{#3}{\texttt{#1}} in sec.~\ref{#3} (#4)%
+  {\bf Keyword \large \tt #1:} see definition of \hyperlink{#3}{\texttt{#1}} in sec.~\ref{#3} (#4)%
 }
 \newcommand{\simkey}[3]{%
   \index{#2!\texttt{#1}}
-  {\bf \large \tt #1:} analogous to \texttt{#3}%
+  {\bf Keyword \large \tt #1:} analogous to \texttt{#3}%
 }
 
 \newcommand{\gradx}{\mbox{\boldmath$\nabla_{\!\!x}\,$}}
@@ -120,24 +120,6 @@
 \newcommand{\cvsubsec}[2]{\noindent\hypertarget{#2}{\subsection{#1}}\label{#2}\ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi}
 \newcommand{\cvsubsubsec}[2]{\noindent\hypertarget{#2}{\subsubsection{#1}}\label{#2}\ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi}
 \newcommand{\cvurl}[1]{\url{#1}}
-
-\cvnamdonly{
-\newcommand{\outputName}{\emph{outputName}}
-\newcommand{\restartName}{\emph{restartName}}
-\newcommand{\inputName}{\emph{inputName}}
-}
-
-\cvvmdonly{
-\newcommand{\outputName}{\emph{outputName}}
-\newcommand{\restartName}{\emph{restartName}}
-\newcommand{\inputName}{\emph{inputName}}
-}
-
-\cvlammpsonly{
-\newcommand{\outputName}{\emph{output}}
-\newcommand{\restartName}{\emph{restart}}
-\newcommand{\inputName}{\emph{input}}
-}
 
 \input{colvars-refman-main}
 

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -279,6 +279,8 @@ then
            "${target}/ug/ug_colvars.bib"
   condcopy "${source}/doc/colvars-refman-main.tex" \
            "${target}/ug/ug_colvars.tex"
+  condcopy "${source}/doc/cvscript-tcl.tex" \
+           "${target}/ug/ug_colvars_tclref_namd.tex"
   condcopy "${source}/namd/ug/ug_colvars_macros.tex" \
            "${target}/ug/ug_colvars_macros.tex"
   condcopy "${source}/doc/colvars_diagram.pdf" \
@@ -353,6 +355,8 @@ then
            "${target}/doc/ug_colvars.bib"
   condcopy "${source}/doc/colvars-refman-main.tex" \
            "${target}/doc/ug_colvars.tex"
+  condcopy "${source}/doc/cvscript-tcl.tex" \
+           "${target}/doc/ug_colvars_tclref_vmd.tex"
   condcopy "${source}/vmd/doc/ug_colvars_macros.tex" \
            "${target}/doc/ug_colvars_macros.tex"
   condcopy "${source}/doc/colvars_diagram.pdf" \


### PR DESCRIPTION
There is a caveat with the Colvars doc when embedded in the NAMD and VMD manuals. Conditional text (e.g. `\cvscriptonly{...}`) does not play nice with `\input`ing long sections in the LaTeX environment used at UIUC.

Acknowledging that the Colvars manual is a "section" of disproportionate size (longer than one third of either the NAMD and VMD manual), maybe it's easier to stop embedding it and just link it?  Specific versions of the GitHub Pages website for each NAMD or VMD version would be needed, but that's doable.

Alternatively, to stay with the current arrangement, is there a way to `\input` conditionally files into the NAMD or VMD LaTeX file?  

EDIT: I made an attempt to the latter solution.  Merging the first commit (i.e. the useful content?) into master so that it's in sync with the code, but waiting to merge the rest to confirm that everything works as it should with the NAMD and VMD doc build systems.

EDIT 2: Jim mentioned that the doc build host is running CentOS 6, perhaps try building there.