### PR TITLE
Implement global map of components

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -18,7 +18,9 @@
 #include "colvarcomp.h"
 #include "colvarscript.h"
 
-
+#if (__cplusplus >= 201103L)
+std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> colvar::global_cvc_map = std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>>();
+#endif
 
 colvar::colvar()
 {
@@ -724,15 +726,15 @@ int colvar::init_output_flags(std::string const &conf)
   return COLVARS_OK;
 }
 
-
-
-
 // read the configuration and set up corresponding instances, for
 // each type of component implemented
 template<typename def_class_name> int colvar::init_components_type(std::string const &conf,
                                                                    char const * /* def_desc */,
                                                                    char const *def_config_key)
 {
+#if (__cplusplus >= 201103L)
+  global_cvc_map[def_config_key] = [](const std::string& cvc_conf){return new def_class_name(cvc_conf);};
+#endif
   size_t def_count = 0;
   std::string def_conf = "";
   size_t pos = 0;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -12,6 +12,11 @@
 
 #include <iostream>
 
+#if (__cplusplus >= 201103L)
+#include <map>
+#include <functional>
+#endif
+
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 #include "colvarparse.h"
@@ -114,6 +119,7 @@ public:
 
   /// List of biases that depend on this colvar
   std::vector<colvarbias *> biases;
+
 protected:
 
 
@@ -605,6 +611,14 @@ public:
   // components that do not handle any atoms directly
   class map_total;
 
+  /// getter of the global cvc map
+#if (__cplusplus >= 201103L)
+  /// A global mapping of cvc names to the cvc constructors
+  static const std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>>& get_global_cvc_map() {
+      return global_cvc_map;
+  }
+#endif
+
 protected:
 
   /// \brief Array of \link colvar::cvc \endlink objects
@@ -637,6 +651,11 @@ protected:
 
   /// Unused value that is written to when a variable simplifies out of a Lepton expression
   double dev_null;
+#endif
+
+#if (__cplusplus >= 201103L)
+  /// A global mapping of cvc names to the cvc constructors
+  static std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> global_cvc_map;
 #endif
 
 public:

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -1493,8 +1493,6 @@ class colvar::linearCombination
   : public colvar::cvc
 {
 protected:
-    /// Map from string to the types of colvar components
-    std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> string_cv_map;
     /// Sub-colvar components
     std::vector<colvar::cvc*> cv;
     /// If all sub-cvs use explicit gradients then we also use it
@@ -1514,8 +1512,6 @@ class colvar::CVBasedPath
   : public colvar::cvc
 {
 protected:
-    /// Map from string to the types of colvar components
-    std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> string_cv_map;
     /// Sub-colvar components
     std::vector<colvar::cvc*> cv;
     /// Reference colvar values from path

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -19,10 +19,6 @@
 #include "colvar.h"
 #include "colvarcomp.h"
 
-namespace GeometricPathCV {
-void init_string_cv_map(std::map<std::string, std::function<colvar::cvc* (const std::string& conf)>>& string_cv_map);
-}
-
 bool compareColvarComponent(colvar::cvc *i, colvar::cvc *j)
 {
     return i->name < j->name;
@@ -406,9 +402,8 @@ void colvar::gzpath::apply_force(colvarvalue const &force) {
 }
 
 colvar::linearCombination::linearCombination(std::string const &conf): cvc(conf) {
-    GeometricPathCV::init_string_cv_map(string_cv_map);
     // Lookup all available sub-cvcs
-    for (auto it_cv_map = string_cv_map.begin(); it_cv_map != string_cv_map.end(); ++it_cv_map) {
+    for (auto it_cv_map = colvar::get_global_cvc_map().begin(); it_cv_map != colvar::get_global_cvc_map().end(); ++it_cv_map) {
         if (key_lookup(conf, it_cv_map->first.c_str())) {
             std::vector<std::string> sub_cvc_confs;
             get_key_string_multi_value(conf, it_cv_map->first.c_str(), sub_cvc_confs);
@@ -506,9 +501,8 @@ void colvar::linearCombination::apply_force(colvarvalue const &force) {
 }
 
 colvar::CVBasedPath::CVBasedPath(std::string const &conf): cvc(conf) {
-    GeometricPathCV::init_string_cv_map(string_cv_map);
     // Lookup all available sub-cvcs
-    for (auto it_cv_map = string_cv_map.begin(); it_cv_map != string_cv_map.end(); ++it_cv_map) {
+    for (auto it_cv_map = colvar::get_global_cvc_map().begin(); it_cv_map != colvar::get_global_cvc_map().end(); ++it_cv_map) {
         if (key_lookup(conf, it_cv_map->first.c_str())) {
             std::vector<std::string> sub_cvc_confs;
             get_key_string_multi_value(conf, it_cv_map->first.c_str(), sub_cvc_confs);
@@ -907,35 +901,6 @@ void colvar::gzpathCV::apply_force(colvarvalue const &force) {
             cv[i_cv]->apply_force(cv_force);
         }
     }
-}
-
-void GeometricPathCV::init_string_cv_map(std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>>& string_cv_map) {
-    string_cv_map["distance"]              = [](const std::string& conf){return new colvar::distance(conf);};
-    string_cv_map["dihedral"]              = [](const std::string& conf){return new colvar::dihedral(conf);};
-    string_cv_map["angle"]                 = [](const std::string& conf){return new colvar::angle(conf);};
-    string_cv_map["rmsd"]                  = [](const std::string& conf){return new colvar::rmsd(conf);};
-    string_cv_map["gyration"]              = [](const std::string& conf){return new colvar::gyration(conf);};
-    string_cv_map["inertia"]               = [](const std::string& conf){return new colvar::inertia(conf);};
-    string_cv_map["inertiaZ"]              = [](const std::string& conf){return new colvar::inertia_z(conf);};
-    string_cv_map["tilt"]                  = [](const std::string& conf){return new colvar::tilt(conf);};
-    string_cv_map["distanceZ"]             = [](const std::string& conf){return new colvar::distance_z(conf);};
-    string_cv_map["distanceXY"]            = [](const std::string& conf){return new colvar::distance_xy(conf);};
-    string_cv_map["polarTheta"]            = [](const std::string& conf){return new colvar::polar_theta(conf);};
-    string_cv_map["polarPhi"]              = [](const std::string& conf){return new colvar::polar_phi(conf);};
-    string_cv_map["distanceVec"]           = [](const std::string& conf){return new colvar::distance_vec(conf);};
-    string_cv_map["orientationAngle"]      = [](const std::string& conf){return new colvar::orientation_angle(conf);};
-    string_cv_map["distancePairs"]         = [](const std::string& conf){return new colvar::distance_pairs(conf);};
-    string_cv_map["dipoleMagnitude"]       = [](const std::string& conf){return new colvar::dipole_magnitude(conf);};
-    string_cv_map["coordNum"]              = [](const std::string& conf){return new colvar::coordnum(conf);};
-    string_cv_map["selfCoordNum"]          = [](const std::string& conf){return new colvar::selfcoordnum(conf);};
-    string_cv_map["dipoleAngle"]           = [](const std::string& conf){return new colvar::dipole_angle(conf);};
-    string_cv_map["orientation"]           = [](const std::string& conf){return new colvar::orientation(conf);};
-    string_cv_map["orientationProj"]       = [](const std::string& conf){return new colvar::orientation_proj(conf);};
-    string_cv_map["eigenvector"]           = [](const std::string& conf){return new colvar::eigenvector(conf);};
-    string_cv_map["cartesian"]             = [](const std::string& conf){return new colvar::cartesian(conf);};
-    string_cv_map["alpha"]                 = [](const std::string& conf){return new colvar::alpha_angles(conf);};
-    string_cv_map["dihedralPC"]            = [](const std::string& conf){return new colvar::dihedPC(conf);};
-    string_cv_map["linearCombination"]     = [](const std::string& conf){return new colvar::linearCombination(conf);};
 }
 
 #endif


### PR DESCRIPTION
Fix #257. This implementation adds an static cvc map in the colvar
class, and populates the map when calling init_components_type, so we do
not need to fill the map by copy and paste. It should be noted that this
implementation requires C++11.