### PR TITLE
Enforce and document XYZ file format

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -878,7 +878,84 @@ The values of the atomic coordinates and other fields, such as occupancy or temp
 PDB files may be used either as one of the available mechanisms to select atoms (see the \refkey{atomsFile}{atom-group|atomsFile} keyword), or more frequently to read reference coordinates for least-squares fit alignment (see the \refkey{atomsFile}{atom-group|refPositionsFile} keyword).
 }
 
-% TODO Move multicolumn format here?
+
+\cvsubsubsec{Grid files: multicolumn text format}{sec:colvar_multicolumn_grid}
+
+Many simulation methods and analysis tools write files that contain functions of the collective variables tabulated on a grid (e.g.{} potentials of mean force or multidimentional histograms) for the purpose of analyzing results.
+Such files are produced by ABF (\ref{sec:colvarbias_abf}), metadynamics (\ref{sec:colvarbias_meta}), multidimensional histograms (\ref{sec:colvarbias_histogram}), as well as any restraint with optional thermodynamic integration support (\ref{sec:colvarbias_ti}).
+
+In some cases, these files may also be read as input of a new simulation.
+Suitable input files for this purpose are typically generated as output files of previous simulations, or directly by the user in the specific case of ensemble-biased metadynamics (\ref{sec:colvarbias_ebmeta}).
+This section explains the ``multicolumn'' format used by these files.
+For a multidimensional function $f(\xi_{1}$, $\xi_{2}$, \ldots $)$ the multicolumn grid format is defined as follows:\\
+
+\begin{tabular}{l l l l l l l}
+\# & $N_{\mathrm{cv}}$ & & & & \\
+\# & $\mathtt{min}(\xi_{1})$ & $\mathtt{width}(\xi_{1})$ & $\mathtt{npoints}({\xi_{1}})$ & $\mathtt{periodic}({\xi_{1}})$ \\
+\# & $\mathtt{min}(\xi_{2})$ & $\mathtt{width}(\xi_{2})$ & $\mathtt{npoints}({\xi_{2}})$ & $\mathtt{periodic}({\xi_{2}})$ \\
+\# & \ldots & \ldots & \ldots & \ldots \\
+\# & $\mathtt{min}(\xi_{N_{\mathrm{cv}}})$ & $\mathtt{width}(\xi_{N_{\mathrm{cv}}})$ & $\mathtt{npoints}({\xi_{N_{\mathrm{cv}}}})$ & $\mathtt{periodic}({\xi_{N_{\mathrm{cv}}}})$ & \\
+\\
+& $\xi^{1}_{1}$ & $\xi^{1}_{2}$ & \ldots & $\xi^{1}_{N_{\mathrm{cv}}}$ & f($\xi^{1}_{1}$, $\xi^{1}_{2}$, \ldots, $\xi^{1}_{N_{\mathrm{cv}}}$) & \\
+& $\xi^{1}_{1}$ & $\xi^{1}_{2}$ & \ldots & $\xi^{2}_{N_{\mathrm{cv}}}$ & f($\xi^{1}_{1}$, $\xi^{1}_{2}$, \ldots, $\xi^{2}_{N_{\mathrm{cv}}}$) \\
+& \ldots & \ldots & \ldots & \ldots & \ldots \\
+\\
+\end{tabular}
+
+\noindent{}Lines beginning with the character ``\texttt{\#}'' are the header of the file.
+$N_{\mathrm{cv}}$ is the number of collective variables sampled by the grid.
+For each variable $\xi_{i}$, $\mathtt{min}(\xi_{i})$ is the lowest value sampled by the grid (i.e.{} the left-most boundary of the grid along $\xi_{i}$), $\mathtt{width}(\xi_{i})$ is the width of each grid step along $\xi_{i}$, $\mathtt{npoints}(\xi_{i})$ is the number of points and $\mathtt{periodic}(\xi_{i})$ is a flag whose value is 1 or 0 depending on whether the grid is periodic along $\xi_{i}$.
+In most situations:
+\begin{itemize}
+\item $\mathtt{min}(\xi_{i})$ is given by the \refkey{lowerBoundary}{colvar|lowerBoundary} keyword of the variable $\xi_{i}$;
+\item $\mathtt{width}(\xi_{i})$ is given by the \refkey{width}{colvar|width} keyword;
+\item $\mathtt{npoints}(\xi_{i})$ is calculated from the two above numbers and the \refkey{upperBoundary}{colvar|upperBoundary} keyword;
+\item $\mathtt{periodic}(\xi_{i})$ is set to 1 if and only if $\xi_{i}$ is periodic and the grids' boundaries cover its period.
+\end{itemize}
+\textbf{Exception:} there is a slightly different header in PMF files computed by ABF (\ref{sec:colvarbias_abf}) or by other biases with an optional thermodynamic integration (TI) estimator (\ref{sec:colvarbias_ti}).
+In this case, free-energy gradients are accumulated on an \texttt{(npoints)}-long grid along each variable $\xi$: after these gradients are integrated, the resulting PMF is discretized on a grid with \texttt{(npoints+1)} points along $\xi$.
+Therefore, the edges of the PMF's grid extend $\mathtt{width}/2$ above and below the original boundaries (unless these are periodic).  The format of the file's header is otherwise unchanged.
+
+After the header, the rest of the file contains values of the tabulated function
+$f(\xi_{1}$, $\xi_{2}$, \ldots $\xi_{N_{\mathrm{cv}}})$, one for each line.
+The first $N_{\mathrm{cv}}$ columns contain values of $\xi_{1}$, $\xi_{2}$, \ldots $\xi_{N_{\mathrm{cv}}}$ and the last column contains the value of the function $f$.
+Points are sorted in ascending order with the fastest-changing values at the right (``C-style'' order).
+Each sweep of the right-most variable $\xi_{N_{\mathrm{cv}}}$ is terminated by an empty line.
+For two dimensional grid files, this allows quick visualization by programs such as GNUplot.
+\\
+
+\noindent\textbf{Example 1:} multicolumn text file for a one-dimensional histogram with \texttt{lowerBoundary} = 15, \texttt{upperBoundary} = 48 and \texttt{width} = 0.1.
+
+\begin{tabular}{l l l l l l}
+\\
+\# & \texttt{1} & & & & \\
+\# & \texttt{15} & \texttt{0.1} & \texttt{330} & \texttt{0} \\
+\\
+& \texttt{15.05} & \texttt{6.14012e-07} & & & \\
+& \texttt{15.15} & \texttt{7.47644e-07} & & & \\
+& \ldots & \ldots & & & \\
+& \texttt{47.85} & \texttt{1.65944e-06} & & & \\
+& \texttt{47.95} & \texttt{1.46712e-06} & & & \\
+\\
+\end{tabular}
+
+\noindent\textbf{Example 2:} multicolumn text file for a two-dimensional histogram of two dihedral angles (periodic interval with 6$^\circ$ bins):
+
+\begin{tabular}{l l l l l l}
+& & & & \\
+\# & \texttt{2} & & & & \\
+\# & \texttt{-180.0} & \texttt{6.0} & \texttt{30} & \texttt{1} \\
+\# & \texttt{-180.0} & \texttt{6.0} & \texttt{30} & \texttt{1} \\
+\\
+& \texttt{-177.0} & \texttt{-177.0} & \texttt{8.97117e-06} & & \\
+& \texttt{-177.0} & \texttt{-171.0} & \texttt{1.53525e-06} & & \\
+& \ldots & \ldots & \ldots & & \\
+& \texttt{-177.0} & \texttt{ 177.0} & \texttt{2.442956-06} & & \\
+\\
+& \texttt{-171.0} & \texttt{-177.0} & \texttt{2.04702e-05} & & \\
+& \ldots & \ldots & \ldots & & \\
+\end{tabular}
+
 
 
 \cvsec{Defining collective variables}{sec:colvar}
@@ -3372,83 +3449,6 @@ The parameters described below offer a way to specify these parameters only once
 
 \end{itemize}
 
-
-\cvsubsubsec{Grid files: multicolumn text format}{sec:colvar_multicolumn_grid}
-
-Many simulation methods and analysis tools write files that contain functions of the collective variables tabulated on a grid (e.g.{} potentials of mean force or multidimentional histograms) for the purpose of analyzing results.
-Such files are produced by ABF (\ref{sec:colvarbias_abf}), metadynamics (\ref{sec:colvarbias_meta}), multidimensional histograms (\ref{sec:colvarbias_histogram}), as well as any restraint with optional thermodynamic integration support (\ref{sec:colvarbias_ti}).
-
-In some cases, these files may also be read as input of a new simulation.
-Suitable input files for this purpose are typically generated as output files of previous simulations, or directly by the user in the specific case of ensemble-biased metadynamics (\ref{sec:colvarbias_ebmeta}).
-This section explains the ``multicolumn'' format used by these files.
-For a multidimensional function $f(\xi_{1}$, $\xi_{2}$, \ldots $)$ the multicolumn grid format is defined as follows:\\
-
-\begin{tabular}{l l l l l l l}
-\# & $N_{\mathrm{cv}}$ & & & & \\
-\# & $\mathtt{min}(\xi_{1})$ & $\mathtt{width}(\xi_{1})$ & $\mathtt{npoints}({\xi_{1}})$ & $\mathtt{periodic}({\xi_{1}})$ \\
-\# & $\mathtt{min}(\xi_{2})$ & $\mathtt{width}(\xi_{2})$ & $\mathtt{npoints}({\xi_{2}})$ & $\mathtt{periodic}({\xi_{2}})$ \\
-\# & \ldots & \ldots & \ldots & \ldots \\
-\# & $\mathtt{min}(\xi_{N_{\mathrm{cv}}})$ & $\mathtt{width}(\xi_{N_{\mathrm{cv}}})$ & $\mathtt{npoints}({\xi_{N_{\mathrm{cv}}}})$ & $\mathtt{periodic}({\xi_{N_{\mathrm{cv}}}})$ & \\
-\\
-& $\xi^{1}_{1}$ & $\xi^{1}_{2}$ & \ldots & $\xi^{1}_{N_{\mathrm{cv}}}$ & f($\xi^{1}_{1}$, $\xi^{1}_{2}$, \ldots, $\xi^{1}_{N_{\mathrm{cv}}}$) & \\
-& $\xi^{1}_{1}$ & $\xi^{1}_{2}$ & \ldots & $\xi^{2}_{N_{\mathrm{cv}}}$ & f($\xi^{1}_{1}$, $\xi^{1}_{2}$, \ldots, $\xi^{2}_{N_{\mathrm{cv}}}$) \\
-& \ldots & \ldots & \ldots & \ldots & \ldots \\
-\\
-\end{tabular}
-
-\noindent{}Lines beginning with the character ``\texttt{\#}'' are the header of the file.
-$N_{\mathrm{cv}}$ is the number of collective variables sampled by the grid.
-For each variable $\xi_{i}$, $\mathtt{min}(\xi_{i})$ is the lowest value sampled by the grid (i.e.{} the left-most boundary of the grid along $\xi_{i}$), $\mathtt{width}(\xi_{i})$ is the width of each grid step along $\xi_{i}$, $\mathtt{npoints}(\xi_{i})$ is the number of points and $\mathtt{periodic}(\xi_{i})$ is a flag whose value is 1 or 0 depending on whether the grid is periodic along $\xi_{i}$.
-In most situations:
-\begin{itemize}
-\item $\mathtt{min}(\xi_{i})$ is given by the \refkey{lowerBoundary}{colvar|lowerBoundary} keyword of the variable $\xi_{i}$;
-\item $\mathtt{width}(\xi_{i})$ is given by the \refkey{width}{colvar|width} keyword;
-\item $\mathtt{npoints}(\xi_{i})$ is calculated from the two above numbers and the \refkey{upperBoundary}{colvar|upperBoundary} keyword;
-\item $\mathtt{periodic}(\xi_{i})$ is set to 1 if and only if $\xi_{i}$ is periodic and the grids' boundaries cover its period.
-\end{itemize}
-\textbf{Exception:} there is a slightly different header in PMF files computed by ABF (\ref{sec:colvarbias_abf}) or by other biases with an optional thermodynamic integration (TI) estimator (\ref{sec:colvarbias_ti}).
-In this case, free-energy gradients are accumulated on an \texttt{(npoints)}-long grid along each variable $\xi$: after these gradients are integrated, the resulting PMF is discretized on a grid with \texttt{(npoints+1)} points along $\xi$.
-Therefore, the edges of the PMF's grid extend $\mathtt{width}/2$ above and below the original boundaries (unless these are periodic).  The format of the file's header is otherwise unchanged.
-
-After the header, the rest of the file contains values of the tabulated function
-$f(\xi_{1}$, $\xi_{2}$, \ldots $\xi_{N_{\mathrm{cv}}})$, one for each line.
-The first $N_{\mathrm{cv}}$ columns contain values of $\xi_{1}$, $\xi_{2}$, \ldots $\xi_{N_{\mathrm{cv}}}$ and the last column contains the value of the function $f$.
-Points are sorted in ascending order with the fastest-changing values at the right (``C-style'' order).
-Each sweep of the right-most variable $\xi_{N_{\mathrm{cv}}}$ is terminated by an empty line.
-For two dimensional grid files, this allows quick visualization by programs such as GNUplot.
-\\
-
-\noindent\textbf{Example 1:} multicolumn text file for a one-dimensional histogram with \texttt{lowerBoundary} = 15, \texttt{upperBoundary} = 48 and \texttt{width} = 0.1.
-
-\begin{tabular}{l l l l l l}
-\\
-\# & \texttt{1} & & & & \\
-\# & \texttt{15} & \texttt{0.1} & \texttt{330} & \texttt{0} \\
-\\
-& \texttt{15.05} & \texttt{6.14012e-07} & & & \\
-& \texttt{15.15} & \texttt{7.47644e-07} & & & \\
-& \ldots & \ldots & & & \\
-& \texttt{47.85} & \texttt{1.65944e-06} & & & \\
-& \texttt{47.95} & \texttt{1.46712e-06} & & & \\
-\\
-\end{tabular}
-
-\noindent\textbf{Example 2:} multicolumn text file for a two-dimensional histogram of two dihedral angles (periodic interval with 6$^\circ$ bins):
-
-\begin{tabular}{l l l l l l}
-& & & & \\
-\# & \texttt{2} & & & & \\
-\# & \texttt{-180.0} & \texttt{6.0} & \texttt{30} & \texttt{1} \\
-\# & \texttt{-180.0} & \texttt{6.0} & \texttt{30} & \texttt{1} \\
-\\
-& \texttt{-177.0} & \texttt{-177.0} & \texttt{8.97117e-06} & & \\
-& \texttt{-177.0} & \texttt{-171.0} & \texttt{1.53525e-06} & & \\
-& \ldots & \ldots & \ldots & & \\
-& \texttt{-177.0} & \texttt{ 177.0} & \texttt{2.442956-06} & & \\
-\\
-& \texttt{-171.0} & \texttt{-177.0} & \texttt{2.04702e-05} & & \\
-& \ldots & \ldots & \ldots & & \\
-\end{tabular}
 
 \cvsubsec{Trajectory output}{sec:colvar_traj_output}
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -842,6 +842,45 @@ All such files' names also begin with the prefix \outputName.
 \cvnamdonly{Lastly, the total energy of all biases or restraints applied to the colvars appears under the NAMD standard output, under the MISC column.}
 
 
+\cvsubsec{File formats}{sec:colvars_file_formats}
+
+\cvsubsubsec{Configuration and state files.}{sec:colvars_text_format}
+
+Configuration files are text files that are generally read as input by \MDENGINE{}\cvscriptonly{, and may be optionally inlined in a \MDENGINE{} script (see \ref{sec:cv_command_init})}.
+Starting from versions 2017-02-01, changes in newline encodings are handled transparently, i.e.{} it is possible to typeset a configuration file in Windows (CR-LF newlines) and then use it with Linux or macOS (LF-only newlines).
+
+State files, although not written manually, follow otherwise the same format as configuration files.
+
+\cvsubsubsec{Index files.}{sec:colvars_ndx_format}
+
+For atom selections that cannot be specified only with Colvars keywords, external index files may be used following the \href{http://manual.gromacs.org/documentation/current/reference-manual/file-formats.html\#ndx}{NDX format} used in GROMACS.
+\cvlammpsonly{In LAMMPS, such files may also be produced via the \texttt{group2ndx} command.}
+
+
+\cvsubsubsec{XYZ coordinate files.}{sec:colvars_xyz_format}
+XYZ files are read by the Colvars module using an internal reader, and expect the following format.
+\begin{mdexampleinput}
+\-$N$\\
+\-Comment~line\\
+\-$E_{1}$~$x_{1}$~$y_{1}$~$z_{1}$\\
+\-\ldots\\
+\-$E_{N}$~$x_{N}$~$y_{N}$~$z_{N}$
+\end{mdexampleinput}
+\noindent{}where $N$ is the number of atomic coordinates in the file and $E_i$ is the chemical element of the $i$-th atom.
+Because $E_i$ is not used in Colvars, any string is acceptable.
+
+
+\cvnamebasedonly{
+\cvsubsubsec{PDB coordinate files.}{sec:colvars_pdb_format}
+PDB coordinate files are read by the Colvars module using existing functionality in \MDENGINE, and therefore follow the same format.
+The values of the atomic coordinates and other fields, such as occupancy or temperature factors, are then communicated to Colvars by \MDENGINE{}.
+
+PDB files may be used either as one of the available mechanisms to select atoms (see the \refkey{atomsFile}{atom-group|atomsFile} keyword), or more frequently to read reference coordinates for least-squares fit alignment (see the \refkey{atomsFile}{atom-group|refPositionsFile} keyword).
+}
+
+% TODO Move multicolumn format here?
+
+
 \cvsec{Defining collective variables}{sec:colvar}
 
 A collective variable is defined by the keyword \texttt{colvar} followed by its configuration options contained within curly braces:
@@ -1588,8 +1627,8 @@ with respect to $\{\mathbf{x}_{i}(t)\}$.
     \texttt{rmsd}}{%
     Reference coordinates}{%
     space-separated list of \texttt{(x, y, z)} triplets}{%
-    This option (mutually exclusive with \texttt{refPositionsFile}) sets the reference coordinates for RMSD calculation, and uses these to compute the roto-translational fit.
-    It is functionally equivalent to the option \refkey{refPositions}{atom-group|refPositions} in the atom group definition, which also supports more advanced fitting options.
+    This option (mutually exclusive with \texttt{refPositionsFile}) sets the reference coordinates for RMSD calculation, and uses these to compute the roto-translational fit.  
+    See the equivalent option \refkey{refPositions}{atom-group|refPositions} within the atom group definition for details on acceptable formats and other features.
     }
 
 \item %
@@ -1599,8 +1638,8 @@ with respect to $\{\mathbf{x}_{i}(t)\}$.
     \texttt{rmsd}}{%
     Reference coordinates file}{%
     UNIX filename}{%
-    This option (mutually exclusive with \texttt{refPositions}) sets the reference coordinates for RMSD calculation, and uses these to compute the roto-translational fit.
-    It is functionally equivalent to the option \refkey{refPositionsFile}{atom-group|refPositionsFile} in the atom group definition, which also supports more advanced fitting options.
+    This option (mutually exclusive with \texttt{refPositions}) sets the reference coordinates for RMSD calculation, and uses these to compute the roto-translational fit.  
+    See the equivalent option \refkey{refPositionsFile}{atom-group|refPositionsFile} within the atom group definition for details on acceptable file formats and other features.
     }
 
 \cvnamebasedonly{
@@ -3892,6 +3931,7 @@ The complete list of selection keywords available in \MDENGINE{} is:
     \texttt{atomNameResidueRange}, in order of their occurrence.
     This option is only necessary if a PSF topology file is used.}
 
+\labelkey{atom-group|atomsFile}
 \item %
   \key
     {atomsFile}{%
@@ -4003,7 +4043,8 @@ Be careful when using these options in ABF simulations or when using total force
     UNIX filename}{%
     \label{key:colvars:atom_group:refPositionsFile}
     This option provides a list of reference coordinates for \texttt{centerReference} and/or \texttt{rotateReference}, and is mutually exclusive with \texttt{refPositions}.
-    The acceptable file format is XYZ, which is read in double precision\cvnamebasedonly{, or PDB; \emph{the latter is discouraged if the precision of the reference coordinates is a concern}}.
+    The acceptable file format is XYZ (see \ref{sec:colvars_xyz_format}), which is read in double precision\cvnamebasedonly{, or PDB (see \ref{sec:colvars_pdb_format})
+; \emph{the latter is discouraged if the precision of the reference coordinates is a concern}}.
     Atomic positions are read differently depending on the following scenarios:
     \textbf{(i)} the file contains exactly as many records as the atoms in the group: all positions are read in sequence;
     \textbf{(ii)} (most common case) the file contains coordinates for the entire system: only the positions corresponding to the numeric indices of the atom group are read\cvnamebasedonly{;


### PR DESCRIPTION
Raise error when number of positions in XYZ file doesn't match number of atoms.  Especially useful for LAMMPS users, who have no option for reading PDB files.

Document what is the expected XYZ file format (in case people are not using VMD to prepare it).
    
Fixes #369
