### PR TITLE
Implement centerToOrigin

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1745,7 +1745,7 @@ with respect to $\{\mathbf{x}_{i}(t)\}$.
     \texttt{atoms~\{...\}} block}{%
     Defines the group of atoms of which the RMSD should be calculated.
     Optimal fit options (such as \texttt{refPositions} and
-    \texttt{rotateReference}) should typically NOT be set within this
+    \texttt{rotateToReference}) should typically NOT be set within this
     block. Exceptions to this rule are the special cases discussed in
     the \emph{Advanced usage} paragraph below.
     }
@@ -1840,10 +1840,10 @@ atom group block. This allows for the following non-standard cases:
 
 \begin{enumerate}
 \item applying the optimal translation, but no rotation
-(\texttt{rotateReference off}), to bias or restrain the shape and
+(\texttt{rotateToReference off}), to bias or restrain the shape and
 orientation, but not the position of the atom group;
 \item applying the optimal rotation, but no translation
-(\texttt{centerReference off}), to bias or restrain the shape and
+(\texttt{centerToReference off}), to bias or restrain the shape and
 position, but not the orientation of the atom group;
 \item disabling the application of optimal roto-translations, which
 lets the RMSD component describe the deviation of atoms
@@ -2634,7 +2634,7 @@ $(x_1, y_1, z_1, \cdots, x_n, y_n, z_n)$.
     Group of atoms}{%
     Block \texttt{atoms \{...\}}}{%
     Defines the atoms whose coordinates make up the value of the component.
-    If \texttt{rotateReference}, \texttt{centerReference}, or \texttt{centerToOrigin} are defined, coordinates
+    If \texttt{rotateToReference}, \texttt{centerToReference}, or \texttt{centerToOrigin} are defined, coordinates
     are evaluated within the moving frame of reference.}
 \end{cvcoptions}
 
@@ -4180,32 +4180,32 @@ The complete list of selection keywords available in \MDENGINE{} is:
 
 \cvsubsec{Moving frame of reference.}{sec:colvar_atom_groups_ref_frame}
 
-The following options define an automatic calculation of an optimal translation (\texttt{centerReference}) or optimal rotation (\texttt{rotateReference}), that superimposes the positions of this group to a provided set of reference coordinates.
+The following options define an automatic calculation of an optimal translation (\texttt{centerToReference}) or optimal rotation (\texttt{rotateToReference}), that superimposes the positions of this group to a provided set of reference coordinates.
 Alternately, \texttt{centerToOrigin} applies a translation to place the geometric center of the group at (0, 0, 0).
 This can allow, for example, to effectively remove from certain colvars the effects of molecular tumbling and of diffusion.
 Given the set of atomic positions $\mathbf{x}_{i}$, the colvar $\xi$ can be defined on a set of roto-translated positions $\mathbf{x}_{i}' = R(\mathbf{x}_{i} - \mathbf{x}^{\mathrm{C}}) + \mathbf{x}^{\mathrm{ref}}$.
 $\mathbf{x}^{\mathrm{C}}$ is the geometric center of the $\mathbf{x}_{i}$, $R$ is the optimal rotation matrix to the reference positions and $\mathbf{x}^{\mathrm{ref}}$ is the geometric center of the reference positions.
 
 Components that are defined based on pairwise distances are naturally invariant under global roto-translations.
-Other components are instead affected by global rotations or translations: however, they can be made invariant if they are expressed in the frame of reference of a chosen group of atoms, using the \texttt{centerReference} and \texttt{rotateReference} options.
-Finally, a few components are defined by convention using a roto-translated frame (e.g. the minimal RMSD): for these components, \texttt{centerReference} and \texttt{rotateReference} are enabled by default.
+Other components are instead affected by global rotations or translations: however, they can be made invariant if they are expressed in the frame of reference of a chosen group of atoms, using the \texttt{centerToReference} and \texttt{rotateToReference} options.
+Finally, a few components are defined by convention using a roto-translated frame (e.g. the minimal RMSD): for these components, \texttt{centerToReference} and \texttt{rotateToReference} are enabled by default.
 In typical applications, the default settings result in the expected behavior.
 
 \paragraph*{Warning on rotating frames of reference and periodic boundary conditions.}
-\texttt{rotateReference} affects coordinates that depend on minimum-image distances in periodic boundary conditions (PBC).
+\texttt{rotateToReference} affects coordinates that depend on minimum-image distances in periodic boundary conditions (PBC).
 After rotation of the coordinates, the periodic cell vectors become irrelevant: the rotated system is effectively non-periodic.
 A safe way to handle this is to ensure that the relevant inter-group distance vectors remain smaller than the half-size of the periodic cell.
 If this is not desirable, one should avoid the rotating frame of reference, and apply orientational restraints to the reference group instead, in order to keep the orientation of the reference group consistent with the orientation of the periodic cell.
 
 \paragraph*{Warning on rotating frames of reference and ABF.}
-Note that \texttt{centerReference} and \texttt{rotateReference} may affect the Jacobian derivative of colvar components in a way that is not taken into account by default.
+Note that \texttt{centerToReference} and \texttt{rotateToReference} may affect the Jacobian derivative of colvar components in a way that is not taken into account by default.
 Be careful when using these options in ABF simulations or when using total force values.
 
 \begin{itemize}
 
 \item %
   \keydef
-    {centerReference}{%
+    {centerToReference}{%
     atom group}{%
     Implicitly remove translations for this group}{%
     boolean}{%
@@ -4222,7 +4222,7 @@ Be careful when using these options in ABF simulations or when using total force
     Implicitly remove translations for this group by keeping its center at the origin}{%
     boolean}{%
     \texttt{off}}{%
-    This option implies \texttt{centerReference}.
+    This option implies \texttt{centerToReference}.
     If this option is \texttt{on}, coordinates from the group will be translated so that the center of geometry of the group remains at (0, 0, 0), except if 
     \texttt{fittingGroup} is enabled.
     In that case, the translation applied is the translation that brings the center of geometry of the fitting group to (0, 0, 0).
@@ -4230,13 +4230,13 @@ Be careful when using these options in ABF simulations or when using total force
 
 \item %
   \keydef
-    {rotateReference}{%
+    {rotateToReference}{%
     atom group}{%
     Implicitly remove rotations for this group}{%
     boolean}{%
     \texttt{off}}{%
     If this option is \texttt{on}, the coordinates of this group will be optimally superimposed to the reference positions provided by \cvnamebasedonly{either} \texttt{refPositions} or \texttt{refPositionsFile}.
-    The rotation will be performed around the center of geometry if \texttt{centerReference} is \texttt{on}, or around the origin otherwise.
+    The rotation will be performed around the center of geometry if \texttt{centerToReference} is \texttt{on}, or around the origin otherwise.
     The algorithm used is the same employed by the \texttt{orientation} colvar component~\cite{Coutsias2004}.
     Forces applied to the atoms of this group will also be implicitly rotated back to the original frame.
     \textbf{Note}: unless otherwise specified, \texttt{rmsd} and \texttt{eigenvector} set this option to \texttt{on} \emph{by default}.
@@ -4250,8 +4250,8 @@ Be careful when using these options in ABF simulations or when using total force
     Reference positions for fitting (\AA)}{%
     space-separated list of \texttt{(x, y, z)} triplets}{%
     \label{key:colvars:atom_group:refPositions}
-    This option provides a list of reference coordinates for \texttt{centerReference} and/or \texttt{rotateReference}, and is mutually exclusive with \texttt{refPositionsFile}.
-    If only \texttt{centerReference} is \texttt{on}, the list may contain a single (x, y, z) triplet; if also \texttt{rotateReference} is \texttt{on}, the list should be as long as the atom group, and \emph{its order must match the order in which atoms were defined}.
+    This option provides a list of reference coordinates for \texttt{centerToReference} and/or \texttt{rotateToReference}, and is mutually exclusive with \texttt{refPositionsFile}.
+    If only \texttt{centerToReference} is \texttt{on}, the list may contain a single (x, y, z) triplet; if also \texttt{rotateToReference} is \texttt{on}, the list should be as long as the atom group, and \emph{its order must match the order in which atoms were defined}.
 }
 
 \item %
@@ -4262,7 +4262,7 @@ Be careful when using these options in ABF simulations or when using total force
     File containing the reference positions for fitting}{%
     UNIX filename}{%
     \label{key:colvars:atom_group:refPositionsFile}
-    This option provides a list of reference coordinates for \texttt{centerReference} and/or \texttt{rotateReference}, and is mutually exclusive with \texttt{refPositions}.
+    This option provides a list of reference coordinates for \texttt{centerToReference} and/or \texttt{rotateToReference}, and is mutually exclusive with \texttt{refPositions}.
     The acceptable file format is XYZ (see \ref{sec:colvars_xyz_format}), which is read in double precision.
     \cvnamebasedonly{Alternatively, a PDB file may be read (see \ref{sec:colvars_pdb_format}) using \MDENGINE{}'s reader; however, due to the constraints of the PDB format \emph{PDB files are discouraged if the precision of the reference coordinates is a concern}}.
 }
@@ -4296,7 +4296,7 @@ Be careful when using these options in ABF simulations or when using total force
     Use an alternate set of atoms to define the roto-translation}{%
     Block \texttt{fittingGroup \{ ... \}}}{%
     This atom group itself}{%
-    If either \texttt{centerReference} or \texttt{rotateReference} is defined, this keyword defines an alternate atom group to calculate the optimal roto-translation.
+    If either \texttt{centerToReference} or \texttt{rotateToReference} is defined, this keyword defines an alternate atom group to calculate the optimal roto-translation.
     Use this option to define a continuous rotation if the structure of the group involved changes significantly (a typical symptom would be the message ``Warning: discontinuous rotation!'').
     \textbf{Performance considerations:} note that enabling this option will result in projecting each of the atomic gradients of the colvar (e.g.{} the RMSD) onto each the gradients of the roto-translation, which may be a computationally expensive operation: see the closely related \refkey{enableFitGradients}{atom-group|enableFitGradients} for details.%
 }
@@ -4318,8 +4318,8 @@ atoms \{\\
 \\
 \-~~atomNumbers 1 2 3 4 5 6 7 \# atoms of the ligand (1-based)\\
 \\
-\-~~centerReference yes\\
-\-~~rotateReference yes\\
+\-~~centerToReference yes\\
+\-~~rotateToReference yes\\
 \-~~fittingGroup \{\\
 \-~~~~\# define the frame by fitting alpha carbon atoms\\
 \-~~~~\# in 2 protein segments close to the site\\
@@ -4343,7 +4343,7 @@ The following two options have default values appropriate for the vast majority 
     Include the roto-translational contribution to colvar gradients}{%
     boolean}{%
     \texttt{on}}{%
-    When either \texttt{centerReference} or \texttt{rotateReference} is on,
+    When either \texttt{centerToReference} or \texttt{rotateToReference} is on,
     the gradients of some colvars include terms proportional to
     $\partial{}R/\partial\mathbf{x}_{i}$ (rotational gradients) and
     $\partial\mathbf{x}^{\mathrm{C}}/\partial\mathbf{x}_{i}$ (translational gradients).

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2634,7 +2634,7 @@ $(x_1, y_1, z_1, \cdots, x_n, y_n, z_n)$.
     Group of atoms}{%
     Block \texttt{atoms \{...\}}}{%
     Defines the atoms whose coordinates make up the value of the component.
-    If \texttt{rotateReference} or \texttt{centerReference} are defined, coordinates
+    If \texttt{rotateReference}, \texttt{centerReference}, or \texttt{centerToOrigin} are defined, coordinates
     are evaluated within the moving frame of reference.}
 \end{cvcoptions}
 
@@ -4181,6 +4181,7 @@ The complete list of selection keywords available in \MDENGINE{} is:
 \cvsubsec{Moving frame of reference.}{sec:colvar_atom_groups_ref_frame}
 
 The following options define an automatic calculation of an optimal translation (\texttt{centerReference}) or optimal rotation (\texttt{rotateReference}), that superimposes the positions of this group to a provided set of reference coordinates.
+Alternately, \texttt{centerToOrigin} applies a translation to place the geometric center of the group at (0, 0, 0).
 This can allow, for example, to effectively remove from certain colvars the effects of molecular tumbling and of diffusion.
 Given the set of atomic positions $\mathbf{x}_{i}$, the colvar $\xi$ can be defined on a set of roto-translated positions $\mathbf{x}_{i}' = R(\mathbf{x}_{i} - \mathbf{x}^{\mathrm{C}}) + \mathbf{x}^{\mathrm{ref}}$.
 $\mathbf{x}^{\mathrm{C}}$ is the geometric center of the $\mathbf{x}_{i}$, $R$ is the optimal rotation matrix to the reference positions and $\mathbf{x}^{\mathrm{ref}}$ is the geometric center of the reference positions.
@@ -4212,6 +4213,19 @@ Be careful when using these options in ABF simulations or when using total force
     If this option is \texttt{on}, the center of geometry of the group will be aligned with that of the reference positions provided by \cvnamebasedonly{either} \texttt{refPositions} or \texttt{refPositionsFile}.
     Colvar components will only have access to the aligned positions.
 \textbf{Note}: unless otherwise specified, \texttt{rmsd} and \texttt{eigenvector} set this option to \texttt{on} \emph{by default}.
+}
+
+\item %
+  \keydef
+    {centerToOrigin}{%
+    atom group}{%
+    Implicitly remove translations for this group by keeping its center at the origin}{%
+    boolean}{%
+    \texttt{off}}{%
+    This option implies \texttt{centerReference}.
+    If this option is \texttt{on}, coordinates from the group will be translated so that the center of geometry of the group remains at (0, 0, 0), except if 
+    \texttt{fittingGroup} is enabled.
+    In that case, the translation applied is the translation that brings the center of geometry of the fitting group to (0, 0, 0).
 }
 
 \item %

--- a/examples/04_geometric_restraints.colvars.in
+++ b/examples/04_geometric_restraints.colvars.in
@@ -17,8 +17,8 @@ colvar {
       # group definition:
       atomNumbers 12 13 14 15 16 # explicit list of 1-based atom IDs
       
-      centerReference          # use relative coordinates
-      rotateReference          # (translated and rotated frame of reference)
+      centerToReference          # use relative coordinates
+      rotateToReference          # (translated and rotated frame of reference)
       fittingGroup {           # Define frame of reference based on separate atom group
         atomsFile     ref.pdb  # from separate file
         atomsCol      B

--- a/examples/07_permeation.colvars.in
+++ b/examples/07_permeation.colvars.in
@@ -11,8 +11,8 @@ colvar {
       atomsCol   B           # based on column B
       atomsColValue 1        # atoms flagged with 1
 
-      rotateReference
-      centerReference
+      rotateToReference
+      centerToReference
       fittingGroup {
         atomsfile  ref.pdb
         atomsCol   B         # atoms with nonzero value in column B

--- a/examples/08_relative_rotation.colvars.in
+++ b/examples/08_relative_rotation.colvars.in
@@ -17,7 +17,7 @@ colvar {
       atomsCol   B            # all atoms with nonzero B-factor
                               
 
-      rotateReference
+      rotateToReference
       fittingGroup {          # define the fitting group atoms
         atomsfile  atoms.pdb  
         atomsCol   O           # all atoms with nonzero occupancy

--- a/examples/11_polar_angles.in
+++ b/examples/11_polar_angles.in
@@ -14,8 +14,8 @@ colvar {
       atomsCol   B
       atomsColValue 2
 
-      rotateReference
-      centerReference
+      rotateToReference
+      centerToReference
       fittingGroup {
         atomsfile  system.pdb   # Receptor has flag 1
         atomsCol   B
@@ -36,8 +36,8 @@ colvar {
       atomsCol   B
       atomsColValue 2
 
-      rotateReference
-      centerReference
+      rotateToReference
+      centerToReference
       fittingGroup {
         atomsfile  system.pdb   # Receptor has flag 1
         atomsCol   B

--- a/examples/12_DBC_restraint.in
+++ b/examples/12_DBC_restraint.in
@@ -26,8 +26,8 @@ colvar {
               atomNumbers 1 2 3 4
 
             # Moving frame of reference is defined below
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 # Define binding site atoms used for fitting
                 atomNumbers 6 7 8 9
@@ -49,8 +49,8 @@ colvar {
             atomNumbers  1 2 3 4
 
             # Moving frame of reference is defined below
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 # Define binding site atoms used for fitting
                 atomNumbers 6 7 8 9

--- a/gromacs/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.in
+++ b/gromacs/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/gromacs/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.in
+++ b/gromacs/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.in
@@ -14,8 +14,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -23,8 +23,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/gromacs/tests/library/000_distancez-fitgroup_harmonic-fixed/test.in
+++ b/gromacs/tests/library/000_distancez-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -22,8 +22,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -31,8 +31,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/gromacs/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.in
+++ b/gromacs/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/gromacs/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.in
+++ b/gromacs/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/gromacs/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.in
+++ b/gromacs/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/lammps/tests/library/000_distancedir-fitgroup_harmonic-ddir-fixed/test.in
+++ b/lammps/tests/library/000_distancedir-fitgroup_harmonic-ddir-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceDir {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.in
+++ b/lammps/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.legacy.in
+++ b/lammps/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.in
+++ b/lammps/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.in
@@ -14,8 +14,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -23,8 +23,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/lammps/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.legacy.in
+++ b/lammps/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.legacy.in
@@ -14,8 +14,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -23,8 +23,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/lammps/tests/library/000_distancez-fitgroup_harmonic-fixed/test.in
+++ b/lammps/tests/library/000_distancez-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -22,8 +22,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -31,8 +31,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/lammps/tests/library/000_distancez-fitgroup_harmonic-fixed/test.legacy.in
+++ b/lammps/tests/library/000_distancez-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -22,8 +22,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -31,8 +31,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.in
+++ b/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.legacy.in
+++ b/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.in
+++ b/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.legacy.in
+++ b/lammps/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.in
+++ b/lammps/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientationAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.legacy.in
+++ b/lammps/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientationAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.in
+++ b/lammps/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientationProj {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.legacy.in
+++ b/lammps/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientationProj {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/lammps/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.in
+++ b/lammps/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/lammps/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.legacy.in
+++ b/lammps/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/interface/000_distance-scalable-centerref-dummy/test.in
+++ b/namd/tests/interface/000_distance-scalable-centerref-dummy/test.in
@@ -11,8 +11,8 @@ colvar {
     distance {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositions (0.0, 0.0, 1.0) (2.0, 2.0, 2.0) (0.0, -10.0, 1.0) (-2.0, 0.0, 5.0)
         }
         group2 {

--- a/namd/tests/interface/000_distance-scalable-fit-dummy/test.in
+++ b/namd/tests/interface/000_distance-scalable-fit-dummy/test.in
@@ -11,8 +11,8 @@ colvar {
     distance {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositions (0.0, 0.0, 1.0) (2.0, 2.0, 2.0) (0.0, -10.0, 1.0) (-2.0, 0.0, 5.0)
         }
         group2 {

--- a/namd/tests/interface/007_map_total_internal/test.in
+++ b/namd/tests/interface/007_map_total_internal/test.in
@@ -32,8 +32,8 @@ colvar {
         atoms {
             # Use internal selection with fitting group
             indexGroup Protein
-            rotateReference yes
-            centerReference yes
+            rotateToReference yes
+            centerToReference yes
             fittingGroup {
                 atomNumbers  54 64 74 84 99 
             }

--- a/namd/tests/library/000_distancedir-fitgroup_harmonic-ddir-fixed/test.in
+++ b/namd/tests/library/000_distancedir-fitgroup_harmonic-ddir-fixed/test.in
@@ -13,8 +13,6 @@ colvar {
     distanceDir {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -23,8 +21,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_distancedir-fitgroup_harmonic-ddir-fixed/test.legacy.in
+++ b/namd/tests/library/000_distancedir-fitgroup_harmonic-ddir-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     distanceDir {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.in
+++ b/namd/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.legacy.in
+++ b/namd/tests/library/000_distancevec-fitgroup_harmonic-dvec-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms
@@ -23,8 +23,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.in
@@ -14,8 +14,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -23,8 +23,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_distancez-axis-fitgroup_harmonic-fixed/test.legacy.in
@@ -14,8 +14,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -23,8 +23,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_distancez-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_distancez-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -22,8 +22,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -31,8 +31,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_distancez-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_distancez-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -22,8 +22,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -31,8 +31,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.in
+++ b/namd/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.legacy.in
+++ b/namd/tests/library/000_orientation-fitgroup_harmonic-ori-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.in
+++ b/namd/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.legacy.in
+++ b/namd/tests/library/000_orientation-fitgroup_harmonic-ori-moving/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientationAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_orientationangle-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientationAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     orientationProj {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_orientationproj-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     orientationProj {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/namd/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_rmsd-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_spinangle-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_spinangle-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     spinAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_spinangle-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_spinangle-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     spinAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_tilt-fitgroup_harmonic-fixed/test.in
+++ b/namd/tests/library/000_tilt-fitgroup_harmonic-fixed/test.in
@@ -13,8 +13,8 @@ colvar {
     tilt {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/000_tilt-fitgroup_harmonic-fixed/test.legacy.in
+++ b/namd/tests/library/000_tilt-fitgroup_harmonic-fixed/test.legacy.in
@@ -13,8 +13,8 @@ colvar {
     tilt {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/namd/tests/library/001_10ala_RMSD/test.in
+++ b/namd/tests/library/001_10ala_RMSD/test.in
@@ -45,8 +45,8 @@ colvar {
     rmsd {
         atoms {
             atomNumbers { 1 2 3 4 5 6 7 8 }
-            rotateReference
-            centerReference
+            rotateToReference
+            centerToReference
             refpositionsfile ../Common/pi-ideal.xyz
         }
         refpositionsfile ../Common/da.xyz
@@ -73,7 +73,7 @@ colvar {
     rmsd {
         atoms {
             atomNumbers { 1 2 3 4 5 6 7 8 }
-            centerReference
+            centerToReference
             refpositionsfile ../Common/da.xyz
         }
         refpositionsfile ../Common/da.xyz
@@ -100,7 +100,7 @@ colvar {
     rmsd {
         atoms {
             atomNumbers { 1 2 3 4 5 6 7 8 }
-            rotateReference
+            rotateToReference
             refpositionsfile ../Common/da.xyz
         }
         refpositionsfile ../Common/da.xyz
@@ -127,8 +127,8 @@ colvar {
     rmsd {
         atoms {
             atomNumbers { 1 2 3 4 5 6 7 8 }
-            centerReference no
-            rotateReference no
+            centerToReference no
+            rotateToReference no
         }
         refpositionsfile ../Common/da.xyz
     }

--- a/namd/tests/library/014_refposgroup/test.in
+++ b/namd/tests/library/014_refposgroup/test.in
@@ -11,8 +11,8 @@ colvar {
         debugGradients yes
         atoms {
             atomNumbers  4
-            rotateReference yes
-            centerReference yes
+            rotateToReference yes
+            centerToReference yes
             fittingGroup {
                 atomNumbers  54 64 74 84 99 
             }

--- a/namd/tests/library/025_sym_rmsd/test.in
+++ b/namd/tests/library/025_sym_rmsd/test.in
@@ -5,8 +5,8 @@ colvar {
 
     rmsd {
         atoms {
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 atomNumbers 50 51 52 53 54 55 56 57 58
             }
@@ -22,8 +22,8 @@ colvar {
 
     rmsd {
         atoms {
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 atomNumbers 50 51 52 53 54 55 56 57 58
             }
@@ -43,8 +43,8 @@ colvar {
     rmsd {
         name r1
         atoms {
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 atomNumbers 50 51 52 53 54 55 56 57 58
             }
@@ -56,8 +56,8 @@ colvar {
     rmsd {
         name r2
         atoms {
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 atomNumbers 50 51 52 53 54 55 56 57 58
             }
@@ -69,8 +69,8 @@ colvar {
     rmsd {
         name r3
         atoms {
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 atomNumbers 50 51 52 53 54 55 56 57 58
             }

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -328,19 +328,7 @@ public:
   /// If yes, returns 1-based number of a common atom; else, returns 0
   static int overlap(const atom_group &g1, const atom_group &g2);
 
-  /// \brief When updating atomic coordinates, translate them to align with the
-  /// center of mass of the reference coordinates
-  bool b_center;
-
-  /// \brief When updating atom coordinates (and after
-  /// centering them if b_center is set), rotate the group to
-  /// align with the reference coordinates.
-  ///
-  /// Note: gradients will be calculated in the rotated frame: when
-  /// forces will be applied, they will rotated back to the original
-  /// frame
-  bool b_rotate;
-  /// The rotation calculated automatically if b_rotate is defined
+  /// The rotation calculated automatically if f_ag_rotate is defined
   cvm::rotation rot;
 
   /// \brief Indicates that the user has explicitly set centerReference or
@@ -348,15 +336,15 @@ public:
   /// cvc's (eg rmsd, eigenvector) will not override the user's choice
   bool b_user_defined_fit;
 
-  /// \brief use reference coordinates for b_center or b_rotate
+  /// \brief use reference coordinates for f_ag_center or f_ag_rotate
   std::vector<cvm::atom_pos> ref_pos;
 
   /// \brief Center of geometry of the reference coordinates; regardless
-  /// of whether b_center is true, ref_pos is centered to zero at
+  /// of whether f_ag_center is true, ref_pos is centered to zero at
   /// initialization, and ref_pos_cog serves to center the positions
   cvm::atom_pos              ref_pos_cog;
 
-  /// \brief If b_center or b_rotate is true, use this group to
+  /// \brief If f_ag_center or f_ag_rotate is true, use this group to
   /// define the transformation (default: this group itself)
   atom_group                *fitting_group;
 
@@ -395,12 +383,12 @@ public:
   void apply_translation(cvm::rvector const &t);
 
   /// \brief Get the current velocities; this must be called always
-  /// *after* read_positions(); if b_rotate is defined, the same
+  /// *after* read_positions(); if f_ag_rotate is defined, the same
   /// rotation applied to the coordinates will be used
   void read_velocities();
 
   /// \brief Get the current total_forces; this must be called always
-  /// *after* read_positions(); if b_rotate is defined, the same
+  /// *after* read_positions(); if f_ag_rotate is defined, the same
   /// rotation applied to the coordinates will be used
   void read_total_forces();
 

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -331,7 +331,7 @@ public:
   /// The rotation calculated automatically if f_ag_rotate is defined
   cvm::rotation rot;
 
-  /// \brief Indicates that the user has explicitly set centerReference or
+  /// \brief Indicates that the user has explicitly set centerToReference or
   /// rotateReference, and the corresponding reference:
   /// cvc's (eg rmsd, eigenvector) will not override the user's choice
   bool b_user_defined_fit;

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -426,7 +426,7 @@ void colvar::cvc::collect_gradients(std::vector<int> const &atom_ids, std::vecto
 
     // If necessary, apply inverse rotation to get atomic
     // gradient in the laboratory frame
-    if (ag.b_rotate) {
+    if (ag.is_enabled(f_ag_rotate)) {
       cvm::rotation const rot_inv = ag.rot.inverse();
 
       for (size_t k = 0; k < ag.size(); k++) {
@@ -505,7 +505,7 @@ void colvar::cvc::debug_gradients()
     cvm::atom_pos fit_gradient_sum, gradient_sum;
 
     // print the values of the fit gradients
-    if (group->b_rotate || group->b_center) {
+    if (group->is_enabled(f_ag_center) || group->is_enabled(f_ag_rotate)) {
       if (group->is_enabled(f_ag_fit_gradients)) {
         size_t j;
 
@@ -514,7 +514,7 @@ void colvar::cvc::debug_gradients()
         for (j = 0; j < group_for_fit->fit_gradients.size(); j++) {
           cvm::log((group->fitting_group ? std::string("refPosGroup") : group->key) +
                   "[" + cvm::to_str(j) + "] = " +
-                  (group->b_rotate ?
+                  (group->is_enabled(f_ag_rotate) ?
                     cvm::to_str(rot_0.rotate(group_for_fit->fit_gradients[j])) :
                     cvm::to_str(group_for_fit->fit_gradients[j])));
         }
@@ -525,7 +525,7 @@ void colvar::cvc::debug_gradients()
     for (size_t ia = 0; ia < group->size(); ia++) {
 
       // tests are best conducted in the unrotated (simulation) frame
-      cvm::rvector const atom_grad = (group->b_rotate ?
+      cvm::rvector const atom_grad = (group->is_enabled(f_ag_rotate) ?
                                       rot_inv.rotate((*group)[ia].grad) :
                                       (*group)[ia].grad);
       gradient_sum += atom_grad;

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -1028,7 +1028,7 @@ colvar::rmsd::rmsd(std::string const &conf)
     cvm::log("WARNING: explicit fitting parameters were provided for atom group \"atoms\".\n");
   } else {
     // Default: fit everything
-    cvm::log("Enabling \"centerReference\" and \"rotateReference\", to minimize RMSD before calculating it as a variable: "
+    cvm::log("Enabling \"centerToReference\" and \"rotateToReference\", to minimize RMSD before calculating it as a variable: "
               "if this is not the desired behavior, disable them explicitly within the \"atoms\" block.\n");
     atoms->enable(f_ag_center);
     atoms->enable(f_ag_rotate);
@@ -1284,7 +1284,7 @@ colvar::eigenvector::eigenvector(std::string const &conf)
     cvm::log("WARNING: explicit fitting parameters were provided for atom group \"atoms\".\n");
   } else {
     // default: fit everything
-    cvm::log("Enabling \"centerReference\" and \"rotateReference\", to minimize RMSD before calculating the vector projection: "
+    cvm::log("Enabling \"centerToReference\" and \"rotateToReference\", to minimize RMSD before calculating the vector projection: "
               "if this is not the desired behavior, disable them explicitly within the \"atoms\" block.\n");
     atoms->enable(f_ag_center);
     atoms->enable(f_ag_rotate);

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -810,7 +810,7 @@ colvar::gyration::gyration(std::string const &conf)
   if (atoms->b_user_defined_fit) {
     cvm::log("WARNING: explicit fitting parameters were provided for atom group \"atoms\".\n");
   } else {
-    atoms->b_center = true;
+    atoms->enable(f_ag_center);
     atoms->ref_pos.assign(1, cvm::atom_pos(0.0, 0.0, 0.0));
     atoms->fit_gradients.assign(atoms->size(), cvm::rvector(0.0, 0.0, 0.0));
   }
@@ -1030,8 +1030,8 @@ colvar::rmsd::rmsd(std::string const &conf)
     // Default: fit everything
     cvm::log("Enabling \"centerReference\" and \"rotateReference\", to minimize RMSD before calculating it as a variable: "
               "if this is not the desired behavior, disable them explicitly within the \"atoms\" block.\n");
-    atoms->b_center = true;
-    atoms->b_rotate = true;
+    atoms->enable(f_ag_center);
+    atoms->enable(f_ag_rotate);
     // default case: reference positions for calculating the rmsd are also those used
     // for fitting
     atoms->ref_pos = ref_pos;
@@ -1156,7 +1156,7 @@ void colvar::rmsd::calc_Jacobian_derivative()
   cvm::real rotation_term = 0.0;
 
   // The rotation term only applies is coordinates are rotated
-  if (atoms->b_rotate) {
+  if (atoms->is_enabled(f_ag_rotate)) {
 
     // gradient of the rotation matrix
     cvm::matrix2d<cvm::rvector> grad_rot_mat(3, 3);
@@ -1202,7 +1202,7 @@ void colvar::rmsd::calc_Jacobian_derivative()
   }
 
   // The translation term only applies is coordinates are centered
-  cvm::real translation_term = atoms->b_center ? 3.0 : 0.0;
+  cvm::real translation_term = atoms->is_enabled(f_ag_center) ? 3.0 : 0.0;
 
   jd.real_value = x.real_value > 0.0 ?
     (3.0 * atoms->size() - 1.0 - translation_term - rotation_term) / x.real_value :
@@ -1286,8 +1286,8 @@ colvar::eigenvector::eigenvector(std::string const &conf)
     // default: fit everything
     cvm::log("Enabling \"centerReference\" and \"rotateReference\", to minimize RMSD before calculating the vector projection: "
               "if this is not the desired behavior, disable them explicitly within the \"atoms\" block.\n");
-    atoms->b_center = true;
-    atoms->b_rotate = true;
+    atoms->enable(f_ag_center);
+    atoms->enable(f_ag_rotate);
     atoms->ref_pos = ref_pos;
     atoms->center_ref_pos();
     atoms->disable(f_ag_fit_gradients); // cancel out if group is fitted on itself
@@ -1355,14 +1355,14 @@ colvar::eigenvector::eigenvector(std::string const &conf)
 
   if (b_difference_vector) {
 
-    if (atoms->b_center) {
+    if (atoms->is_enabled(f_ag_center)) {
       // both sets should be centered on the origin for fitting
       for (size_t i = 0; i < atoms->size(); i++) {
         eigenvec[i] -= eig_center;
         ref_pos[i]  -= ref_pos_center;
       }
     }
-    if (atoms->b_rotate) {
+    if (atoms->is_enabled(f_ag_rotate)) {
       atoms->rot.calc_optimal_rotation(eigenvec, ref_pos);
       for (size_t i = 0; i < atoms->size(); i++) {
         eigenvec[i] = atoms->rot.rotate(eigenvec[i]);
@@ -1372,7 +1372,7 @@ colvar::eigenvector::eigenvector(std::string const &conf)
     for (size_t i = 0; i < atoms->size(); i++) {
       eigenvec[i] -= ref_pos[i];
     }
-    if (atoms->b_center) {
+    if (atoms->is_enabled(f_ag_center)) {
       // bring back the ref positions to where they were
       for (size_t i = 0; i < atoms->size(); i++) {
         ref_pos[i] += ref_pos_center;

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -65,8 +65,8 @@ colvar::CartesianBasedPath::CartesianBasedPath(std::string const &conf): cvc(con
         cvm::atom_group* tmp_atoms = parse_group(conf, "atoms");
         if (!has_user_defined_fitting) {
             // Swipe from the rmsd class
-            tmp_atoms->b_center = true;
-            tmp_atoms->b_rotate = true;
+            tmp_atoms->enable(f_ag_center);
+            tmp_atoms->enable(f_ag_rotate);
             tmp_atoms->ref_pos = reference_frames[i_frame];
             tmp_atoms->center_ref_pos();
             tmp_atoms->enable(f_ag_fit_gradients);
@@ -87,8 +87,8 @@ colvar::CartesianBasedPath::CartesianBasedPath(std::string const &conf): cvc(con
             std::vector<cvm::atom_pos> reference_fitting_position(tmp_fitting_atoms->size());
             cvm::load_coords(reference_position_filename.c_str(), &reference_fitting_position, tmp_fitting_atoms, reference_column, reference_column_value);
             // setup the atom group for calculating
-            tmp_atoms->b_center = true;
-            tmp_atoms->b_rotate = true;
+            tmp_atoms->enable(f_ag_center);
+            tmp_atoms->enable(f_ag_rotate);
             tmp_atoms->b_user_defined_fit = true;
             tmp_atoms->disable(f_ag_scalable);
             tmp_atoms->disable(f_ag_scalable_com);

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -375,6 +375,7 @@ public:
   enum features_atomgroup {
     f_ag_active,
     f_ag_center,
+    f_ag_center_origin,
     f_ag_rotate,
     f_ag_fitting_group,
     /// Perform a standard minimum msd fit for given atoms

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -125,6 +125,10 @@ void colvarparse::mark_key_set_user(std::string const &key_str,
     cvm::log("# "+key_str+" = "+cvm::to_str(value)+"\n",
              cvm::log_user_params());
   }
+  if (parse_mode & parse_deprecation_warning) {
+    cvm::log("Warning: keyword "+key_str+
+      " is deprecated. Check the documentation for the current equivalent.\n");
+  }
 }
 
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -56,6 +56,8 @@ public:
     parse_echo = (1<<1),
     /// Print the default value of a keyword, if it is NOT given
     parse_echo_default = (1<<2),
+    /// Print a deprecation warning if the keyword is given
+    parse_deprecation_warning = (1<<3),
     /// Do not print the keyword
     parse_silent = 0,
     /// Raise error if the keyword is not provided
@@ -66,7 +68,9 @@ public:
     /// The call is being executed from a read_restart() function
     parse_restart = (1<<18),
     /// Alias for old default behavior (should be phased out)
-    parse_normal = (1<<2) | (1<<1) | (1<<17)
+    parse_normal = (1<<2) | (1<<1) | (1<<17),
+    /// Settings for a deprecated keyword
+    parse_deprecated = (1<<1) | (1<<3) | (1<<17)
   };
 
   /// \brief Check that all the keywords within "conf" are in the list

--- a/tests/distancedir-fitgroup.in
+++ b/tests/distancedir-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     distanceDir {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -19,8 +19,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/tests/distancevec-PDBflags.in
+++ b/tests/distancevec-PDBflags.in
@@ -15,8 +15,8 @@ colvar {
             atomsCol B
             atomsColValue 1
 
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsFile ../Common/da-flags.pdb
             refPositionsCol B
@@ -27,8 +27,8 @@ colvar {
             atomsCol B
             atomsColValue 2
 
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsFile ../Common/da-flags.pdb
             refPositionsCol B
@@ -51,8 +51,8 @@ colvar {
             atomsCol B
             atomsColValue 1
 
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsFile ../Common/da-partial.pdb
         }
@@ -61,8 +61,8 @@ colvar {
             atomsCol B
             atomsColValue 2
 
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsFile ../Common/da-flags.pdb
             refPositionsCol B

--- a/tests/distancevec-fitgroup.in
+++ b/tests/distancevec-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms
@@ -19,8 +19,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/tests/distancevec-refposgroup.in
+++ b/tests/distancevec-refposgroup.in
@@ -9,8 +9,8 @@ colvar {
     distanceVec {
         group1 {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms
@@ -19,8 +19,8 @@ colvar {
         }
         group2 {
             indexGroup group2
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/tests/distancez-axis-fitgroup.in
+++ b/tests/distancez-axis-fitgroup.in
@@ -10,8 +10,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -19,8 +19,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/tests/distancez-axis-refposgroup.in
+++ b/tests/distancez-axis-refposgroup.in
@@ -10,8 +10,8 @@ colvar {
         axis (0.3, -0.4, 0.5)
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -19,8 +19,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/tests/distancez-fitgroup.in
+++ b/tests/distancez-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -18,8 +18,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }
@@ -27,8 +27,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/tests/distancez-refposgroup.in
+++ b/tests/distancez-refposgroup.in
@@ -9,8 +9,8 @@ colvar {
     distanceZ {
         main {
             indexGroup group5
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -18,8 +18,8 @@ colvar {
         }
         ref {
             indexGroup group1
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }
@@ -27,8 +27,8 @@ colvar {
         }
         ref2 {
             indexGroup group10
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/tests/orientation-fitgroup.in
+++ b/tests/orientation-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/tests/orientation-refposgroup.in
+++ b/tests/orientation-refposgroup.in
@@ -9,8 +9,8 @@ colvar {
     orientation {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/tests/orientationangle-fitgroup.in
+++ b/tests/orientationangle-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     orientationAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/tests/orientationangle-refposgroup.in
+++ b/tests/orientationangle-refposgroup.in
@@ -9,8 +9,8 @@ colvar {
     orientationAngle {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/tests/orientationproj-fitgroup.in
+++ b/tests/orientationproj-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     orientationProj {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             fittingGroup {
                 indexGroup heavy_atoms

--- a/tests/orientationproj-refposgroup.in
+++ b/tests/orientationproj-refposgroup.in
@@ -9,8 +9,8 @@ colvar {
     orientationProj {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             enableFitGradients no # Not available because gradients are implicit
             refPositionsGroup {
                 indexGroup heavy_atoms

--- a/tests/rmsd-fitgroup.in
+++ b/tests/rmsd-fitgroup.in
@@ -9,8 +9,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 indexGroup heavy_atoms
             }

--- a/tests/rmsd-refposgroup.in
+++ b/tests/rmsd-refposgroup.in
@@ -9,8 +9,8 @@ colvar {
     rmsd {
         atoms {
             indexGroup RMSD_atoms
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             refPositionsGroup {
                 indexGroup heavy_atoms
             }

--- a/vmd/cv_dashboard/templates/colvar/DBC_ligand_RMSD.in
+++ b/vmd/cv_dashboard/templates/colvar/DBC_ligand_RMSD.in
@@ -14,8 +14,8 @@ colvar {
             atomNumbers 1 2 3 4
 
             # Moving frame of reference is defined below
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
             fittingGroup {
                 # Define binding site atoms used for fitting
                 atomNumbers 6 7 8 9

--- a/vmd/cv_dashboard/templates/component/orientation.in
+++ b/vmd/cv_dashboard/templates/component/orientation.in
@@ -2,8 +2,8 @@
     orientation {
         atoms {
             atomNumbers 1 2 3 4
-            # centerReference yes
-            # rotateReference yes
+            # centerToReference yes
+            # rotateToReference yes
             # enableFitGradients no # Not available because gradients are implicit
             # fittingGroup {
             #     atomNumbers 5 6 7 8

--- a/vmd/cv_dashboard/templates/other/moving_frame_of_reference.in
+++ b/vmd/cv_dashboard/templates/other/moving_frame_of_reference.in
@@ -6,8 +6,8 @@
             ## Optionally, use GROMACS-style index groups
             # indexGroup @
 
-            centerReference yes
-            rotateReference yes
+            centerToReference yes
+            rotateToReference yes
 
             ## Atoms defining the moving frame of reference
             ## if fittingGroup is omitted, atoms defined above are fitted

--- a/vmd/tests/interface/004_map_total_internal/test.in
+++ b/vmd/tests/interface/004_map_total_internal/test.in
@@ -31,8 +31,8 @@ colvar {
         atoms {
             # Use internal selection with fitting group
             indexGroup Protein
-            rotateReference yes
-            centerReference yes
+            rotateToReference yes
+            centerToReference yes
             fittingGroup {
                 atomNumbers  54 64 74 84 99 
             }


### PR DESCRIPTION
When we want to cancel center of mass motion and the target position of the fitting group is (0, 0, 0). Useful in particular for polar angles. See #386 

TODO possibly: harmonize `centerReference` and `rotateReference` ?