### PR TITLE
Update repo documentation for Gromacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ The module itself implements a variety of functions and algorithms, including fr
 The easiest way to obtain pre-compiled versions of Colvars is via one of following:
 - the molecular simulation program [LAMMPS](https://lammps.sandia.gov/download.html);
 - the molecular simulation program [NAMD](https://www.ks.uiuc.edu/Research/namd/);
-- the molecular visualization program [VMD](https://www.ks.uiuc.edu/Research/vmd/).
+- the molecular visualization program [VMD](https://www.ks.uiuc.edu/Research/vmd/);
+- the molecular simulation program [GROMACS](http://www.gromacs.org/) through our [releases](#gromacs-colvars-releases).
 
 Please check [here](https://github.com/Colvars/colvars/releases) to see which version of Colvars is included with the round-number or "stable" versions of each code.
 
 ## Documentation
 
-The [Colvars webpage](https://colvars.github.io/) includes user documentation for the three codes, as well as a Doxygen-based [developer documentation](https://colvars.github.io/doxygen/html/).
+The [Colvars webpage](https://colvars.github.io/) includes user documentation for the four codes, as well as a Doxygen-based [developer documentation](https://colvars.github.io/doxygen/html/).
 
 The reference article is:
-G. Fiorin, M. L. Klein, and J. Hénin, Molecular Physics 111, 3345 (2013).  
+G. Fiorin, M. L. Klein, and J. Hénin, Molecular Physics 111, 3345 (2013).
 https://dx.doi.org/10.1080/00268976.2013.813594  \[[BibTex file](https://github.com/Colvars/colvars/blob/master/doc/ref_Fiorin_2013.bib?raw=true)\] \[[Endnote file](https://github.com/Colvars/colvars/blob/master/doc/ref_Fiorin_2013.ciw?raw=true)\]
 
 ## Example input
@@ -38,6 +39,11 @@ cv configfile <Colvars configuration file>
 ```
 fix Colvars all colvars configfile <Colvars configuration file>
 ```
+- In GROMACS:
+```
+gmx mdrun -s topol.tpr -deffnm topol -colvars <Colvars configuration file>
+```
+
 The contents of the configuration file are typically the same across all programs, for example:
 ```
 colvar { # Define a new variable
@@ -55,6 +61,7 @@ harmonic { # Define a harmonic potential, 1/2*K*(d-d0)^2/w_d^2
   forceConstant 10.0 # Force constant, "K"
 }
 ```
+
 
 Complete input decks for some of the most commonly used features are available in the `examples` repository:
 https://github.com/Colvars/examples
@@ -75,6 +82,7 @@ and run the provided `update-colvars-code.sh` script against the unpacked source
 ./update-colvars-code.sh /path/to/NAMD_X.YY_Source ; # updates NAMD
 ./update-colvars-code.sh /path/to/vmd-X.Y.Z        ; # updates VMD
 ./update-colvars-code.sh /path/to/vmd-plugins      ; # updates VMD plugins
+./update-colvars-code.sh /path/to/gromacs-XXX.X    ; # update GROMACS
 ```
 and recompile them.
 
@@ -85,9 +93,21 @@ The `update-colvars-code.sh` script and its supporting files are synchronized wi
 
 Earlier versions are not supported.
 
+For GROMACS, the versions supported are 2018.X and 2020.X.
+
+## Gromacs-Colvars releases
+
+Here a list of GROMACS archives with Colvars patch:
+
+ - [2018.8](https://github.com/Colvars/gromacs/releases/tag/v2018.8-colvars) with Colvars version 2020-10-22
+ - [2020.1](https://github.com/Colvars/gromacs/releases/tag/v2020.1-colvars) with Colvars version 2020-10-22
+ - [2020.2](https://github.com/Colvars/gromacs/releases/tag/v2020.2-colvars) with Colvars version 2020-10-22
+ - [2020.3](https://github.com/Colvars/gromacs/releases/tag/v2020.3-colvars) with Colvars version 2020-10-22
+ - [2020.4](https://github.com/Colvars/gromacs/releases/tag/v2020.4-colvars) with Colvars version 2020-10-22
+
 ## Which version is recommended?
 
-The `master` branch is to be considered the "*stable*" release at any given time; any bugfixes are released through `master` first.  The input syntax is near-completely *backward-compatible* and output files are *forward-compatible*.  Feel free to download Colvars and update NAMD, VMD or LAMMPS as needed.
+The `master` branch is to be considered the "*stable*" release at any given time; any bugfixes are released through `master` first.  The input syntax is near-completely *backward-compatible* and output files are *forward-compatible*.  Feel free to download Colvars and update NAMD, VMD, LAMMPS or GROMACS as needed.
 
 Other branches are dedicated to the development of specific features: please use them at your own discretion.
 

--- a/devel-tools/create_gromacs-colvars-releases.md
+++ b/devel-tools/create_gromacs-colvars-releases.md
@@ -1,0 +1,58 @@
+# Create patched colvars gromacs versions
+
+Steps to create a release archive of a Gromacs version with colvars support.
+This is done on the Gromacs fork of Colvars organization: https://github.com/Colvars/gromacs
+
+All commands are done within the GROMACS source tree folder.
+
+If a colvars release branch already exists with a Colvars commit, go to step 3.
+
+## 1. Create a derived branch from a release one
+
+```
+git checkout -b release-XXXX-colvars release-XXX
+```
+
+## 2. Apply, check and commit colvars patch
+
+This step implies that the colvars sources support the desired Gromacs version.
+
+```
+# Applying patch
+/path/to/colvars/update-colvars-code.sh .
+```
+
+Next, is to make sure the patch works but compiling gromacs and eventually, run the colvars gromacs tests.
+
+Once verified, commit the patch with its version name within the message:
+```
+git add <list of files>
+git commit -m "Colvars patch versions XXXX-XX-XX"
+```
+
+## 3. Create a Colvars-GROMACS tag from a Gromacs minor version tag
+
+Go to the GROMACS minor version to be patched:
+
+```
+git checkout tags/vYYYY.Y
+```
+
+Cherry pick the Colvars commit from step #2 to be applied on this tag:
+
+```
+git cherry-pick <commit SHA1>
+```
+
+Make sure the commit works by compiling GROMACS and running Colvars tests.
+
+Create a new tag:
+```
+git tag -a "vYYYY.Y-colvars" -m "Colvars patch version XXXX-XX-XX for Gromacs YYYY.Y"
+```
+
+Return to master and push the tag:
+```
+git checkout -
+git push origin vYYYY.Y-colvars
+```

--- a/devel-tools/create_gromacs-colvars-releases.md
+++ b/devel-tools/create_gromacs-colvars-releases.md
@@ -1,11 +1,11 @@
-# Create patched colvars gromacs versions
+# Create patched Colvars GROMACS versions
 
-Steps to create a release archive of a Gromacs version with colvars support.
-This is done on the Gromacs fork of Colvars organization: https://github.com/Colvars/gromacs
+Steps to create a release archive of a GROMACS version with Colvars support.
+This is done on the GROMACS fork of Colvars organization: https://github.com/Colvars/gromacs
 
 All commands are done within the GROMACS source tree folder.
 
-If a colvars release branch already exists with a Colvars commit, go to step 3.
+If a Colvars release branch already exists with a Colvars commit, go to step 3.
 
 ## 1. Create a derived branch from a release one
 
@@ -13,16 +13,16 @@ If a colvars release branch already exists with a Colvars commit, go to step 3.
 git checkout -b release-XXXX-colvars release-XXX
 ```
 
-## 2. Apply, check and commit colvars patch
+## 2. Apply, check and commit Colvars patch
 
-This step implies that the colvars sources support the desired Gromacs version.
+This step implies that the Colvars sources support the desired GROMACS version.
 
 ```
 # Applying patch
 /path/to/colvars/update-colvars-code.sh .
 ```
 
-Next, is to make sure the patch works but compiling gromacs and eventually, run the colvars gromacs tests.
+Make sure the patch works by compiling GROMACS and eventually, run the Colvars GROMACS tests.
 
 Once verified, commit the patch with its version name within the message:
 ```
@@ -30,7 +30,7 @@ git add <list of files>
 git commit -m "Colvars patch versions XXXX-XX-XX"
 ```
 
-## 3. Create a Colvars-GROMACS tag from a Gromacs minor version tag
+## 3. Create a Colvars-GROMACS tag from a GROMACS minor version tag
 
 Go to the GROMACS minor version to be patched:
 

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -442,7 +442,7 @@ then
   fi
 
   # copy library files and proxy files to the "colvars" folder
-  for src in ${source}/src/*.h ${source}/src/*.cpp ${source}/gromacs/gromacs-${GMX_VERSION}/*
+  for src in ${source}/src/*.h ${source}/src/*.cpp ${source}/gromacs/src/*.h ${source}/gromacs/gromacs-${GMX_VERSION}/*
   do \
     tgt=$(basename ${src})
     condcopy "${src}" "${target}/src/gromacs/colvars/${tgt}" "${cpp_patch}"


### PR DESCRIPTION
This PR update the README with the Gromacs information.
I added also a documentation (`devel-tools/create_gromacs-colvars-releases.md`) on how to create Gromacs-colvars release in the repository https://github.com/Colvars/gromacs/