### PR TITLE
GROMACS documentation fixes

### DIFF
--- a/doc/colvars-refman-gromacs.tex
+++ b/doc/colvars-refman-gromacs.tex
@@ -31,7 +31,7 @@
 \newcommand{\cvleptononly}[1]{#1}
 
 % content that applies only to programs that use atom names (i.e. not LAMMPS)
-\newcommand{\cvnamebasedonly}[1]{#1}
+\newcommand{\cvnamebasedonly}[1]{}
 
 
 \input{colvars-refman.tex}


### PR DESCRIPTION
`\cvnamebasedonly` selects features where atoms are selected by name and residue, or PDB files are loaded.  Neither is supported in GROMACS at the moment.

I simply disabled the macro, but for more flexible behavior it may be appropriate to break up these two features, and set them by code, e.g.:
```
\cvnamdonly{
\def\cvreadpdb{1}
\def\cvatomnamesel{1}
}
\cvgromacsonly{
\def\cvreadpdb{0}
\def\cvatomnamesel{0}
}
```
and perhaps leave only those `\cv*only{...}` macros that identify the particular backend.