### PR TITLE
Fix #368 in aspathCV and azpathCV.

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -789,13 +789,8 @@ cvm::rvector colvarproxy_namd::position_distance(cvm::atom_pos const &pos1,
   Position const p1(pos1.x, pos1.y, pos1.z);
   Position const p2(pos2.x, pos2.y, pos2.z);
   // return p2 - p1
-  if (this->lattice != NULL) {
-    Vector const d = this->lattice->delta(p2, p1);
-    return cvm::rvector(d.x, d.y, d.z);
-  }
-  else {
-    return colvarproxy_system::position_distance(pos1, pos2);
-  }
+  Vector const d = this->lattice->delta(p2, p1);
+  return cvm::rvector(d.x, d.y, d.z);
 }
 
 

--- a/src/colvar_arithmeticpath.h
+++ b/src/colvar_arithmeticpath.h
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <string>
 
 namespace ArithmeticPathCV {
 
@@ -24,6 +25,7 @@ public:
     virtual void computeValue();
     virtual void computeDerivatives();
     virtual void compute();
+    virtual void reComputeLambda(const vector<scalar_type>& rmsd_between_refs);
 protected:
     scalar_type lambda;
     vector<scalar_type> weights;
@@ -124,6 +126,16 @@ void ArithmeticPathBase<element_type, scalar_type, path_type>::computeDerivative
     }
 }
 
+template <typename element_type, typename scalar_type, path_sz path_type>
+void ArithmeticPathBase<element_type, scalar_type, path_type>::reComputeLambda(const vector<scalar_type>& rmsd_between_refs) {
+    scalar_type mean_square_displacements = 0.0;
+    for (size_t i_frame = 1; i_frame < total_frames; ++i_frame) {
+        cvm::log(std::string("Distance between frame ") + cvm::to_str(i_frame) + " and " + cvm::to_str(i_frame + 1) + " is " + cvm::to_str(rmsd_between_refs[i_frame - 1]) + std::string("\n"));
+        mean_square_displacements += rmsd_between_refs[i_frame - 1] * rmsd_between_refs[i_frame - 1];
+    }
+    mean_square_displacements /= scalar_type(total_frames - 1);
+    lambda = 1.0 / mean_square_displacements;
+}
 }
 
 #endif // ARITHMETICPATHCV_H


### PR DESCRIPTION
Instead of calculating the default lambda value in the initialization of
the components, this commit provides a negative value for it in the
initialization, and then re-computes the lambda value if it is still
non-positive in calc_value(). This commit can avoid the use and
detection of the null pointer of the Lattice object at least in aspathCV
and azpathCV.