### PR TITLE
Format code examples with colored background

### DIFF
--- a/doc/colvars-refman-css.tex
+++ b/doc/colvars-refman-css.tex
@@ -6,6 +6,9 @@
 % Colvars repository at GitHub.
 
 \Css{
+.heading {
+    background-color: rgb(215, 215, 215);
+}
 @media only screen and (max-width: 959px) {
 .inner {
     max-width: 100\%;

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -821,11 +821,11 @@ A collective variable is defined by the keyword \texttt{colvar} followed by its 
 
 \begin{cvexampleinput}
 \-colvar \{\\
-\-~~name xi\\
-\-~~$<$other options$>$\\
-\-~~function\_name \{\\
+\-~~name~xi\\
+\-~~$<$other~options$>$\\
+\-~~function\_name~\{\\
 \-~~~~$<$parameters$>$\\
-\-~~~~$<$atom selection$>$\\
+\-~~~~$<$atom~selection$>$\\
 \-~~\}\\
 \}
 \end{cvexampleinput}
@@ -4117,9 +4117,9 @@ To gain an estimate of the computational cost of a large colvar, one can use a t
 A biasing or analysis method can be applied to existing collective variables by using the following configuration:
 
 \begin{cvexampleinput}
-\-$<$biastype$>$ \{\\
-\-~~name $<$name$>$ \\
-\-~~colvars $<$xi1$>$ $<$xi2$>$ ...\\
+\-$<$biastype$>$~\{\\
+\-~~name~$<$name$>$ \\
+\-~~colvars~$<$xi1$>$~$<$xi2$>$~...\\
 \-~~$<$parameters$>$\\
 \}
 \end{cvexampleinput}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -95,7 +95,7 @@ Detailed explanations of the design of the Colvars module are provided in refere
 
 
 \cvvmdonly{
-\paragraph{Using the Colvars Module in VMD}
+\paragraph*{Using the Colvars Module in VMD}
 Within VMD, the Colvars Module can be accessed in two ways:
 \begin{itemize}
  \item Using the Colvars dashboard, an intuitive, but partial interface to the Colvars module, to easily define and analyze \textbf{collective variables, but not biases} (section~\ref{sec:dashboard}).

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -110,6 +110,9 @@ It is passed to the module using back-end-specific commands documented in sectio
 \cvvmdonly{Writing the configuration fora  collective variable in VMD is made much easier using the dashboard and its configuration editor (section~\ref{sec:dashboard}).
 However, note that the dashboard does not handle biases: if necessary, they should be managed separately using the scripting interface.}
 
+
+\paragraph*{Example: steering two atoms away from each other.}
+
 Now let us look at a complete, non-trivial configuration.
 Suppose that we want to run a steered MD experiment where a small molecule is pulled away from a protein binding site.
 In Colvars terms, this is done by applying a moving restraint to the distance between the two objects.
@@ -146,6 +149,63 @@ The atom selection keywords are detailed in section \ref{sec:colvar_atom_groups}
 If the selection is too complex to implement only via internal keywords, an external index file may be created following the NDX format used in GROMACS:\\
 \url{http://manual.gromacs.org/documentation/current/reference-manual/file-formats.html\#ndx}\\
 or by using the \texttt{group2ndx} LAMMPS command.}
+
+
+\paragraph*{Example: using multiple variables and multiple biasing/analysis methods together.}
+
+A more complex example configuration is included below, showing how a variable may be constructed by combining multiple existing functions, and how multiple variables or multiple biases may be used concurrently.
+The colvar indicated below as ``$d$'' is defined as the difference between two distances (see \ref{sec:cvc_distances}): the first distance ($d_{1}$) is taken between the center of mass of atoms 1 and 2 and that of atoms 3 to 5, the second ($d_{2}$) between atom 7 and the center of mass of atoms 8 to 10 (see \ref{sec:colvar_atom_groups}).
+The difference $d = d_{1} - d_{2}$ is obtained by multiplying the two by a coefficient $C = +1$ or $C = -1$, respectively (see \ref{sec:cvc_superp}).
+The colvar called ``$c$'' is the coordination number calculated between atoms 1 to 10 and atoms 11 to 20.  A harmonic restraint (see \ref{sec:colvarbias_harmonic}) is applied to both $d$ and $c$: to allow using the same force constant $K$, both $d$ and $c$ are scaled by their respective fluctuation widths $w_d$ and $w_c$.
+\cvnamebasedonly{A third colvar ``alpha'' is defined as the $\alpha$-helical content of residues 1 to 10 (see \ref{sec:cvc_alpha}).}
+The values of ``$c$''\cvnamebasedonly{ and ``alpha''} are also recorded throughout the simulation as a joint 2-dimensional histogram (see \ref{sec:colvarbias_histogram}).
+
+\begin{cvexampleinput}
+\noindent{}colvar \{\\
+\-~~\# difference of two distances\\
+\-~~name d \\
+\-~~width 0.2  \# 0.2 \AA{} of estimated fluctuation width \\
+\-~~distance \{\\
+\-~~~~componentCoeff  1.0\\
+\-~~~~group1 \{ atomNumbers 1 2 \}\\
+\-~~~~group2 \{ atomNumbers 3 4 5 \}\\
+\-~~\}\\
+\-~~distance \{\\
+\-~~~~componentCoeff -1.0\\
+\-~~~~group1 \{ atomNumbers 7 \}\\
+\-~~~~group2 \{ atomNumbers 8 9 10 \}\\
+\-~~\}\\
+\}\\
+\\
+colvar \{\\
+\-~~name c\\
+\-~~coordNum \{\\
+\-~~~~cutoff 6.0\\
+\-~~~~group1 \{ atomNumbersRange  1-10 \}\\
+\-~~~~group2 \{ atomNumbersRange 11-20 \}\\
+\-~~~~tolerance 1.0e-6\\
+\-~~~~pairListFrequency 1000\\
+\-~~\}\\
+\}\\
+\cvnamebasedonly{%
+colvar \{\\
+\-~~name alpha\\
+\-~~alpha \{\\
+\-~~~~psfSegID PROT\\
+\-~~~~residueRange 1-10\\
+\-~~\}\\
+\}}
+\\
+harmonic \{\\
+\-~~colvars d c\\
+\-~~centers 3.0 4.0\\
+\-~~forceConstant 5.0\\
+\}\\
+\\
+histogram \{\\
+\-~~colvars c\cvnamebasedonly{ alpha}\\
+\}
+\end{cvexampleinput}
 
 
 \cvvmdonly{
@@ -709,78 +769,6 @@ The following keywords are available in the global context of the Colvars config
     If this flag is enabled (default), SMP parallelism over threads will be used to compute variables and biases, provided that this is supported by the \MDENGINE{} build in use.}
     
 \end{itemize}
-
-
-To illustrate the flexibility of the Colvars module, a non-trivial setup is represented in Figure~\ref{fig:colvars_diagram}.
-The corresponding configuration is given below. The options within the \texttt{colvar} blocks are described in \ref{sec:colvar}, those within the \texttt{harmonic} and \texttt{histogram} blocks in \ref{sec:colvarbias}.
-\textbf{Note:} \emph{except }\texttt{colvar}\emph{, none of the keywords shown is mandatory}.\\
-
-\begin{figure}[!ht]
-  \centering
-\cvnamdugonly{\includegraphics[width=12cm]{figures/colvars_diagram}}
-\cvvmdugonly{\includegraphics[width=12cm]{pictures/colvars_diagram}}
-\cvrefmanonly{\ifdefined\HCode{\HCode{<img class="diagram" src="colvars_diagram.png" alt="Colvars diagram">}}\else\includegraphics[width=12cm]{colvars_diagram}\fi}
-  \caption[Graphical representation of a Colvars configuration.]{Graphical representation of a Colvars configuration\cvlammpsonly{ \textbf{(note:} \emph{currently, the $\alpha$-helical content colvar is unavailable in LAMMPS)}}.
-    The colvar called ``$d$'' is defined as the difference between two distances: the first distance ($d_{1}$) is taken between the center of mass of atoms 1 and 2 and that of atoms 3 to 5, the second ($d_{2}$) between atom 7 and the center of mass of atoms 8 to 10.
-The difference $d = d_{1} - d_{2}$ is obtained by multiplying the two by a coefficient $C = +1$ or $C = -1$, respectively.
-The colvar called ``$c$'' is the coordination number calculated between atoms 1 to 10 and atoms 11 to 20.  A harmonic restraint is applied to both $d$ and $c$: to allow using the same force constant $K$, both $d$ and $c$ are scaled by their respective fluctuation widths $w_d$ and $w_c$.
-\cvnamebasedonly{A third colvar ``alpha'' is defined as the $\alpha$-helical content of residues 1 to 10.}
-The values of ``$c$''\cvnamebasedonly{ and ``alpha''} are also recorded throughout the simulation as a joint 2-dimensional histogram.
-}
-  \label{fig:colvars_diagram}
-\end{figure}
-
-\begin{cvexampleinput}
-\noindent{}colvar \{\\
-\-~~\# difference of two distances\\
-\-~~name d \\
-\-~~width 0.2  \# 0.2 \AA{} of estimated fluctuation width \\
-\-~~distance \{\\
-\-~~~~componentCoeff  1.0\\
-\-~~~~group1 \{ atomNumbers 1 2 \}\\
-\-~~~~group2 \{ atomNumbers 3 4 5 \}\\
-\-~~\}\\
-\-~~distance \{\\
-\-~~~~componentCoeff -1.0\\
-\-~~~~group1 \{ atomNumbers 7 \}\\
-\-~~~~group2 \{ atomNumbers 8 9 10 \}\\
-\-~~\}\\
-\}\\
-\\
-colvar \{\\
-\-~~name c\\
-\-~~coordNum \{\\
-\-~~~~cutoff 6.0\\
-\-~~~~group1 \{ atomNumbersRange  1-10 \}\\
-\-~~~~group2 \{ atomNumbersRange 11-20 \}\\
-\-~~\}\\
-\}\\
-\cvnamebasedonly{%
-colvar \{\\
-\-~~name alpha\\
-\-~~alpha \{\\
-\-~~~~psfSegID PROT\\
-\-~~~~residueRange 1-10\\
-\-~~\}\\
-\}}
-\\
-harmonic \{\\
-\-~~colvars d c\\
-\-~~centers 3.0 4.0\\
-\-~~forceConstant 5.0\\
-\}\\
-\\
-histogram \{\\
-\-~~colvars c\cvnamebasedonly{ alpha}\\
-\}
-\end{cvexampleinput}
-
-%\cvlammpsonly{\textbf{Note:} \emph{currently, the $\alpha$-helical content colvar is unavailable in LAMMPS, as it requires a name-based topology; future releases will overcome this limitation.}}
-
-Section \ref{sec:colvar} explains how to define a colvar and its behavior, regardless of its specific functional form.
-To define colvars that are appropriate to a specific physical system, Section \ref{sec:colvar_atom_groups} documents how to select atoms, and section \ref{sec:colvar} lists all of the available functional forms, which we call ``colvar components''.
-Finally, section \ref{sec:colvarbias} lists the available methods and algorithms to perform biased simulations and multidimensional analysis of colvars.
-
 
 
 \cvsubsec{Input state file}{sec:colvars_input}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -408,13 +408,12 @@ Because these are static parameters, it is typically more convenient to use the 
 
 
 \cvlammpsonly{
-\subsection{LAMMPS keywords}
-\label{sec:colvars_mdengine_parameters}
+\cvsubsec{LAMMPS keywords}{sec:colvars_mdengine_parameters}
 
-To enable a Colvars-based calculation, the following line must be added to the LAMMPS configuration file:\\
-\\
-\texttt{fix } \emph{ID } \texttt{all }  \texttt{colvars } \emph{configfile } \emph{keyword value pairs ...}\\
-\\
+To enable a Colvars-based calculation, the following line must be added to the LAMMPS configuration file:
+\begin{mdexampleinput}
+\-fix~\emph{ID}~all~colvars~\emph{configfile}~\emph{keyword~value~pairs ...}
+\end{mdexampleinput}
 where \emph{ID} is a string that uniquely identifies this fix command inside a LAMMPS script, \emph{configfile} is the name of the configuration file for the Colvars module, followed by one or more of the following optional keywords with their corresponding arguments:
 
 \begin{itemize}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -5,6 +5,30 @@
 % If you wish to distribute your changes, please submit them to the
 % Colvars repository at GitHub.
 
+% Set flags depending on which engine this manual is compiled for
+
+\cvlammpsonly{
+\def\cvscriptapi{1} % Supports the scripting API
+\def\cvscriptcmdapi{1} % Supports command-line scripting (via fix_modify)
+\def\cvscriptpyapi{1} % Supports Python scripting
+\newcommand{\cvscriptcmd}{\texttt{fix\_modify Colvars}}
+}
+
+\cvnamdonly{
+\def\cvvmdornamd{1}
+\def\cvscriptapi{1}
+\def\cvscriptcmdapi{1} % Supports command-line scripting (via cv Tcl command)
+\newcommand{\cvscriptcmd}{\texttt{cv}}
+}
+
+\cvvmdonly{
+\def\cvvmdornamd{1}
+\def\cvscriptapi{1}
+\def\cvscriptcmdapi{1}
+\newcommand{\cvscriptcmd}{\texttt{cv}}
+}
+
+
 \cvnamdugonly{
 \section{Collective Variable-based Calculations (Colvars)}
 \label{section:colvars}
@@ -92,9 +116,7 @@ In Colvars terms, this is done by applying a moving restraint to the distance be
 The configuration will contain two blocks, one defining the distance variable (see section \ref{sec:colvar} and \ref{sec:cvc_distance}), and the other the moving harmonic restraint (\ref{sec:colvarbias_harmonic}).
 \cvvmdonly{Note that in VMD, no biasing forces are applied, but biases may be useful in the context of an analysis script, e.g. to collect histograms or to compute bias energies.}
 
-\bigskip
-% verbatim can't appear within commands
-{\noindent\ttfamily
+\begin{cvexampleinput}
 \cvlammpsonly{indexFile index.ndx\\}colvar \{\\
 \-~~name dist\\
 \-~~distance \{\\
@@ -113,8 +135,8 @@ harmonic \{\\
 \-~~centers 4.0~~~~~~~~~\# initial distance\\
 \-~~targetCenters 15.0~~\# final distance\\
 \-~~targetNumSteps 500000\\
-\}\\
-}
+\}
+\end{cvexampleinput}
 
 Reading this input in plain English: the variable here named \emph{dist} consists in a distance function between the centers of two groups: the ligand (atoms 42 to 55) and the $\alpha$-carbon atoms of residues 15 to 30 in the protein \cvnamebasedonly{(segment name PR)}\cvlammpsonly{(selected from the index group ``\texttt{C-alpha\_15-30}'')}.
 To the ``\emph{dist}'' variable, we apply a \texttt{harmonic} potential of force constant 20~\cvnamdonly{kcal/mol}\cvvmdonly{kcal/mol}\cvlammpsonly{(energy unit)}/\cvnamdonly{\AA}\cvvmdonly{\AA}\cvlammpsonly{(length unit)}$^2$, initially centered around a value of 4~\cvnamdonly{\AA}\cvvmdonly{\AA}\cvlammpsonly{(length unit)}, which will increase to 15~\cvnamdonly{\AA}\cvvmdonly{\AA}\cvlammpsonly{(length unit)} over 500,000 simulation steps.
@@ -708,10 +730,8 @@ The values of ``$c$''\cvnamebasedonly{ and ``alpha''} are also recorded througho
   \label{fig:colvars_diagram}
 \end{figure}
 
-{%
-% verbatim can't appear within commands
-\noindent\ttfamily
-colvar \{\\
+\begin{cvexampleinput}
+\noindent{}colvar \{\\
 \-~~\# difference of two distances\\
 \-~~name d \\
 \-~~width 0.2  \# 0.2 \AA{} of estimated fluctuation width \\
@@ -734,28 +754,26 @@ colvar \{\\
 \-~~~~group1 \{ atomNumbersRange  1-10 \}\\
 \-~~~~group2 \{ atomNumbersRange 11-20 \}\\
 \-~~\}\\
-\}\\}
-\cvnamebasedonly{{%
-\noindent\ttfamily\\
+\}\\
+\cvnamebasedonly{%
 colvar \{\\
 \-~~name alpha\\
 \-~~alpha \{\\
 \-~~~~psfSegID PROT\\
 \-~~~~residueRange 1-10\\
 \-~~\}\\
-\}}}
-{%
-\noindent\ttfamily\\
+\}}
 \\
 harmonic \{\\
 \-~~colvars d c\\
 \-~~centers 3.0 4.0\\
 \-~~forceConstant 5.0\\
 \}\\
-
-\noindent histogram \{\\
+\\
+histogram \{\\
 \-~~colvars c\cvnamebasedonly{ alpha}\\
-\}\\}
+\}
+\end{cvexampleinput}
 
 %\cvlammpsonly{\textbf{Note:} \emph{currently, the $\alpha$-helical content colvar is unavailable in LAMMPS, as it requires a name-based topology; future releases will overcome this limitation.}}
 
@@ -814,16 +832,17 @@ All such files' names also begin with the prefix \outputName.
 
 A collective variable is defined by the keyword \texttt{colvar} followed by its configuration options contained within curly braces:
 
-{\bigskip\noindent\ttfamily
-colvar \{\\
+\begin{cvexampleinput}
+\-colvar \{\\
 \-~~name xi\\
 \-~~$<$other options$>$\\
 \-~~function\_name \{\\
 \-~~~~$<$parameters$>$\\
 \-~~~~$<$atom selection$>$\\
 \-~~\}\\
-\}\\
-}
+\}
+\end{cvexampleinput}
+
 
 \noindent{}There are multiple ways of defining a variable:
 \begin{itemize}
@@ -2404,10 +2423,8 @@ In the \texttt{gspath~\{...\}} and the \texttt{gzpath~\{...\}} block all vectors
 
 The usage of \texttt{gzpath} and \texttt{gspath} is illustrated below:
 
-\bigskip
-{%
-% verbatim can't appear within commands
-\noindent\ttfamily colvar \{\\
+\begin{cvexampleinput}
+colvar \{\\
 \-~~\# Progress along the path\\
 \-~~name gs\\
 \-~~\# The path is defined by 5 reference frames (from string-00.pdb to string-04.pdb)\\
@@ -2434,7 +2451,9 @@ The usage of \texttt{gzpath} and \texttt{gspath} is illustrated below:
 \-~~~~refPositionsFile4 string-03.pdb\\
 \-~~~~refPositionsFile5 string-04.pdb\\
 \-~~\}\\
-\}}
+\}
+\end{cvexampleinput}
+
 
 \cvsubsubsec{\texttt{linearCombination}: Helper CV to define a linear combination of other CVs}{sec:cvc_linearCombination}
 \labelkey{colvar|linearCombination}
@@ -2498,10 +2517,8 @@ In the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} block all vec
 
 The usage of \texttt{gzpathCV} and \texttt{gspathCV} is illustrated below:
 
-\bigskip
-{%
-% verbatim can't appear within commands
-\noindent\ttfamily colvar \{\\
+\begin{cvexampleinput}
+\-colvar \{\\
 \-~~\# Progress along the path\\
 \-~~name gs\\
 \-~~\# Path defined by the CV space of two dihedral angles\\
@@ -2523,7 +2540,8 @@ The usage of \texttt{gzpathCV} and \texttt{gspathCV} is illustrated below:
 \-~~~~\}\\
 \-~~\}\\
 \}\\
-\noindent\ttfamily colvar \{\\
+\\
+\-colvar \{\\
 \-~~\# Distance from the path\\
 \-~~name gz\\
 \-~~gzpathCV \{\\
@@ -2543,7 +2561,8 @@ The usage of \texttt{gzpathCV} and \texttt{gspathCV} is illustrated below:
 \-~~~~~~group4 \{atomNumbers \{17\}\}\\
 \-~~~~\}\\
 \-~~\}\\
-\}}
+\}
+\end{cvexampleinput}
 
 
 \cvsubsec{Arithmetic path collective variables}{sec:cvc_apathCV}
@@ -2605,10 +2624,8 @@ This colvar component computes the $z$ variable. Options are the same as in \ref
 
 The usage of \texttt{azpathCV} and \texttt{aspathCV} is illustrated below:
 
-\bigskip
-{%
-% verbatim can't appear within commands
-\noindent\ttfamily colvar \{\\
+\begin{cvexampleinput}
+colvar \{\\
 \-~~\# Progress along the path\\
 \-~~name as\\
 \-~~\# Path defined by the CV space of two dihedral angles\\
@@ -2632,7 +2649,8 @@ The usage of \texttt{azpathCV} and \texttt{aspathCV} is illustrated below:
 \-~~~~\}\\
 \-~~\}\\
 \}\\
-\noindent\ttfamily colvar \{\\
+\\
+colvar \{\\
 \-~~\# Distance from the path\\
 \-~~name az\\
 \-~~azpathCV \{\\
@@ -2654,8 +2672,8 @@ The usage of \texttt{azpathCV} and \texttt{aspathCV} is illustrated below:
 \-~~~~~~group4 \{atomNumbers \{17\}\}\\
 \-~~~~\}\\
 \-~~\}\\
-\}}
-
+\}
+\end{cvexampleinput}
 
 
 \cvscriptonly{
@@ -2724,31 +2742,32 @@ Because the volumetric map itself and the atoms affected by it are defined exter
 Firstly, a volumetric map that has a value of 1 inside the cavity and 0 outside should be prepared.
 A reasonable starting point may be obtained, for example, with VMD: using an existing trajectory where the cavity is occupied by solvent and a spatial selection that identifies all the molecules within the cavity, \texttt{volmap occupancy -allframes -combine max} computes the occupancy map as a step function (values 1 or 0), and \texttt{volutil -smooth \ldots} makes it a continuous map, suitable for use as a MD simulation bias.
 A PDB file defining the selection (for example, where all water oxygens and ions have an occupancy of 1 and other atoms 0) is also prepared using VMD.
-Both the map file and the atom selection file are then loaded via the \texttt{mGridForcePotFile} and related NAMD commands:\\
+Both the map file and the atom selection file are then loaded via the \texttt{mGridForcePotFile} and related NAMD commands:
 
-{\noindent\ttfamily
+\begin{mdexampleinput}
   \-mGridForce yes\\
   \-mGridForcePotFile Cavity cavity.dx~~~\# OpenDX map file\\
   \-mGridForceFile Cavity water-sel.pdb~~\# PDB file used for atom selection\\
   \-mGridForceCol Cavity O~~~~~~~~~~~~~~~\# Use the occupancy column of the PDB file\\
   \-mGridForceChargeCol Cavity B~~~~~~~~~\# Use beta as ``charge'' (default: electric charge)\\
   \-mGridForceScale Cavity 0.0 0.0 0.0~~~\# Do not use GridForces for this map\\
-}
+\end{mdexampleinput}
 
 The value of \texttt{mGridForceScale} is particularly important, because it determines the GridForces force constant for the ``Cavity'' map.
 A non-zero value enables a conventional GridForces calculation, where the force constant remains fixed within each \texttt{run} command and the forces on the atoms depend only on their positions in space.
 However, setting \texttt{mGridForceScale} to zero signals to NAMD that the force acting through the volumetric map may be computed dynamically, as part of a collective-variable biasing scheme.
 To do so, the map labeled ``Cavity'' needs to be referred to in the Colvars configuration:\\
 
-{\noindent\ttfamily
+\begin{mdexampleinput}
   \-cv config "\\
   \-colvar \{\\
   \-\-~~name n\_waters\\
   \-\-~~mapTotal \{\\
   \-\-~~~~mapName Cavity  \# Same label as the GridForce map\\
   \-\-~~\}\\
-  \-\}"\\
-}
+  \-\}"
+\end{mdexampleinput}
+
 
 The variable ``\texttt{n\_waters}'' may then be used with any of the enhanced sampling methods available (\ref{sec:colvarbias}): new forces applied to it at each simulation step will be transmitted to the corresponding atoms within the same step.
 
@@ -2768,7 +2787,7 @@ where $K$ is the number of maps employed and each $\Phi_k$ is a \texttt{mapTotal
 
 \noindent\textbf{Example: transitions between macromolecular shapes using volumetric maps.}\\
 A series of map files, each representing a different shape, is loaded into NAMD:\\
-{\noindent\ttfamily
+\begin{mdexampleinput}
   \-mGridForce yes\\
   \-for \{ set k 1 \} \{ \$k <= \$K \} \{ incr k \} \{\\
   \-~~mGridForcePotFile Shape\_\$k map\_\$k.dx~~~\# Density map of the k-th state\\
@@ -2776,10 +2795,12 @@ A series of map files, each representing a different shape, is loaded into NAMD:
   \-~~mGridForceCol Shape\_\$k O~~~\# Use the occupancy column of the PDB file atoms.pdb\\
   \-~~mGridForceChargeCol Shape\_\$k B~~~\# Use beta as ``charge'' (default: electric charge)\\
   \-~~mGridForceScale Shape\_\$k 0.0 0.0 0.0~~\# Do not use GridForces for this map\\
-  \-\}\\
-}
+  \-\}
+\end{mdexampleinput}
+
+
 The GridForces maps thus loaded are then used to define the Multi-Map collective variable, with coefficients $\xi_k = k$ \cite{Fiorin2020}:\\
-{\noindent\ttfamily
+\begin{mdexampleinput}
   \-\# Collect the definition of all components into one string\\
   \-set components "\\
   \-for \{ set k 1 \} \{ \$k <= \$K \} \{ incr k \} \{\\
@@ -2795,8 +2816,9 @@ The GridForces maps thus loaded are then used to define the Multi-Map collective
   \-colvar \{\\
   \-\-~~name shapes\\
   \-\-~~\$\{components\}\\
-  \-\}"\\
-}
+  \-\}"
+\end{mdexampleinput}
+
 
 The above example illustrates a use case where a weighted sum (i.e.{} a linear combination) is used to define a single variable from multiple components.
 Depending on the problem under study, non-linear functions may be more appropriate.
@@ -3026,10 +3048,8 @@ the keyword \texttt{period}, and the optional keyword \texttt{wrapAround}, with 
 same meaning as in periodic components (see \ref{sec:cvc_periodic} for details).
 A vector variable may be defined by specifying the \texttt{customFunction} parameter several times: each expression defines one scalar element of the vector colvar, as in this example:
 
-\bigskip
-{%
-% verbatim can't appear within commands
-\noindent\ttfamily colvar \{\\
+\begin{cvexampleinput}
+\-colvar \{\\
 \-~~name custom\\
 \\
 \-~~\# A 2-dimensional vector function of a scalar x and a 3-vector r\\
@@ -3046,7 +3066,8 @@ A vector variable may be defined by specifying the \texttt{customFunction} param
 \-~~~~group1 \{ atomNumbers 10 11 12 \}\\
 \-~~~~group2 \{ atomNumbers  20 21 22 \}\\
 \-~~\}\\
-\}}
+\}
+\end{cvexampleinput}
 
 Numeric constants may be given in either decimal or exponential form (e.g. 3.12e-2).
 An expression may be followed by definitions for intermediate values that
@@ -3723,20 +3744,17 @@ However, atoms included by multiple keywords are only counted once.
 Below is an example configuration for an atom group called ``\texttt{atoms}''.
 \textbf{Note: }\emph{this is an unusually varied combination of selection keywords, demonstrating how they can be combined together: most simulations only use one of them.}\\
 
-{%
-% verbatim can't appear within commands
-\noindent\ttfamily atoms \{\\
+\begin{cvexampleinput}
+\-atoms \{\\
 \\
-\-~~\# add atoms 1 and 3 to this group (note: the first atom in the system is 1)\\
+\-~~\# add atoms 1 and 3 to this group (note: first atom in the system is 1)\\
 \-~~atomNumbers \{ \\
 \-~~~~1 3\\
 \-~~\}\\
 \\
 \-~~\# add atoms starting from 20 up to and including 50\\
 \-~~atomNumbersRange  20-50\\
-}
-\cvnamebasedonly{{%
-\noindent\ttfamily\\
+\cvnamebasedonly{%
 \-~~\# add all the atoms with occupancy 2 in the file atoms.pdb\\
 \-~~atomsFile             atoms.pdb\\
 \-~~atomsCol              O\\
@@ -3746,11 +3764,11 @@ Below is an example configuration for an atom group called ``\texttt{atoms}''.
 \-~~psfSegID              PR1 PR2\\
 \-~~atomNameResidueRange  CA 11-20\\
 \-~~atomNameResidueRange  CA 11-20\\
-}}
-{\noindent\ttfamily\\
+}
 \-~~\# add index group (requires a .ndx file to be provided globally)\\
 \-~~indexGroup Water\\
-\}\\}
+\}
+\end{cvexampleinput}
 
 
 The resulting selection includes atoms 1 and 3, those between 20 and 50,\cvnamebasedonly{ the $\mathrm{C}_{\alpha}$ atoms between residues 11 and 20 of the two segments \texttt{PR1} and \texttt{PR2},} and those in the index group called ``Water''.
@@ -3966,7 +3984,9 @@ Be careful when using these options in ABF simulations or when using total force
     Block \texttt{fittingGroup \{ ... \}}}{%
     This atom group itself}{%
     If either \texttt{centerReference} or \texttt{rotateReference} is defined, this keyword defines an alternate atom group to calculate the optimal roto-translation.
-    Use this option to define a continuous rotation if the structure of the group involved changes significantly (a typical symptom would be the message ``Warning: discontinuous rotation!'').
+    Use this option to define a continuous rotation if the structure of the group involved changes significantly (a typical symptom would be the message ``Warning: discontinuous rotation!'').}
+
+\end{itemize}
 
 \cvnamebasedonly{
     The following example illustrates the use of \texttt{fittingGroup} as part of a Distance to Bound Configuration (DBC)
@@ -3974,11 +3994,10 @@ Be careful when using these options in ABF simulations or when using total force
     The group called ``\texttt{atoms}'' describes coordinates of a ligand's atoms, expressed in a moving frame of
     reference tied to a binding site (here within a protein).
     An optimal roto-translation is calculated automatically by fitting the C$_{\alpha}$ trace of the rest of the protein onto the coordinates provided by a PDB file.
-    To define a DBC coordinate, this atom group would be used within an \refkey{rmsd}{sec:cvc_rmsd} function.}
+    To define a DBC coordinate, this atom group would be used within an \refkey{rmsd}{sec:cvc_rmsd} function.
 
-{%
-\noindent\ttfamily
-\# Example: defining a group "atoms" (the ligand) whose coordinates are expressed \\
+\begin{cvexampleinput}
+\-\# Example: defining a group "atoms" (the ligand) whose coordinates are expressed \\
 \# in a roto-translated frame of reference defined by a second group (the receptor)\\
 atoms \{\\
 \\
@@ -3994,9 +4013,9 @@ atoms \{\\
 \-~~~~atomNameResidueRange  CA 59-100\\
 \-~~\} \\
 \-~~refPositionsFile all.pdb  \# can be the entire system\\
-\}\\}
+\}
+\end{cvexampleinput}
 }
-\end{itemize}
 
 The following two options have default values appropriate for the vast majority of applications, and are only provided to support rare, special cases.
 \begin{itemize}
@@ -4110,15 +4129,15 @@ To gain an estimate of the computational cost of a large colvar, one can use a t
 
 A biasing or analysis method can be applied to existing collective variables by using the following configuration:
 
-{\bigskip\noindent\ttfamily
-$<$biastype$>$ \{\\
+\begin{cvexampleinput}
+\-$<$biastype$>$ \{\\
 \-~~name $<$name$>$ \\
 \-~~colvars $<$xi1$>$ $<$xi2$>$ ...\\
 \-~~$<$parameters$>$\\
-\}\\
-}
+\}
+\end{cvexampleinput}
 
-\noindent{} The keyword \texttt{$<$biastype$>$} indicates the method of choice.
+\noindent{}The keyword \texttt{$<$biastype$>$} indicates the method of choice.
 There can be multiple instances of the same method, e.g.{} using multiple \texttt{harmonic} blocks allows defining multiple restraints.
 
 All biasing and analysis methods implemented recognize the following options:
@@ -4865,8 +4884,7 @@ Unfortunately, processing explicit hills alongside the potential and force grids
 In general, it is a good idea to \emph{define a repulsive potential to avoid hills from coming too close to the grid's boundaries}, for example as a \texttt{harmonicWalls} restraint (see \ref{sec:colvarbias_harmonic_walls}).\\
 
 \noindent\textbf{Example:} Using harmonic walls to protect the grid's boundaries.
-{\noindent\ttfamily
-\\
+\begin{cvexampleinput}
 \-colvar \{\\
 \-\-~~name r\\
 \-\-~~distance \{ ... \}\\
@@ -4886,8 +4904,8 @@ In general, it is a good idea to \emph{define a repulsive potential to avoid hil
 \-\-~~colvars r\\
 \-\-~~upperWalls 13.0\\
 \-\-~~upperWallConstant 2.0\\
-\-\}\\
-}
+\-\}
+\end{cvexampleinput}
 
 In the colvar \texttt{r}, the \texttt{distance} function used has a \texttt{lowerBoundary} automatically set to 0~\AA{} by default, thus the keyword \texttt{lowerBoundary} itself is not mandatory and \texttt{hardLowerBoundary} is set to \texttt{yes} internally.
 However, \texttt{upperBoundary} does not have such a ``natural'' choice of value.
@@ -5164,8 +5182,7 @@ Instead, multiple probability distributions on different variables can be target
 \\
 
 \noindent\textbf{Example:} EBmetaD configuration for a single variable.
-{\noindent\ttfamily
-\\
+\begin{cvexampleinput}
 \-colvar \{\\
 \-\-~~name r \\
 \-\-~~distance \{\\
@@ -5184,8 +5201,8 @@ Instead, multiple probability distributions on different variables can be target
 \-\-~~ebMeta            on\\
 \-\-~~targetDistFile    targetdist1.dat\\
 \-\-~~ebMetaEquilSteps  500000\\
-\-\}\\
-}
+\-\}
+\end{cvexampleinput}
 
 \noindent{}where \texttt{targetdist1.dat} is a text file in ``multicolumn'' format (\ref{sec:colvar_multicolumn_grid}) with the same \texttt{width} as the variable \texttt{r} (0.1 in this case):\\
 \begin{tabular}{l l l l l l}
@@ -5257,7 +5274,7 @@ In between the times when this file is modified/replaced, new hills are also tem
 Both files are only used for communication, and may be deleted after the replica begins writing files with a new \outputName.\\
 
 \noindent\textbf{Example:} Multiple-walker metadynamics with file-based communication.\\
-{\noindent\ttfamily
+\begin{cvexampleinput}
 \-metadynamics \{\\
 \-\-~~name mymtd\\
 \-\-~~colvars x\\
@@ -5268,8 +5285,8 @@ Both files are only used for communication, and may be deleted after the replica
 \-\-~~multipleReplicas       on\\
 \-\-~~replicasRegistry       /shared-folder/mymtd-replicas.txt\\
 \-\-~~replicaUpdateFrequency 50000  \# Best if larger than newHillFrequency\\
-\-\}\\
-}
+\-\}
+\end{cvexampleinput}
 
 The following are the multiple-walkers related options:
 
@@ -5701,8 +5718,7 @@ The \texttt{harmonicWalls} bias implements the following options:
 \end{itemize}
 
 \noindent\textbf{Example 1:} harmonic walls for one variable with two different force constants.
-{\noindent\ttfamily
-\\
+\begin{cvexampleinput}
 \-harmonicWalls \{\\
 \-\-~~name  mywalls\\
 \-\-~~colvars    dist\\
@@ -5710,22 +5726,19 @@ The \texttt{harmonicWalls} bias implements the following options:
 \-\-~~upperWalls  38.0 \\
 \-\-~~lowerWallConstant  2.0 \\
 \-\-~~upperWallConstant 10.0 \\
-\-\}\\
-}
+\-\}
+\end{cvexampleinput}
 
 \noindent\textbf{Example 2:} harmonic walls for two variables with a single force constant.
-{\noindent\ttfamily
-\\
+\begin{cvexampleinput}
 \-harmonicWalls \{\\
 \-\-~~name  mywalls\\
 \-\-~~colvars       phi    psi\\
 \-\-~~lowerWalls -180.0    0.0\\
 \-\-~~upperWalls    0.0  180.0\\
 \-\-~~forceConstant 5.0 \\
-\-\}\\
-}
-
-
+\-\}
+\end{cvexampleinput}
 
 
 \cvsubsec{Linear restraints}{sec:colvarbias_linear}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -95,10 +95,10 @@ Detailed explanations of the design of the Colvars module are provided in refere
 
 
 \cvvmdonly{
-\paragraph*{Using the Colvars Module in VMD}
-Within VMD, the Colvars Module can be accessed in two ways:
+\paragraph*{Using the Colvars module in VMD}
+Within VMD, the Colvars module can be accessed in two ways:
 \begin{itemize}
- \item Using the Colvars dashboard, an intuitive, but partial interface to the Colvars module, to easily define and analyze \textbf{collective variables, but not biases} (section~\ref{sec:dashboard}).
+ \item Using the Colvars Dashboard, an intuitive, but partial interface to the Colvars module, to easily define and analyze \textbf{collective variables, but not biases} (section~\ref{sec:dashboard}).
  \item Using the full-featured Tcl scripting interface as documented in section~\ref{sec:cv_scripting}; see in particular the example in section~\ref{sec:cv_command_vmd_traj}.
 \end{itemize}
 }
@@ -107,8 +107,8 @@ Within VMD, the Colvars Module can be accessed in two ways:
 
 The Colvars configuration is a plain text file or string that defines collective variables, biases, and general parameters of the Colvars module.
 It is passed to the module using back-end-specific commands documented in section \ref{sec:colvarmodule}.
-\cvvmdonly{Writing the configuration fora  collective variable in VMD is made much easier using the dashboard and its configuration editor (section~\ref{sec:dashboard}).
-However, note that the dashboard does not handle biases: if necessary, they should be managed separately using the scripting interface.}
+\cvvmdonly{Writing the configuration fora  collective variable in VMD is made much easier using the Dashboard and its configuration editor (section~\ref{sec:dashboard}).
+However, note that the Dashboard does not handle biases: if necessary, they should be managed separately using the scripting interface.}
 
 
 \paragraph*{Example: steering two atoms away from each other.}
@@ -211,7 +211,7 @@ histogram \{\\
 \cvvmdonly{
 \cvsec{The Colvars dashboard}{sec:dashboard}
 
-The Colvars dashboard is a graphical interface for interactive visualization and refinement of collective variables aided by molecular structures and trajectories.
+The Colvars Dashboard is a graphical interface for interactive visualization and refinement of collective variables aided by molecular structures and trajectories.
 It is accessible in VMD's Main Menu under ``Extensions/Analysis/Colvars Dashboard''.
 Throughout the interface, keyboard shortcuts for common operations are indicated in square brackets.
 
@@ -240,16 +240,16 @@ By default the frame is updated to track VMD's currently displayed frame, but th
 Vector-values variables can be expanded to list their scalar elements. This is necessary when individual scalar quantities have to be selected for plotting.
 Other operations act on variables as a whole and ignore specific selected scalar elements.
 
-Buttons above the table allow for general operations on the state of the Colvars Module.
+Buttons above the table allow for general operations on the state of the Colvars module.
 Buttons below the table offer operations on selected variables.
 
-If several molecules are loaded, the dashboard only interacts with the molecule labeled "top" (T in VMD's main window).
-If the top molecule is changed, the Colvars Module needs to be reset using the Reset button.
+If several molecules are loaded, the Dashboard only interacts with the molecule labeled "top" (T in VMD's main window).
+If the top molecule is changed, the Colvars module needs to be reset using the Reset button.
 This will remove all current definitions, so make sure to save the variables to a file beforehand.
 
 If variables are modified, added or deleted interactively or by an external script, hit ``Refresh'' or press F5 to update the displayed variables and values.
-Starting the dashboard also enables trajectory animation using the left/right arrow keys within VMD's graphical window.
-Atomic coordinates can be modified using VMD's ``Mouse/Move'' functions, and the Colvars Module can then be updated by pressing F5 directly from the graphical window.
+Starting the Dashboard also enables trajectory animation using the left/right arrow keys within VMD's graphical window.
+Atomic coordinates can be modified using VMD's ``Mouse/Move'' functions, and the Colvars module can then be updated by pressing F5 directly from the graphical window.
 
 A dropdown list allows for changing the current unit system if no variables are defined.
 If some variables are already defined, it is recommended to edit the configuration for all of
@@ -265,7 +265,7 @@ Auto-updating selections (see below) can be used to adapt the colvar definitions
 \cvsubsec{Loading / Saving configuration files}{sec:dashboard_load_save}
 
 This saves the configuration of all defined collective variables to a file.
-Neither biases, nor general parameters of the Colvars Module are saved: editing them is beyond the scope of the dashboard.
+Neither biases, nor general parameters of the Colvars module are saved: editing them is beyond the scope of the Dashboard.
 We recommend keeping them in separate configuration files, and reading them separately in biased MD simulations.
 
 \cvsubsec{The configuration editor}{sec:dashboard_config_editor}
@@ -336,7 +336,7 @@ The ``internal units'' of the Colvars module are the units in which values are e
 Generally \textbf{the Colvars module uses internally the same units as its back-end MD engine, with the exception of VMD}, where different unit sets are supported to allow for easy setup, visualization and analysis of Colvars simulations performed with any simulation engine.
 
 Note that \textbf{angles} are expressed in degrees, and derived quantites such as force constants are based on degrees as well. 
-Atomic coordinates read from \textbf{XYZ files} (and PDB files where applicable) are expected to be expressed in \AA{}ngstr\"om, no matter what unit system is in use by the back-end or the Colvars Module.
+Atomic coordinates read from \textbf{XYZ files} (and PDB files where applicable) are expected to be expressed in \AA{}ngstr\"om, no matter what unit system is in use by the back-end or the Colvars module.
 
 To avoid errors due to reading configuration files written in a different unit system, it can be specified within the input:
 

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -24,7 +24,7 @@
 \usepackage{transparent}
 
 % Example code blocks
-\usepackage{xcolor}
+\usepackage{xcolor} % Needed for HTML version
 \usepackage{mdframed}
 
 \definecolor{cvexample-border-color}{rgb}{0.5,0.0,0.5}
@@ -142,9 +142,56 @@
 \newcommand{\vx}{{\mbox{\boldmath{$x$}}}}
 \newcommand{\bm}[1]{{\mbox{\boldmath{$#1$}}}}
 
-\newcommand{\cvsec}[2]{\newpage\noindent\hypertarget{#2}{\section{#1}}\label{#2}\ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi}
-\newcommand{\cvsubsec}[2]{\noindent\hypertarget{#2}{\subsection{#1}}\label{#2}\ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi}
-\newcommand{\cvsubsubsec}[2]{\noindent\hypertarget{#2}{\subsubsection{#1}}\label{#2}\ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi}
+
+\newcommand{\cvsec}[2]{%
+  \newpage
+  \ifdefined\HCode
+  \HCode{<div class="heading">} % Use CSS, mdframed won't work for this
+  \else
+  \begin{mdframed}[backgroundcolor=background-color,linewidth=2pt]
+  \fi
+  \hypertarget{#2}{\section{#1}}
+  \ifdefined\HCode
+  \HCode{</div>}
+  \else
+  \end{mdframed}
+  \fi
+  \label{#2}
+  \ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi
+}
+
+\newcommand{\cvsubsec}[2]{%
+  \ifdefined\HCode
+  \HCode{<div class="heading">}
+  \else
+  \begin{mdframed}[backgroundcolor=background-color,linewidth=2pt]
+  \fi
+  \hypertarget{#2}{\subsection{#1}}
+  \ifdefined\HCode
+  \HCode{</div>}
+  \else
+  \end{mdframed}
+  \fi
+  \label{#2}
+  \ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi
+}
+
+\newcommand{\cvsubsubsec}[2]{%
+  \ifdefined\HCode
+  \HCode{<div class="heading">}
+  \else
+  \begin{mdframed}[backgroundcolor=background-color,linewidth=2pt]
+  \fi
+  \hypertarget{#2}{\subsubsection{#1}}
+  \ifdefined\HCode
+  \HCode{</div>}
+  \else
+  \end{mdframed}
+  \fi
+  \label{#2}
+  \ifdefined\HCode\HCode{<selfref>}\ref{#2}\HCode{</selfref>}\fi
+}
+
 \newcommand{\cvurl}[1]{\url{#1}}
 
 \input{colvars-refman-main}

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -23,6 +23,32 @@
 \definecolor{background-color}{gray}{0.84}
 \usepackage{transparent}
 
+% Example code blocks
+\usepackage{xcolor}
+\usepackage{mdframed}
+
+\definecolor{cvexample-border-color}{rgb}{0.5,0.0,0.5}
+\definecolor{cvexample-background-color}{rgb}{1.0,0.95,1.0}
+\newenvironment{cvexampleinput}{%
+  \begin{mdframed}[%
+      linecolor=cvexample-border-color,linewidth=2pt,%
+      backgroundcolor=cvexample-background-color]
+  \ifdefined\HCode\HCode{<pre>}\else\begin{ttfamily}\fi}{%
+  \ifdefined\HCode\HCode{</pre>}\else\end{ttfamily}\fi
+  \end{mdframed}
+}
+
+\definecolor{mdexample-border-color}{rgb}{1.0,0.6,0.1}
+\definecolor{mdexample-background-color}{rgb}{1.0,0.96,0.9}
+\newenvironment{mdexampleinput}{%
+  \begin{mdframed}[%
+      linecolor=mdexample-border-color,linewidth=2pt,%
+      backgroundcolor=mdexample-background-color]
+  \ifdefined\HCode\HCode{<pre>}\else\begin{ttfamily}\fi}{%
+  \ifdefined\HCode\HCode{</pre>}\else\end{ttfamily}\fi
+  \end{mdframed}
+}
+
 % for code-specific macros
 \usepackage{comment}
 


### PR DESCRIPTION
There are very few examples in the Colvars guide, thus it is easy to miss them especially in the HTML version: Tex4ht ignores the `\ttfamily` directive and just formats everything the same (text and code).  This ends up being not only harmful to the copy-pasters (not an issue in my view), but also to those who are genuinely reading the doc.

This PR introduces two new LaTeX environments, `mdexampleinput` for examples of input of the hosting engine, and `cvexampleinput` for Colvars configuration examples. They are colored differently (orange and purple, respectively) to more quickly differentiate the two.

Both environments also contain explicit `<pre>` tags when the HTML version is compiled, to prevent Tex4ht from trying to be smart about the fonts and ending up doing the dumb thing. 

All the examples that I could find on a quick look (again, **we know** that there aren't many!) are now formatted with the new environments.  I purposefully left alone the scripting API examples (one section that actually contains a high density of examples), because I'm working on that section in another branch.