### PR TITLE
Use a t_atoms struct for holding atoms information in proxy

### DIFF
--- a/gromacs/gromacs-2018.3.patch
+++ b/gromacs/gromacs-2018.3.patch
@@ -266,7 +266,7 @@ diff -aur src/gromacs/mdlib/sim_util.cpp src_colvars/gromacs/mdlib/sim_util.cpp
 +        set_pbc(&pbc, inputrec->ePBC, box);
 +        inputrec->colvars_proxy->update_data(cr, step, pbc, box, bNS);
 +
-+        inputrec->colvars_proxy->calculateForces(cr, mdatoms, box, t, x, forceWithVirial);
++        inputrec->colvars_proxy->calculateForces(cr, box, x, forceWithVirial);
 +    }
 +
      if (inputrec->bPull && pull_have_potential(inputrec->pull_work))
@@ -396,7 +396,7 @@ diff -aur src/programs/mdrun/md.cpp src_colvars/programs/mdrun/md.cpp
 +        }
 +
 +        ir->colvars_proxy =  new colvarproxy_gromacs();
-+        ir->colvars_proxy->init(ir,ir->init_step,mdatoms, observablesHistory, prefix, filenames,filename_restart, cr, MASTER(cr) ? as_rvec_array(state->x.data()) : nullptr);
++        ir->colvars_proxy->init(ir,ir->init_step,top_global, observablesHistory, prefix, filenames,filename_restart, cr, MASTER(cr) ? as_rvec_array(state->x.data()) : nullptr);
 +    }
 +    else
 +    {

--- a/gromacs/gromacs-2018.3/colvarproxy_gromacs.h
+++ b/gromacs/gromacs-2018.3/colvarproxy_gromacs.h
@@ -25,7 +25,7 @@ public:
   //Box
   const real (*gmx_box)[3];
   //
-  const t_mdatoms *gmx_atoms;
+  t_atoms gmx_atoms;
 protected:
   cvm::real thermostat_temperature;
   cvm::real timestep;
@@ -74,7 +74,7 @@ public:
   ~colvarproxy_gromacs();
 
   // Initialize colvars.
-  void init(t_inputrec *gmx_inp, int64_t step, t_mdatoms *mdatoms, ObservablesHistory* oh,
+  void init(t_inputrec *gmx_inp, int64_t step, gmx_mtop_t *mtop, ObservablesHistory* oh,
             const std::string &prefix, gmx::ArrayRef<const std::string> filenames_config,
             const std::string &filename_restart, const t_commrec *cr,
             const rvec x[]);
@@ -86,7 +86,7 @@ public:
   //Home made method for computed colvars forces.
   //The pattern match the one of the IForceProvider method but we cant use it because the latter use const references which is in conflict
   //with the function `communicate_group_positions` (solved in 2020.X)
-  void calculateForces(t_commrec *cr,t_mdatoms *mdatoms, matrix box, double t, rvec *x_pointer , gmx::ForceWithVirial  *forceWithVirial);
+  void calculateForces(t_commrec *cr, matrix box, rvec *x_pointer , gmx::ForceWithVirial  *forceWithVirial);
 
   // Compute virial tensor for position r and force f, and add to matrix vir
   void add_virial_term(matrix vir, rvec const f, gmx::RVec const r);


### PR DESCRIPTION
This patch aims only the Gromacs 2018.X version.

It replaces the t_mdatoms one which was prone to bug when using large
number of MPI threads/ranks.
It now uses the same syntax as the 2020.X version.

I also removed 2 unused parameters of the `calculateForces()` function.