### PR TITLE
Conditionally compile the volmap related functions.

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1329,8 +1329,6 @@ void colvarproxy_namd::clear_volmap(int index)
   colvarproxy::clear_volmap(index);
 }
 
-#endif
-
 
 int colvarproxy_namd::get_volmap_id_from_name(char const *volmap_name)
 {
@@ -1419,7 +1417,7 @@ int colvarproxy_namd::compute_volmap(int flags,
   return COLVARS_OK;
 }
 
-
+#endif
 
 #if CMK_SMP && USE_CKLOOP // SMP only
 


### PR DESCRIPTION
This commit guards all volmap related functions for NAMD 2.14b1 only.
Without this commit, if NAMD_VERSION_NUMBER is defined as less than
34471681, NAMD 3.0 stills fails to build with the master branch of
colvars.