### PR TITLE
Convert the input keyword to lowercase in read_state_data_key

### DIFF
--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -475,7 +475,7 @@ std::istream & colvarbias::read_state_data_key(std::istream &is, char const *key
   size_t const start_pos = is.tellg();
   std::string key_in;
   if ( !(is >> key_in) ||
-       !(key_in == to_lower_cppstr(std::string(key))) ) {
+       !(to_lower_cppstr(key_in) == to_lower_cppstr(std::string(key))) ) {
     cvm::error("Error: in reading restart configuration for "+
                bias_type+" bias \""+this->name+"\" at position "+
                cvm::to_str(static_cast<size_t>(is.tellg()))+


### PR DESCRIPTION
colvarbias::read_state_data_key compares the input keyword from the
state file with the hardcoded one. The hardcoded keyword is always
convert to lowercase but the input keyword is not. As a result, the
following code fails:
(In function write_state_data()):
    os << "grid_dV\n";
(In function read_state_data()):
    if (! read_state_data_key(is, "grid_dV"))
This commit fixes the problem.