### PR TITLE
Conditionally compile volumetric map support based on NAMD version

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -243,11 +243,13 @@ int colvarproxy_namd::setup()
     atom_groups_new_colvar_forces[ig] = cvm::rvector(0.0, 0.0, 0.0);
   }
 
+#if NAMD_VERSION_NUMBER >= 34471681
   log("updating grid object data ("+cvm::to_str(volmaps_ids.size())+
       " grid objects in total).\n");
   for (int imap = 0; imap < modifyGridObjForces().size(); imap++) {
     volmaps_new_colvar_forces[imap] = 0.0;
   }
+#endif
 
   return COLVARS_OK;
 }
@@ -260,7 +262,9 @@ int colvarproxy_namd::reset()
   // Unrequest all atoms and group from NAMD
   modifyRequestedAtoms().clear();
   modifyRequestedGroups().clear();
+#if NAMD_VERSION_NUMBER >= 34471681
   modifyRequestedGridObjects().clear();
+#endif
 
   atoms_map.clear();
 
@@ -344,9 +348,11 @@ void colvarproxy_namd::calculate()
     atom_groups_new_colvar_forces[i] = cvm::rvector(0.0, 0.0, 0.0);
   }
 
+#if NAMD_VERSION_NUMBER >= 34471681
   for (int imap = 0; imap < volmaps_ids.size(); imap++) {
     volmaps_new_colvar_forces[imap] = 0.0;
   }
+#endif
 
   // create the atom map if needed
   size_t const n_all_atoms = Node::Object()->molecule->numAtoms;
@@ -445,6 +451,7 @@ void colvarproxy_namd::calculate()
     }
   }
 
+#if NAMD_VERSION_NUMBER >= 34471681
   {
     if (cvm::debug()) {
       log("Updating grid objects.\n");
@@ -462,6 +469,7 @@ void colvarproxy_namd::calculate()
       }
     }
   }
+#endif
 
   if (cvm::debug()) {
     cvm::log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
@@ -480,9 +488,11 @@ void colvarproxy_namd::calculate()
     cvm::log("atom_groups_total_forces = "+cvm::to_str(atom_groups_total_forces)+"\n");
     cvm::log(cvm::line_marker);
 
+#if NAMD_VERSION_NUMBER >= 34471681
     cvm::log("volmaps_ids = "+cvm::to_str(volmaps_ids)+"\n");
     cvm::log("volmaps_values = "+cvm::to_str(volmaps_values)+"\n");
     cvm::log(cvm::line_marker);
+#endif
   }
 
   // call the collective variable module
@@ -496,8 +506,10 @@ void colvarproxy_namd::calculate()
     cvm::log(cvm::line_marker);
     cvm::log("atom_groups_new_colvar_forces = "+cvm::to_str(atom_groups_new_colvar_forces)+"\n");
     cvm::log(cvm::line_marker);
+#if NAMD_VERSION_NUMBER >= 34471681
     cvm::log("volmaps_new_colvar_forces = "+cvm::to_str(volmaps_new_colvar_forces)+"\n");
     cvm::log(cvm::line_marker);
+#endif
   }
 
   // communicate all forces to the MD integrator
@@ -516,6 +528,7 @@ void colvarproxy_namd::calculate()
     }
   }
 
+#if NAMD_VERSION_NUMBER >= 34471681
   if (volmaps_new_colvar_forces.size() > 0) {
     modifyGridObjForces().resize(requestedGridObjs().size());
     modifyGridObjForces().setall(0.0);
@@ -530,6 +543,7 @@ void colvarproxy_namd::calculate()
       }
     }
   }
+#endif
 
   // send MISC energy
   reduction->submit();
@@ -1217,6 +1231,8 @@ int colvarproxy_namd::set_unit_system(std::string const &units_in, bool /*check_
 }
 
 
+#if NAMD_VERSION_NUMBER >= 34471681
+
 int colvarproxy_namd::init_volmap(int volmap_id)
 {
   for (size_t i = 0; i < volmaps_ids.size(); i++) {
@@ -1271,6 +1287,8 @@ void colvarproxy_namd::clear_volmap(int index)
 {
   colvarproxy::clear_volmap(index);
 }
+
+#endif
 
 
 #if CMK_SMP && USE_CKLOOP // SMP only

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -10,6 +10,11 @@
 #ifndef COLVARPROXY_NAMD_H
 #define COLVARPROXY_NAMD_H
 
+#ifndef NAMD_VERSION_NUMBER
+// Assume 2.14b1 for now until the NAMD macro is merged
+#define NAMD_VERSION_NUMBER 34471681
+#endif
+
 #include "colvarproxy_namd_version.h"
 
 #include "Vector.h"
@@ -208,9 +213,11 @@ public:
   void clear_atom_group(int index);
   int update_group_properties(int index);
 
+#if NAMD_VERSION_NUMBER >= 34471681
   int init_volmap(int volmap_id);
   int init_volmap(const char *volmap_name);
   void clear_volmap(int index);
+#endif
 
   std::ostream * output_stream(std::string const &output_name,
                                std::ios_base::openmode mode);


### PR DESCRIPTION
Uses internally the macro `NAMD_VERSION_NUMBER` defined in NAMD Gerrit change https://charm.cs.illinois.edu/gerrit/c/namd/+/3926 (but not yet merged) with fall-back to a hard-coded value corresponding to 2.14b1.

To build the current Colvars snapshot against older NAMD snapshots (e.g. 2.13) one has to set explicitly the number version at compile time. Although the numbering scheme is not too obvious, `-DNAMD_VERSION_NUMBER=0` will suffice.

Submitting as draft and passing over to @jhenin for fine tuning.