### PR TITLE
Access atomic data via scripting interface

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -603,14 +603,43 @@ This is normally not required during a simulation if \refkey{colvarsRestartFrequ
 Because not only a state file (used to continue simulations) but also other data files (used to analyze the trajectory) are written, it is generally recommended to call the \texttt{save} method using a prefix, rather than a complete file name:
 \cvscriptexampleinputcv{save}{"$<$job$>$"}
 
- See \ref{sec:cvscript_tcl_cv} for a complete list of scripting commands used to manage the Colvars module.}\fi % End \ifdefined\cvvmdornamd
+\cvsubsubsec{Accessing atomic data}{sec:cv_command_atomic_data}
 
+For computational efficiency the Colvars module keeps internal copies of the numeric IDs, masses, charges, positions, and optionally total forces of the atoms requested for a Colvars computation.
+At each simulation step, up-to-date versions of these properties are copied from central memory of \MDENGINE{} into the internal memory of the Colvars module.
+In a post-processing workflow or outside a simulation (e.g.{} when using VMD), this copy can be carried out as part of the \texttt{update} method:
+\cvscriptexampleinputcv{update}{~}
+\noindent{}which also performs the (re-)computation of all variables and biases defined in Colvars.
+
+For example, the current sequence of numeric IDs of the atoms processed by Colvars can be obtained as:
+\cvscriptexampleinputcv{getatomids}{~}
+\noindent{}and their current positions as:
+\cvscriptexampleinputcv{getatompositions}{~}
+\noindent{}This may prove useful to test the correctness of the coordinates passed to Colvars, particularly in regard to periodic boundary conditions (\ref{sec:colvar_atom_groups_wrapping}).
+There is currently no mechanism to modify the above fields via the scripting interface, but such capability will be added in the future.
+
+\cvnamdonly{A special case are collective variables that are based on \emph{centers of mass}, or \emph{volumetric maps} (see e.g.{} \refkey{mapTotal}{colvar|mapTotal}).
+  These are often computed by NAMD itself, and any atoms that are used only for such variables will not be included in the lists above.}
+
+While running a simulation, or when setting one up in VMD, it is possible to examine all the forces that were last applied by Colvars to the atoms, or are about to be applied:
+\cvscriptexampleinputcv{getatomappliedforces}{~}
+\noindent{}where the length and order of this sequence matches that provided by the \texttt{getatomids} method.
+A simpler way of testing the stability of a Colvars configuration before or during a simulation makes use of aggregated data, such as the energy:
+\cvscriptexampleinputcv{getenergy}{~}
+\noindent{}the root-mean-square of the Colvars applied forces:
+\cvscriptexampleinputcv{getatomappliedforcesrms}{~}
+\noindent{}or the maximum norm of the applied forces:
+\cvscriptexampleinputcv{getatomappliedforcesmax}{~}
+\noindent{}which can be matched to a specific atom via its numeric ID obtained as:
+\cvscriptexampleinputcv{getatomappliedforcesmaxid}{~}
+
+See \ref{sec:cvscript_tcl_cv} for a complete list of scripting commands used to manage atomic data and runtime parameters of he Colvars module.}\fi % End \ifdefined\cvvmdornamd
 
 \cvvmdonly{
 \cvsubsubsec{Analyzing a trajectory in VMD}{sec:cv_command_vmd_traj}
 
 One of the typical uses of Colvars in VMD is computing the values of one or more variables along an existing trajectory.
-A complete example input for this use case is shown here.
+A complete example input for this frequent use case is shown here.
 
 \begin{mdexampleinput}
 \-{\bfseries\#~Activate~the~module~on~the~current~VMD~molecule}\\
@@ -721,6 +750,8 @@ A corresponding ``\texttt{save}'' function is also available:
 \noindent{}This pair of functions is also used internally by Colvars to implement e.g.{} multiple-walker metadynamics (\ref{sec:colvarbias_meta_mr}), but they can be called from a scripted function to implement alternative coupling schemes.
 
 \ifdefined\cvvmdornamd{See \ref{sec:cvscript_tcl_bias} for a complete list of scripting commands used to manage biases.}\fi
+
+
 }\fi % End \ifdefined\cvscriptapi
 
 

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -53,7 +53,7 @@
   \end{mdframed}
 }
 
-\newcommand{\cvscriptexampleinputcv}[3]{%
+\newcommand{\cvscriptexampleinputcv}[2]{%
 \def\cvscriptargsep{~}
 \begin{mdexampleinput}{\ifdefined\cvscriptpyapi\textbf{With the ``\texttt{\cvscriptcmd{}}'' command:}\\\fi}%
 \noindent\cvscriptcmd{}~#1~#2

--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -33,6 +33,60 @@
 \texttt{-------}
 \\
 \texttt{frame : integer - Frame number}
+\item \texttt{cv getatomappliedforces}
+\\
+\texttt{Return the list of forces applied by Colvars to atoms}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{forces : array of arrays of floats - Atomic forces}
+\item \texttt{cv getatomids}
+\\
+\texttt{Return the list of indices of atoms used in Colvars}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{indices : array of ints - Atomic indices}
+\item \texttt{cv getatomcharges}
+\\
+\texttt{Return the list of charges of atoms used in Colvars}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{charges : array of floats - Atomic charges}
+\item \texttt{cv getatommasses}
+\\
+\texttt{Return the list of masses of atoms used in Colvars}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{masses : array of floats - Atomic masses}
+\item \texttt{cv getatompositions}
+\\
+\texttt{Return the list of cached positions of atoms used in Colvars}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{positions : array of arrays of floats - Atomic positions}
+\item \texttt{cv getatomtotalforces}
+\\
+\texttt{Return the list of cached total forces of atoms used in Colvars}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{forces : array of arrays of floats - Atomic total foces}
 \item \texttt{cv getconfig}
 \\
 \texttt{Get the module's configuration string read so far}

--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -28,32 +28,56 @@
 \\
 \texttt{Get or set current frame number (VMD only)}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{frame : integer - Frame number (optional)}
+\texttt{-------}
+\\
+\texttt{frame : integer - Frame number}
 \item \texttt{cv getconfig}
 \\
 \texttt{Get the module's configuration string read so far}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{conf : string - Current configuration string}
 \item \texttt{cv getenergy}
 \\
 \texttt{Get the current Colvars energy}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{E : float - Amount of energy (internal units)}
 \item \texttt{cv help [command]}
 \\
 \texttt{Get the help string of the Colvars scripting interface}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{command : string - Get the help string of this specific command (optional)}
+\texttt{-------}
+\\
+\texttt{help : string - Help string}
 \item \texttt{cv list [param]}
 \\
 \texttt{Return a list of all variables or biases}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{param : string - "colvars" or "biases"; default is "colvars" (optional)}
+\texttt{-------}
+\\
+\texttt{list : sequence of strings - List of elements}
 \item \texttt{cv listcommands}
 \\
 \texttt{Get the list of script functions, prefixed with "cv\_", "colvar\_" or "bias\_"}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{list : sequence of strings - List of commands}
 \item \texttt{cv listindexfiles}
 \\
 \texttt{Get a list of the index files loaded in this session}
@@ -75,15 +99,29 @@
 \\
 \texttt{Get or set the molecule ID on which Colvars is defined (VMD only)}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{molid : integer - Molecule ID; -1 means undefined (optional)}
+\texttt{-------}
+\\
+\texttt{molid : integer - Current molecule ID}
 \item \texttt{cv printframe}
 \\
 \texttt{Return the values that would be written to colvars.traj}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{values : string - The values}
 \item \texttt{cv printframelabels}
 \\
 \texttt{Return the labels that would be written to colvars.traj}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{Labels : string - The labels}
 \item \texttt{cv reset}
 \\
 \texttt{Delete all internal configuration}
@@ -100,19 +138,33 @@
 \item \texttt{cv savetostring}
 \\
 \texttt{Write the Colvars state to a string and return it}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{state : string - The saved state}
 \item \texttt{cv units [units]}
 \\
 \texttt{Get or set the current Colvars unit system}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{units : string - The new unit system (optional)}
+\texttt{-------}
+\\
+\texttt{units : string - The current unit system}
 \item \texttt{cv update}
 \\
 \texttt{Recalculate colvars and biases}
 \item \texttt{cv version}
 \\
 \texttt{Get the Colvars Module version number}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{version : string - Colvars version}
 \end{itemize}
 \cvsubsec{Commands to manage individual collective variables}{sec:cvscript_tcl_colvar}
 \begin{itemize}
@@ -123,6 +175,12 @@
 \texttt{\textbf{Parameters}}
 \\
 \texttt{force : float or array - Applied force; must match colvar dimensionality}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{force : float or array - Applied force; matches colvar dimensionality}
 \item \texttt{cv colvar name cvcflags <flags>}
 \\
 \texttt{Enable or disable individual components by setting their active flags}
@@ -140,24 +198,66 @@
 \texttt{\textbf{Parameters}}
 \\
 \texttt{feature : string - Name of the feature}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{state : 1/0 - State of the given feature}
 \item \texttt{cv colvar name getappliedforce}
 \\
 \texttt{Return the total of the forces applied to this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{force : float - Applied force; matches the colvar dimensionality}
 \item \texttt{cv colvar name getatomgroups}
 \\
 \texttt{Return the atom indices used by this colvar as a list of lists}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{groups : array of arrays of ints - Atom indices}
 \item \texttt{cv colvar name getatomids}
 \\
 \texttt{Return the list of atom indices used by this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{indices : array of ints - Atom indices}
 \item \texttt{cv colvar name getconfig}
 \\
 \texttt{Return the configuration string of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{conf : string - Current configuration string}
 \item \texttt{cv colvar name getgradients}
 \\
 \texttt{Return the atomic gradients of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{gradients : array of arrays of floats - Atomic gradients}
 \item \texttt{cv colvar name gettotalforce}
 \\
 \texttt{Return the sum of internal and external forces to this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{force : float - Total force; matches the colvar dimensionality}
 \item \texttt{cv colvar name getvolmapids}
 \\
 \texttt{Return the list of volumetric map indices used by this colvar}
@@ -165,9 +265,11 @@
 \\
 \texttt{Get a help summary or the help string of one colvar subcommand}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{command : string - Get the help string of this specific command (optional)}
+\texttt{-------}
+\\
+\texttt{help : string - Help string}
 \item \texttt{cv colvar name modifycvcs <confs>}
 \\
 \texttt{Modify configuration of individual components by passing string arguments}
@@ -178,6 +280,12 @@
 \item \texttt{cv colvar name run\_ave}
 \\
 \texttt{Get the current running average of the value of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{value : float or array - Averaged value; matches the colvar dimensionality}
 \item \texttt{cv colvar name set <feature> <value>}
 \\
 \texttt{Set the given feature of this colvar to a new value}
@@ -190,40 +298,90 @@
 \item \texttt{cv colvar name state}
 \\
 \texttt{Print a string representation of the feature state of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{state : string - The feature state}
 \item \texttt{cv colvar name type}
 \\
 \texttt{Get the type description of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{type : string - Type description}
 \item \texttt{cv colvar name update}
 \\
 \texttt{Recompute this colvar and return its up-to-date value}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{value : float or array - Current value; matches the colvar dimensionality}
 \item \texttt{cv colvar name value}
 \\
 \texttt{Get the current value of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{value : float or array - Current value; matches the colvar dimensionality}
 \item \texttt{cv colvar name width}
 \\
 \texttt{Get the width of this colvar}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{width : float - Value of the width}
 \end{itemize}
 \cvsubsec{Commands to manage individual biases}{sec:cvscript_tcl_bias}
 \begin{itemize}
 \item \texttt{cv bias name bin}
 \\
 \texttt{Get the current grid bin index (1D ABF only for now)}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{bin : integer - Bin index}
 \item \texttt{cv bias name bincount [index]}
 \\
 \texttt{Get the number of samples at the given grid bin (1D ABF only for now)}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{index : integer - Grid index; defaults to current bin (optional)}
+\texttt{-------}
+\\
+\texttt{samples : integer - Number of samples}
 \item \texttt{cv bias name binnum}
 \\
 \texttt{Get the total number of grid points of this bias (1D ABF only for now)}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{Bins : integer - Number of grid points}
 \item \texttt{cv bias name delete}
 \\
 \texttt{Delete this bias}
 \item \texttt{cv bias name energy}
 \\
 \texttt{Get the current energy of this bias}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{E : float - Energy value}
 \item \texttt{cv bias name get <feature>}
 \\
 \texttt{Get the value of the given feature for this bias}
@@ -231,16 +389,30 @@
 \texttt{\textbf{Parameters}}
 \\
 \texttt{feature : string - Name of the feature}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{state : 1/0 - State of the given feature}
 \item \texttt{cv bias name getconfig}
 \\
 \texttt{Return the configuration string of this bias}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{conf : string - Current configuration string}
 \item \texttt{cv bias name help [command]}
 \\
 \texttt{Get a help summary or the help string of one bias subcommand}
 \\
-\texttt{\textbf{Parameters}}
+\texttt{Returns}
 \\
-\texttt{command : string - Get the help string of this specific command (optional)}
+\texttt{-------}
+\\
+\texttt{help : string - Help string}
 \item \texttt{cv bias name load <prefix>}
 \\
 \texttt{Load data into this bias}
@@ -265,6 +437,12 @@
 \item \texttt{cv bias name savetostring}
 \\
 \texttt{Save data from this bias into a string and return it}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{state : string - The bias state}
 \item \texttt{cv bias name set <feature> <value>}
 \\
 \texttt{Set the given feature of this bias to a new value}
@@ -280,7 +458,19 @@
 \item \texttt{cv bias name state}
 \\
 \texttt{Print a string representation of the feature state of this bias}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{state : string - String representation of the bias features}
 \item \texttt{cv bias name update}
 \\
 \texttt{Recompute this bias and return its up-to-date energy}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{E : float - Energy value}
 \end{itemize}

--- a/lammps/lib/colvars/Makefile.deps
+++ b/lammps/lib/colvars/Makefile.deps
@@ -285,7 +285,7 @@ $(COLVARS_OBJ_DIR)colvarproxy.o: colvarproxy.cpp colvarmodule.h \
  lepton/include/lepton/Exception.h \
  lepton/include/lepton/ParsedExpression.h lepton/include/lepton/Parser.h \
  colvarscript_commands.h colvarscript_commands_colvar.h \
- colvarscript_commands_bias.h colvaratoms.h
+ colvarscript_commands_bias.h colvaratoms.h colvarmodule_utils.h
 $(COLVARS_OBJ_DIR)colvarproxy_replicas.o: colvarproxy_replicas.cpp \
  colvarmodule.h colvars_version.h colvarproxy.h colvartypes.h \
  colvarvalue.h colvarproxy_tcl.h colvarproxy_volmaps.h
@@ -294,7 +294,8 @@ $(COLVARS_OBJ_DIR)colvarproxy_tcl.o: colvarproxy_tcl.cpp colvarmodule.h \
  colvarproxy_tcl.h colvarproxy_volmaps.h colvaratoms.h colvarparse.h \
  colvarparams.h colvardeps.h
 $(COLVARS_OBJ_DIR)colvarproxy_volmaps.o: colvarproxy_volmaps.cpp \
- colvarmodule.h colvars_version.h colvarproxy_volmaps.h
+ colvarmodule.h colvars_version.h colvarproxy_volmaps.h \
+ colvarmodule_utils.h
 $(COLVARS_OBJ_DIR)colvarscript.o: colvarscript.cpp colvarproxy.h \
  colvarmodule.h colvars_version.h colvartypes.h colvarvalue.h \
  colvarproxy_tcl.h colvarproxy_volmaps.h colvardeps.h colvarparse.h \

--- a/lammps/src/USER-COLVARS/fix_colvars.cpp
+++ b/lammps/src/USER-COLVARS/fix_colvars.cpp
@@ -833,7 +833,7 @@ void FixColvars::post_force(int /*vflag*/)
 
   if (me == 0) {
 
-    std::vector<cvm::rvector> &fo = *(proxy->modify_atom_new_colvar_forces());
+    std::vector<cvm::rvector> &fo = *(proxy->modify_atom_applied_forces());
 
     double *fbuf = force_buf;
     for (int j=0; j < num_coords; ++j) {

--- a/lammps/src/USER-COLVARS/fix_colvars.cpp
+++ b/lammps/src/USER-COLVARS/fix_colvars.cpp
@@ -477,7 +477,7 @@ void FixColvars::one_time_init()
   memory->create(force_buf,3*num_coords,"colvars:force_buf");
 
   if (me == 0) {
-    std::vector<int> &tl = *(proxy->modify_atom_ids());
+    std::vector<int> const &tl = *(proxy->get_atom_ids());
     inthash_t *hashtable=new inthash_t;
     inthash_init(hashtable, num_coords);
     idmap = (void *)hashtable;
@@ -560,7 +560,7 @@ void FixColvars::setup(int vflag)
 
   if (me == 0) {
 
-    std::vector<int>           &id = *(proxy->modify_atom_ids());
+    std::vector<int>     const &id = *(proxy->get_atom_ids());
     std::vector<int>           &tp = *(proxy->modify_atom_types());
     std::vector<cvm::atom_pos> &cd = *(proxy->modify_atom_positions());
     std::vector<cvm::rvector>  &of = *(proxy->modify_atom_total_forces());

--- a/namd/colvars/Make.depends
+++ b/namd/colvars/Make.depends
@@ -59,16 +59,16 @@ obj/colvarbias_abf.o: \
 	colvars/src/colvarbias_abf.cpp \
 	colvars/src/colvarmodule.h \
 	colvars/src/colvars_version.h \
-	colvars/src/colvarproxy.h \
-	colvars/src/colvartypes.h \
-	colvars/src/colvarvalue.h \
-	colvars/src/colvarproxy_tcl.h \
-	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvar.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
 	colvars/src/colvarparse.h \
 	colvars/src/colvarparams.h \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarbias_abf.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvarproxy_tcl.h \
+	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvarbias.h \
 	colvars/src/colvargrid.h \
 	colvars/src/colvar_UIestimator.h
@@ -414,14 +414,16 @@ obj/colvarproxy.o: \
 	colvars/src/colvarscript_commands.h \
 	colvars/src/colvarscript_commands_colvar.h \
 	colvars/src/colvarscript_commands_bias.h \
-	colvars/src/colvaratoms.h
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarmodule_utils.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarproxy.o $(COPTC) colvars/src/colvarproxy.cpp
 obj/colvarproxy_volmaps.o: \
 	obj/.exists \
 	colvars/src/colvarproxy_volmaps.cpp \
 	colvars/src/colvarmodule.h \
 	colvars/src/colvars_version.h \
-	colvars/src/colvarproxy_volmaps.h
+	colvars/src/colvarproxy_volmaps.h \
+	colvars/src/colvarmodule_utils.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarproxy_volmaps.o $(COPTC) colvars/src/colvarproxy_volmaps.cpp
 obj/colvarproxy_replicas.o: \
 	obj/.exists \

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1082,43 +1082,6 @@ int colvarproxy_namd::backup_file(char const *filename)
 }
 
 
-char const *colvarproxy_namd::script_obj_to_str(unsigned char *obj)
-{
-#ifdef NAMD_TCL
-  return colvarproxy_tcl::tcl_get_str(obj);
-#else
-  // This is most likely not going to be executed
-  return colvarproxy::script_obj_to_str(obj);
-#endif
-}
-
-
-std::vector<std::string> colvarproxy_namd::script_obj_to_str_vector(unsigned char *obj)
-{
-  if (cvm::debug()) {
-    cvm::log("Called colvarproxy_namd::script_obj_to_str_vector().\n");
-  }
-  std::vector<std::string> result;
-#ifdef NAMD_TCL
-  Tcl_Interp *interp = reinterpret_cast<Tcl_Interp *>(tcl_interp_);
-  Tcl_Obj *tcl_obj = reinterpret_cast<Tcl_Obj *>(obj);
-  Tcl_Obj **tcl_list_elems = NULL;
-  int count = 0;
-  if (Tcl_ListObjGetElements(interp, tcl_obj, &count, &tcl_list_elems) ==
-      TCL_OK) {
-    result.reserve(count);
-    for (int i = 0; i < count; i++) {
-      result.push_back(Tcl_GetString(tcl_list_elems[i]));
-    }
-  } else {
-    Tcl_SetResult(interp,
-                  const_cast<char *>("Cannot parse Tcl list."), TCL_STATIC);
-  }
-#endif
-  return result;
-}
-
-
 int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
 {
   if (cvm::debug())

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -259,8 +259,6 @@ public:
   int close_output_stream(std::string const &output_name);
   int backup_file(char const *filename);
 
-  char const *script_obj_to_str(unsigned char *obj);
-  std::vector<std::string> script_obj_to_str_vector(unsigned char *obj);
 };
 
 

--- a/namd/tests/interface/000_doc_scripting_commands/AutoDiff/test.output.dat
+++ b/namd/tests/interface/000_doc_scripting_commands/AutoDiff/test.output.dat
@@ -11,6 +11,9 @@ cv configfile <conf_file>
 cv delete
 cv frame [frame]
 cv getatomappliedforces
+cv getatomappliedforcesmax
+cv getatomappliedforcesmaxid
+cv getatomappliedforcesrms
 cv getatomids
 cv getatomcharges
 cv getatommasses
@@ -575,7 +578,7 @@ Help for script function "cv_getatomappliedforces":
 
 cv getatomappliedforces
 
-Return the list of forces applied by Colvars to atoms
+Get the list of forces applied by Colvars to atoms
 
 Returns
 -------
@@ -583,11 +586,47 @@ Returns
 forces : array of arrays of floats - Atomic forces
 
 ======================================================================
+Help for script function "cv_getatomappliedforcesmax":
+
+cv getatomappliedforcesmax
+
+Get the maximum norm of forces applied by Colvars to atoms
+
+Returns
+-------
+
+force : float - Maximum atomic force
+
+======================================================================
+Help for script function "cv_getatomappliedforcesmaxid":
+
+cv getatomappliedforcesmaxid
+
+Get the atom ID with the largest applied force
+
+Returns
+-------
+
+id : int - ID of the atom with the maximum atomic force
+
+======================================================================
+Help for script function "cv_getatomappliedforcesrms":
+
+cv getatomappliedforcesrms
+
+Get the root-mean-square norm of forces applied by Colvars to atoms
+
+Returns
+-------
+
+force : float - RMS atomic force
+
+======================================================================
 Help for script function "cv_getatomcharges":
 
 cv getatomcharges
 
-Return the list of charges of atoms used in Colvars
+Get the list of charges of atoms used in Colvars
 
 Returns
 -------
@@ -599,7 +638,7 @@ Help for script function "cv_getatomids":
 
 cv getatomids
 
-Return the list of indices of atoms used in Colvars
+Get the list of indices of atoms used in Colvars
 
 Returns
 -------
@@ -611,7 +650,7 @@ Help for script function "cv_getatommasses":
 
 cv getatommasses
 
-Return the list of masses of atoms used in Colvars
+Get the list of masses of atoms used in Colvars
 
 Returns
 -------
@@ -623,7 +662,7 @@ Help for script function "cv_getatompositions":
 
 cv getatompositions
 
-Return the list of cached positions of atoms used in Colvars
+Get the list of cached positions of atoms used in Colvars
 
 Returns
 -------
@@ -635,7 +674,7 @@ Help for script function "cv_getatomtotalforces":
 
 cv getatomtotalforces
 
-Return the list of cached total forces of atoms used in Colvars
+Get the list of cached total forces of atoms used in Colvars
 
 Returns
 -------

--- a/namd/tests/interface/000_doc_scripting_commands/AutoDiff/test.output.dat
+++ b/namd/tests/interface/000_doc_scripting_commands/AutoDiff/test.output.dat
@@ -10,6 +10,12 @@ cv config <conf>
 cv configfile <conf_file>
 cv delete
 cv frame [frame]
+cv getatomappliedforces
+cv getatomids
+cv getatomcharges
+cv getatommasses
+cv getatompositions
+cv getatomtotalforces
 cv getconfig
 cv getenergy
 cv help [command]
@@ -563,6 +569,78 @@ Returns
 -------
 
 frame : integer - Frame number
+
+======================================================================
+Help for script function "cv_getatomappliedforces":
+
+cv getatomappliedforces
+
+Return the list of forces applied by Colvars to atoms
+
+Returns
+-------
+
+forces : array of arrays of floats - Atomic forces
+
+======================================================================
+Help for script function "cv_getatomcharges":
+
+cv getatomcharges
+
+Return the list of charges of atoms used in Colvars
+
+Returns
+-------
+
+charges : array of floats - Atomic charges
+
+======================================================================
+Help for script function "cv_getatomids":
+
+cv getatomids
+
+Return the list of indices of atoms used in Colvars
+
+Returns
+-------
+
+indices : array of ints - Atomic indices
+
+======================================================================
+Help for script function "cv_getatommasses":
+
+cv getatommasses
+
+Return the list of masses of atoms used in Colvars
+
+Returns
+-------
+
+masses : array of floats - Atomic masses
+
+======================================================================
+Help for script function "cv_getatompositions":
+
+cv getatompositions
+
+Return the list of cached positions of atoms used in Colvars
+
+Returns
+-------
+
+positions : array of arrays of floats - Atomic positions
+
+======================================================================
+Help for script function "cv_getatomtotalforces":
+
+cv getatomtotalforces
+
+Return the list of cached total forces of atoms used in Colvars
+
+Returns
+-------
+
+forces : array of arrays of floats - Atomic total foces
 
 ======================================================================
 Help for script function "cv_getconfig":

--- a/namd/tests/interface/000_doc_scripting_commands/AutoDiff/test.output.dat
+++ b/namd/tests/interface/000_doc_scripting_commands/AutoDiff/test.output.dat
@@ -101,6 +101,12 @@ Help for script function "bias_bin":
 cv bias name bin
 
 Get the current grid bin index (1D ABF only for now)
+
+Returns
+-------
+
+bin : integer - Bin index
+
 ======================================================================
 Help for script function "bias_bincount":
 
@@ -108,16 +114,23 @@ cv bias name bincount [index]
 
 Get the number of samples at the given grid bin (1D ABF only for now)
 
-Parameters
-----------
+Returns
+-------
 
-index : integer - Grid index; defaults to current bin (optional)
+samples : integer - Number of samples
+
 ======================================================================
 Help for script function "bias_binnum":
 
 cv bias name binnum
 
 Get the total number of grid points of this bias (1D ABF only for now)
+
+Returns
+-------
+
+Bins : integer - Number of grid points
+
 ======================================================================
 Help for script function "bias_delete":
 
@@ -130,6 +143,12 @@ Help for script function "bias_energy":
 cv bias name energy
 
 Get the current energy of this bias
+
+Returns
+-------
+
+E : float - Energy value
+
 ======================================================================
 Help for script function "bias_get":
 
@@ -141,12 +160,24 @@ Parameters
 ----------
 
 feature : string - Name of the feature
+
+Returns
+-------
+
+state : 1/0 - State of the given feature
+
 ======================================================================
 Help for script function "bias_getconfig":
 
 cv bias name getconfig
 
 Return the configuration string of this bias
+
+Returns
+-------
+
+conf : string - Current configuration string
+
 ======================================================================
 Help for script function "bias_help":
 
@@ -154,10 +185,11 @@ cv bias name help [command]
 
 Get a help summary or the help string of one bias subcommand
 
-Parameters
-----------
+Returns
+-------
 
-command : string - Get the help string of this specific command (optional)
+help : string - Help string
+
 ======================================================================
 Help for script function "bias_load":
 
@@ -197,6 +229,12 @@ Help for script function "bias_savetostring":
 cv bias name savetostring
 
 Save data from this bias into a string and return it
+
+Returns
+-------
+
+state : string - The bias state
+
 ======================================================================
 Help for script function "bias_set":
 
@@ -221,12 +259,24 @@ Help for script function "bias_state":
 cv bias name state
 
 Print a string representation of the feature state of this bias
+
+Returns
+-------
+
+state : string - String representation of the bias features
+
 ======================================================================
 Help for script function "bias_update":
 
 cv bias name update
 
 Recompute this bias and return its up-to-date energy
+
+Returns
+-------
+
+E : float - Energy value
+
 ======================================================================
 Help for script function "colvar_addforce":
 
@@ -238,6 +288,12 @@ Parameters
 ----------
 
 force : float or array - Applied force; must match colvar dimensionality
+
+Returns
+-------
+
+force : float or array - Applied force; matches colvar dimensionality
+
 ======================================================================
 Help for script function "colvar_cvcflags":
 
@@ -266,42 +322,84 @@ Parameters
 ----------
 
 feature : string - Name of the feature
+
+Returns
+-------
+
+state : 1/0 - State of the given feature
+
 ======================================================================
 Help for script function "colvar_getappliedforce":
 
 cv colvar name getappliedforce
 
 Return the total of the forces applied to this colvar
+
+Returns
+-------
+
+force : float - Applied force; matches the colvar dimensionality
+
 ======================================================================
 Help for script function "colvar_getatomgroups":
 
 cv colvar name getatomgroups
 
 Return the atom indices used by this colvar as a list of lists
+
+Returns
+-------
+
+groups : array of arrays of ints - Atom indices
+
 ======================================================================
 Help for script function "colvar_getatomids":
 
 cv colvar name getatomids
 
 Return the list of atom indices used by this colvar
+
+Returns
+-------
+
+indices : array of ints - Atom indices
+
 ======================================================================
 Help for script function "colvar_getconfig":
 
 cv colvar name getconfig
 
 Return the configuration string of this colvar
+
+Returns
+-------
+
+conf : string - Current configuration string
+
 ======================================================================
 Help for script function "colvar_getgradients":
 
 cv colvar name getgradients
 
 Return the atomic gradients of this colvar
+
+Returns
+-------
+
+gradients : array of arrays of floats - Atomic gradients
+
 ======================================================================
 Help for script function "colvar_gettotalforce":
 
 cv colvar name gettotalforce
 
 Return the sum of internal and external forces to this colvar
+
+Returns
+-------
+
+force : float - Total force; matches the colvar dimensionality
+
 ======================================================================
 Help for script function "colvar_getvolmapids":
 
@@ -315,10 +413,11 @@ cv colvar name help [command]
 
 Get a help summary or the help string of one colvar subcommand
 
-Parameters
-----------
+Returns
+-------
 
-command : string - Get the help string of this specific command (optional)
+help : string - Help string
+
 ======================================================================
 Help for script function "colvar_modifycvcs":
 
@@ -336,6 +435,12 @@ Help for script function "colvar_run_ave":
 cv colvar name run_ave
 
 Get the current running average of the value of this colvar
+
+Returns
+-------
+
+value : float or array - Averaged value; matches the colvar dimensionality
+
 ======================================================================
 Help for script function "colvar_set":
 
@@ -354,30 +459,60 @@ Help for script function "colvar_state":
 cv colvar name state
 
 Print a string representation of the feature state of this colvar
+
+Returns
+-------
+
+state : string - The feature state
+
 ======================================================================
 Help for script function "colvar_type":
 
 cv colvar name type
 
 Get the type description of this colvar
+
+Returns
+-------
+
+type : string - Type description
+
 ======================================================================
 Help for script function "colvar_update":
 
 cv colvar name update
 
 Recompute this colvar and return its up-to-date value
+
+Returns
+-------
+
+value : float or array - Current value; matches the colvar dimensionality
+
 ======================================================================
 Help for script function "colvar_value":
 
 cv colvar name value
 
 Get the current value of this colvar
+
+Returns
+-------
+
+value : float or array - Current value; matches the colvar dimensionality
+
 ======================================================================
 Help for script function "colvar_width":
 
 cv colvar name width
 
 Get the width of this colvar
+
+Returns
+-------
+
+width : float - Value of the width
+
 ======================================================================
 Help for script function "cv_addenergy":
 
@@ -424,22 +559,35 @@ cv frame [frame]
 
 Get or set current frame number (VMD only)
 
-Parameters
-----------
+Returns
+-------
 
-frame : integer - Frame number (optional)
+frame : integer - Frame number
+
 ======================================================================
 Help for script function "cv_getconfig":
 
 cv getconfig
 
 Get the module's configuration string read so far
+
+Returns
+-------
+
+conf : string - Current configuration string
+
 ======================================================================
 Help for script function "cv_getenergy":
 
 cv getenergy
 
 Get the current Colvars energy
+
+Returns
+-------
+
+E : float - Amount of energy (internal units)
+
 ======================================================================
 Help for script function "cv_help":
 
@@ -447,10 +595,11 @@ cv help [command]
 
 Get the help string of the Colvars scripting interface
 
-Parameters
-----------
+Returns
+-------
 
-command : string - Get the help string of this specific command (optional)
+help : string - Help string
+
 ======================================================================
 Help for script function "cv_list":
 
@@ -458,16 +607,23 @@ cv list [param]
 
 Return a list of all variables or biases
 
-Parameters
-----------
+Returns
+-------
 
-param : string - "colvars" or "biases"; default is "colvars" (optional)
+list : sequence of strings - List of elements
+
 ======================================================================
 Help for script function "cv_listcommands":
 
 cv listcommands
 
 Get the list of script functions, prefixed with "cv_", "colvar_" or "bias_"
+
+Returns
+-------
+
+list : sequence of strings - List of commands
+
 ======================================================================
 Help for script function "cv_listindexfiles":
 
@@ -503,22 +659,35 @@ cv molid [molid]
 
 Get or set the molecule ID on which Colvars is defined (VMD only)
 
-Parameters
-----------
+Returns
+-------
 
-molid : integer - Molecule ID; -1 means undefined (optional)
+molid : integer - Current molecule ID
+
 ======================================================================
 Help for script function "cv_printframe":
 
 cv printframe
 
 Return the values that would be written to colvars.traj
+
+Returns
+-------
+
+values : string - The values
+
 ======================================================================
 Help for script function "cv_printframelabels":
 
 cv printframelabels
 
 Return the labels that would be written to colvars.traj
+
+Returns
+-------
+
+Labels : string - The labels
+
 ======================================================================
 Help for script function "cv_reset":
 
@@ -548,6 +717,12 @@ Help for script function "cv_savetostring":
 cv savetostring
 
 Write the Colvars state to a string and return it
+
+Returns
+-------
+
+state : string - The saved state
+
 ======================================================================
 Help for script function "cv_units":
 
@@ -555,10 +730,11 @@ cv units [units]
 
 Get or set the current Colvars unit system
 
-Parameters
-----------
+Returns
+-------
 
-units : string - The new unit system (optional)
+units : string - The current unit system
+
 ======================================================================
 Help for script function "cv_update":
 
@@ -571,4 +747,10 @@ Help for script function "cv_version":
 cv version
 
 Get the Colvars Module version number
+
+Returns
+-------
+
+version : string - Colvars version
+
 ======================================================================

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -754,6 +754,9 @@ int colvarmodule::calc()
 
   error_code |= end_of_step();
 
+  // TODO move this to a base-class proxy method that calls this function
+  error_code |= proxy->end_of_step();
+
   return error_code;
 }
 

--- a/src/colvarmodule_utils.h
+++ b/src/colvarmodule_utils.h
@@ -29,8 +29,9 @@ inline cvm::real get_force_norm2(cvm::real const &x)
 }
 
 
-template <typename T, int flag>
-cvm::real compute_norm2_stats(std::vector<T> const &v)
+template <typename T, int flag, bool get_index>
+cvm::real compute_norm2_stats(std::vector<T> const &v,
+                              int *minmax_index = NULL)
 {
   cvm::real result = 0.0;
   if (flag == -1) {
@@ -39,8 +40,9 @@ cvm::real compute_norm2_stats(std::vector<T> const &v)
   }
 
   typename std::vector<T>::const_iterator xi = v.begin();
+  size_t i = 0;
 
-  for ( ; xi != v.end(); xi++) {
+  for ( ; xi != v.end(); xi++, i++) {
     cvm::real const norm2 = get_force_norm2<T>(*xi);
     if (flag == 0) {
       result += norm2;
@@ -48,11 +50,13 @@ cvm::real compute_norm2_stats(std::vector<T> const &v)
     if (flag == 1) {
       if (norm2 > result) {
         result = norm2;
+        if (get_index) *minmax_index = i;
       }
     }
     if (flag == -1) {
       if (norm2 < result) {
         result = norm2;
+        if (get_index) *minmax_index = i;
       }
     }
   }

--- a/src/colvarmodule_utils.h
+++ b/src/colvarmodule_utils.h
@@ -1,0 +1,74 @@
+// -*- c++ -*-
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
+
+
+#ifndef COLVARMODULE_UTILS_H
+#define COLVARMODULE_UTILS_H
+
+
+#include "colvarmodule.h"
+
+
+template <typename T>
+cvm::real get_force_norm2(T const &x)
+{
+  return x.norm2();
+}
+
+
+template <>
+inline cvm::real get_force_norm2(cvm::real const &x)
+{
+  return x*x;
+}
+
+
+template <typename T, int flag>
+cvm::real compute_norm2_stats(std::vector<T> const &v)
+{
+  cvm::real result = 0.0;
+  if (flag == -1) {
+    // Initialize for minimum search, using approx. largest float32 value
+    result = 1.0e38;
+  }
+
+  typename std::vector<T>::const_iterator xi = v.begin();
+
+  for ( ; xi != v.end(); xi++) {
+    cvm::real const norm2 = get_force_norm2<T>(*xi);
+    if (flag == 0) {
+      result += norm2;
+    }
+    if (flag == 1) {
+      if (norm2 > result) {
+        result = norm2;
+      }
+    }
+    if (flag == -1) {
+      if (norm2 < result) {
+        result = norm2;
+      }
+    }
+  }
+
+  size_t const n = v.size();
+
+  if (flag == 0) {
+    if (n > 0) {
+      result /= cvm::real(n);
+    }
+  }
+
+  result = cvm::sqrt(result);
+
+  return result;
+}
+
+
+#endif

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -146,6 +146,7 @@ int colvarproxy_system::get_molid(int &)
 colvarproxy_atoms::colvarproxy_atoms()
 {
   atoms_rms_applied_force_ = atoms_max_applied_force_ = 0.0;
+  atoms_max_applied_force_id_ = -1;
   updated_masses_ = updated_charges_ = false;
 }
 
@@ -239,14 +240,25 @@ int colvarproxy_atoms::load_coords(char const * /* filename */,
 void colvarproxy_atoms::compute_rms_atoms_applied_force()
 {
   atoms_rms_applied_force_ =
-    compute_norm2_stats<cvm::rvector, 0>(atoms_new_colvar_forces);
+    compute_norm2_stats<cvm::rvector, 0, false>(atoms_new_colvar_forces);
 }
 
 
 void colvarproxy_atoms::compute_max_atoms_applied_force()
 {
-  atoms_max_applied_force_ =
-    compute_norm2_stats<cvm::rvector, 1>(atoms_new_colvar_forces);
+  size_t const n_atoms_ids = atoms_ids.size();
+  if ((n_atoms_ids > 0) && (n_atoms_ids == atoms_new_colvar_forces.size())) {
+    atoms_max_applied_force_ =
+      compute_norm2_stats<cvm::rvector, 1, true>(atoms_new_colvar_forces,
+                                                 &atoms_max_applied_force_id_);
+    if (atoms_max_applied_force_id_ >= 0) {
+      atoms_max_applied_force_id_ = atoms_ids[atoms_max_applied_force_id_];
+    }
+  } else {
+    atoms_max_applied_force_ =
+      compute_norm2_stats<cvm::rvector, 1, false>(atoms_new_colvar_forces);
+    atoms_max_applied_force_id_ = -1;
+  }
 }
 
 
@@ -320,14 +332,14 @@ void colvarproxy_atom_groups::clear_atom_group(int index)
 void colvarproxy_atom_groups::compute_rms_atom_groups_applied_force()
 {
   atom_groups_rms_applied_force_ =
-    compute_norm2_stats<cvm::rvector, 0>(atom_groups_new_colvar_forces);
+    compute_norm2_stats<cvm::rvector, 0, false>(atom_groups_new_colvar_forces);
 }
 
 
 void colvarproxy_atom_groups::compute_max_atom_groups_applied_force()
 {
   atom_groups_max_applied_force_ =
-    compute_norm2_stats<cvm::rvector, 1>(atom_groups_new_colvar_forces);
+    compute_norm2_stats<cvm::rvector, 1, false>(atom_groups_new_colvar_forces);
 }
 
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -474,22 +474,6 @@ colvarproxy_script::colvarproxy_script()
 colvarproxy_script::~colvarproxy_script() {}
 
 
-char const *colvarproxy_script::script_obj_to_str(unsigned char *obj)
-{
-  cvm::error("Error: trying to print a script object without a scripting "
-             "language interface.\n", BUG_ERROR);
-  return reinterpret_cast<char *>(obj);
-}
-
-
-std::vector<std::string> colvarproxy_script::script_obj_to_str_vector(unsigned char * /* obj */)
-{
-  cvm::error("Error: trying to print a script object without a scripting "
-             "language interface.\n", BUG_ERROR);
-  return std::vector<std::string>();
-}
-
-
 int colvarproxy_script::run_force_callback()
 {
   return COLVARS_NOT_IMPLEMENTED;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -362,6 +362,9 @@ protected:
   /// Maximum norm among all applied forces
   cvm::real atoms_max_applied_force_;
 
+  /// ID of the atom with the maximum norm among all applied forces
+  int atoms_max_applied_force_id_;
+
   /// Whether the masses and charges have been updated from the host code
   bool updated_masses_, updated_charges_;
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -273,11 +273,21 @@ public:
     return &atoms_ids;
   }
 
+  inline std::vector<cvm::real> const *get_atom_masses() const
+  {
+    return &atoms_masses;
+  }
+
   inline std::vector<cvm::real> *modify_atom_masses()
   {
     // assume that we are requesting masses to change them
     updated_masses_ = true;
     return &atoms_masses;
+  }
+
+  inline std::vector<cvm::real> const *get_atom_charges()
+  {
+    return &atoms_charges;
   }
 
   inline std::vector<cvm::real> *modify_atom_charges()
@@ -287,14 +297,29 @@ public:
     return &atoms_charges;
   }
 
+  inline std::vector<cvm::rvector> const *get_atom_positions() const
+  {
+    return &atoms_positions;
+  }
+
   inline std::vector<cvm::rvector> *modify_atom_positions()
   {
     return &atoms_positions;
   }
 
+  inline std::vector<cvm::rvector> const *modify_atom_total_forces() const
+  {
+    return &atoms_total_forces;
+  }
+
   inline std::vector<cvm::rvector> *modify_atom_total_forces()
   {
     return &atoms_total_forces;
+  }
+
+  inline std::vector<cvm::rvector> const *get_atom_applied_forces() const
+  {
+    return &atoms_new_colvar_forces;
   }
 
   inline std::vector<cvm::rvector> *modify_atom_applied_forces()

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -302,6 +302,24 @@ public:
     return &atoms_new_colvar_forces;
   }
 
+  /// Compute the root-mean-square of the applied forces
+  void compute_rms_atoms_applied_force();
+
+  /// Compute the maximum norm among all applied forces
+  void compute_max_atoms_applied_force();
+
+  /// Get the root-mean-square of the applied forces
+  inline cvm::real rms_atoms_applied_force() const
+  {
+    return atoms_rms_applied_force_;
+  }
+
+  /// Get the maximum norm among all applied forces
+  inline cvm::real max_atoms_applied_force() const
+  {
+    return atoms_max_applied_force_;
+  }
+
   /// Record whether masses have been updated
   inline bool updated_masses() const
   {
@@ -331,6 +349,12 @@ protected:
   std::vector<cvm::rvector> atoms_total_forces;
   /// \brief Forces applied from colvars, to be communicated to the MD integrator
   std::vector<cvm::rvector> atoms_new_colvar_forces;
+
+  /// Root-mean-square of the applied forces
+  cvm::real atoms_rms_applied_force_;
+
+  /// Maximum norm among all applied forces
+  cvm::real atoms_max_applied_force_;
 
   /// Whether the masses and charges have been updated from the host code
   bool updated_masses_, updated_charges_;
@@ -410,6 +434,56 @@ public:
     return cvm::rvector(0.0);
   }
 
+  inline std::vector<int> const *get_atom_group_ids() const
+  {
+    return &atom_groups_ids;
+  }
+
+  inline std::vector<cvm::real> *modify_atom_group_masses()
+  {
+    // TODO updated_masses
+    return &atom_groups_masses;
+  }
+
+  inline std::vector<cvm::real> *modify_atom_group_charges()
+  {
+    // TODO updated masses
+    return &atom_groups_charges;
+  }
+
+  inline std::vector<cvm::rvector> *modify_atom_group_positions()
+  {
+    return &atom_groups_coms;
+  }
+
+  inline std::vector<cvm::rvector> *modify_atom_group_total_forces()
+  {
+    return &atom_groups_total_forces;
+  }
+
+  inline std::vector<cvm::rvector> *modify_atom_group_applied_forces()
+  {
+    return &atom_groups_new_colvar_forces;
+  }
+
+  /// Compute the root-mean-square of the applied forces
+  void compute_rms_atom_groups_applied_force();
+
+  /// Compute the maximum norm among all applied forces
+  void compute_max_atom_groups_applied_force();
+
+  /// Get the root-mean-square of the applied forces
+  inline cvm::real rms_atom_groups_applied_force() const
+  {
+    return atom_groups_rms_applied_force_;
+  }
+
+  /// Get the maximum norm among all applied forces
+  inline cvm::real max_atom_groups_applied_force() const
+  {
+    return atom_groups_max_applied_force_;
+  }
+
 protected:
 
   /// \brief Array of 0-based integers used to uniquely associate atom groups
@@ -427,6 +501,12 @@ protected:
   std::vector<cvm::rvector> atom_groups_total_forces;
   /// \brief Forces applied from colvars, to be communicated to the MD integrator
   std::vector<cvm::rvector> atom_groups_new_colvar_forces;
+
+  /// Root-mean-square of the applied group forces
+  cvm::real atom_groups_rms_applied_force_;
+
+  /// Maximum norm among all applied group forces
+  cvm::real atom_groups_max_applied_force_;
 
   /// Used by all init_atom_group() functions: create a slot for an atom group not requested yet
   int add_atom_group_slot(int atom_group_id);

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -268,7 +268,7 @@ public:
     return cvm::rvector(0.0);
   }
 
-  inline std::vector<int> *modify_atom_ids()
+  inline std::vector<int> const *get_atom_ids() const
   {
     return &atoms_ids;
   }
@@ -705,6 +705,9 @@ public:
 
   /// \brief Update data based from the results of a module update (e.g. send forces)
   virtual int update_output();
+
+  /// Carry out operations needed before next step is run
+  int end_of_step();
 
   /// Print a message to the main log
   virtual void log(std::string const &message) = 0;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -525,12 +525,6 @@ public:
   /// Destructor
   virtual ~colvarproxy_script();
 
-  /// Convert a script object (Tcl or Python call argument) to a C string
-  virtual char const *script_obj_to_str(unsigned char *obj);
-
-  /// Convert a script object (Tcl or Python call argument) to a vector of strings
-  virtual std::vector<std::string> script_obj_to_str_vector(unsigned char *obj);
-
   /// Pointer to the scripting interface object
   /// (does not need to be allocated in a new interface)
   colvarscript *script;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -297,7 +297,7 @@ public:
     return &atoms_total_forces;
   }
 
-  inline std::vector<cvm::rvector> *modify_atom_new_colvar_forces()
+  inline std::vector<cvm::rvector> *modify_atom_applied_forces()
   {
     return &atoms_new_colvar_forces;
   }

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -307,7 +307,7 @@ public:
     return &atoms_positions;
   }
 
-  inline std::vector<cvm::rvector> const *modify_atom_total_forces() const
+  inline std::vector<cvm::rvector> const *get_atom_total_forces() const
   {
     return &atoms_total_forces;
   }

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -320,6 +320,12 @@ public:
     return atoms_max_applied_force_;
   }
 
+  /// Get the atom ID with the largest applied force
+  inline int max_atoms_applied_force_id() const
+  {
+    return atoms_max_applied_force_id_;
+  }
+
   /// Record whether masses have been updated
   inline bool updated_masses() const
   {

--- a/src/colvarproxy_tcl.h
+++ b/src/colvarproxy_tcl.h
@@ -27,7 +27,7 @@ public:
   /// Is Tcl available? (trigger initialization if needed)
   int tcl_available();
 
-  /// Tcl implementation of script_obj_to_str()
+  /// Get a string representation of the Tcl object pointed to by obj
   char const *tcl_get_str(void *obj);
 
   /// Tcl implementation of run_force_callback()

--- a/src/colvarproxy_volmaps.cpp
+++ b/src/colvarproxy_volmaps.cpp
@@ -123,12 +123,12 @@ int colvarproxy_volmaps::compute_volmap(int /* flags */,
 void colvarproxy_volmaps::compute_rms_volmaps_applied_force()
 {
   volmaps_rms_applied_force_ =
-    compute_norm2_stats<cvm::real, 0>(volmaps_new_colvar_forces);
+    compute_norm2_stats<cvm::real, 0, false>(volmaps_new_colvar_forces);
 }
 
 
 void colvarproxy_volmaps::compute_max_volmaps_applied_force()
 {
   volmaps_max_applied_force_ =
-    compute_norm2_stats<cvm::real, 1>(volmaps_new_colvar_forces);
+    compute_norm2_stats<cvm::real, 1, false>(volmaps_new_colvar_forces);
 }

--- a/src/colvarproxy_volmaps.cpp
+++ b/src/colvarproxy_volmaps.cpp
@@ -9,9 +9,13 @@
 
 #include "colvarmodule.h"
 #include "colvarproxy_volmaps.h"
+#include "colvarmodule_utils.h"
 
 
-colvarproxy_volmaps::colvarproxy_volmaps() {}
+colvarproxy_volmaps::colvarproxy_volmaps()
+{
+  volmaps_rms_applied_force_ = volmaps_max_applied_force_ = 0.0;
+}
 
 
 colvarproxy_volmaps::~colvarproxy_volmaps() {}
@@ -113,4 +117,18 @@ int colvarproxy_volmaps::compute_volmap(int /* flags */,
                                         cvm::real * /* atom_field */)
 {
   return COLVARS_NOT_IMPLEMENTED;
+}
+
+
+void colvarproxy_volmaps::compute_rms_volmaps_applied_force()
+{
+  volmaps_rms_applied_force_ =
+    compute_norm2_stats<cvm::real, 0>(volmaps_new_colvar_forces);
+}
+
+
+void colvarproxy_volmaps::compute_max_volmaps_applied_force()
+{
+  volmaps_max_applied_force_ =
+    compute_norm2_stats<cvm::real, 1>(volmaps_new_colvar_forces);
 }

--- a/src/colvarproxy_volmaps.h
+++ b/src/colvarproxy_volmaps.h
@@ -95,6 +95,12 @@ public:
     volmap_flag_use_atom_field = (1<<8)
   };
 
+  /// Compute the root-mean-square of the applied forces
+  void compute_rms_volmaps_applied_force();
+
+  /// Compute the maximum norm among all applied forces
+  void compute_max_volmaps_applied_force();
+
 protected:
 
   /// \brief Array of numeric IDs of volumetric maps
@@ -110,6 +116,12 @@ protected:
   /// \brief Forces applied from colvars, to be communicated to the MD
   /// integrator
   std::vector<cvm::real>    volmaps_new_colvar_forces;
+
+  /// Root-mean-square of the the applied forces
+  cvm::real volmaps_rms_applied_force_;
+
+  /// Maximum norm among all applied forces
+  cvm::real volmaps_max_applied_force_;
 };
 
 

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -696,8 +696,17 @@ int tcl_run_colvarscript_command(ClientData /* clientData */,
 
   cvm::clear_error();
 
-  int retval = script->run(objc,
-                           reinterpret_cast<unsigned char * const *>(objv));
+  unsigned char * arg_pointers_[100];
+  if (objc > 100) {
+    std::string const errstr = "Too many positional arguments ("+
+      cvm::to_str(objc)+") passed to the \"cv\" command.\n";
+    Tcl_SetResult(interp, const_cast<char *>(errstr.c_str()), TCL_VOLATILE);
+    return TCL_ERROR;
+  }
+  for (int i = 0; i < objc; i++) {
+    arg_pointers_[i] = reinterpret_cast<unsigned char *>(const_cast<char *>(proxy->tcl_get_str(objv[i])));
+  }
+  int retval = script->run(objc, arg_pointers_);
 
   std::string result = proxy->get_error_msgs() + script->result;
 

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -346,6 +346,60 @@ int colvarscript::run(int objc, unsigned char *const objv[])
 }
 
 
+char *colvarscript::obj_to_str(unsigned char *obj)
+{
+  char *strobj = reinterpret_cast<char *>(obj);
+  if (cvm::debug()) {
+    cvm::log("Using simple-cast script::obj_to_str(): result = \"" +
+             (strobj ? std::string(strobj) : std::string("(null)")) + "\"");
+  }
+  return strobj;
+}
+
+
+std::vector<std::string> colvarscript::obj_to_str_vector(unsigned char *obj)
+{
+  if (cvm::debug()) {
+    cvm::log("Using simple-cast colvarscript::obj_to_str_vector().\n");
+  }
+
+  std::vector<std::string> new_result;
+  std::string const str(reinterpret_cast<char *>(obj));
+
+  // TODO get rid of this once colvarscript can handle both fix_modify and Tcl?
+  // LAMMPS has a nicer function in the utils class
+
+  for (size_t i = 0; i < str.length(); i++) {
+    char const c = str[i];
+    if (c == '\"') {
+      i++;
+      if (i >= str.length()) {
+        cvm::error("Error: could not split the following string:\n"+
+                   str+"\n", INPUT_ERROR);
+        break;
+      }
+      new_result.push_back(std::string(""));
+      while (str[i] != '\"') {
+        new_result.back().append(1, str[i]);
+        if (i >= str.length()) {
+          cvm::error("Error: could not split the following string:\n"+
+                     str+"\n", INPUT_ERROR);
+          break;
+        } else {
+          i++;
+        }
+      }
+    }
+  }
+
+  if (cvm::debug()) {
+    cvm::log("result = "+cvm::to_str(new_result)+".\n");
+  }
+
+  return new_result;
+}
+
+
 int colvarscript::proc_features(colvardeps *obj,
                                 int objc, unsigned char *const objv[]) {
 

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -825,6 +825,17 @@ int colvarscript::set_result_text(std::vector<cvm::rvector> const &x,
   return set_result_text_from_str(x_str, obj);
 }
 
+template <>
+int colvarscript::set_result_text(std::vector<colvarvalue> const &x,
+                                  unsigned char *obj) {
+  std::string x_str("");
+  for (size_t i = 0; i < x.size(); i++) {
+    if (i > 0) x_str.append(1, ' ');
+    x_str += "{ "+x[i].to_simple_string()+" }";
+  }
+  return set_result_text_from_str(x_str, obj);
+}
+
 
 // Member functions to set script results for each typexc
 
@@ -865,4 +876,15 @@ int colvarscript::set_result_rvector(cvm::rvector const &x, unsigned char *obj) 
 int colvarscript::set_result_rvector_vec(std::vector<cvm::rvector> const &x,
                                          unsigned char *obj) {
   return set_result_text< std::vector<cvm::rvector> >(x, obj);
+}
+
+
+int colvarscript::set_result_colvarvalue(colvarvalue const &x,
+                                         unsigned char *obj) {
+  return set_result_text<colvarvalue>(x, obj);
+}
+
+int colvarscript::set_result_colvarvalue_vec(std::vector<colvarvalue> const &x,
+                                             unsigned char *obj) {
+  return set_result_text< std::vector<colvarvalue> >(x, obj);
 }

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -796,6 +796,36 @@ int colvarscript::set_result_text(std::vector<long int> const &x,
 }
 
 
+template <>
+int colvarscript::set_result_text(cvm::real const &x, unsigned char *obj) {
+  std::string const x_str = cvm::to_str(x);
+  return set_result_text_from_str(x_str, obj);
+}
+
+template <>
+int colvarscript::set_result_text(std::vector<cvm::real> const &x,
+                                  unsigned char *obj) {
+  std::string x_str("");
+  pack_vector_elements_text<cvm::real>(x, x_str);
+  return set_result_text_from_str(x_str, obj);
+}
+
+
+// TODO these can be removed after the Tcl backend is ready (otherwise, the
+// default template syntax may break scripts or the Dashboard)
+
+template <>
+int colvarscript::set_result_text(std::vector<cvm::rvector> const &x,
+                                  unsigned char *obj) {
+  std::string x_str("");
+  for (size_t i = 0; i < x.size(); i++) {
+    if (i > 0) x_str.append(1, ' ');
+    x_str += "{ "+x[i].to_simple_string()+" }";
+  }
+  return set_result_text_from_str(x_str, obj);
+}
+
+
 // Member functions to set script results for each typexc
 
 int colvarscript::set_result_int(int const &x, unsigned char *obj) {
@@ -807,11 +837,32 @@ int colvarscript::set_result_int_vec(std::vector<int> const &x,
   return set_result_text< std::vector<int> >(x, obj);
 }
 
+
 int colvarscript::set_result_long_int(long int const &x, unsigned char *obj) {
   return set_result_text<long int>(x, obj);
 }
 
 int colvarscript::set_result_long_int_vec(std::vector<long int> const &x,
-                                     unsigned char *obj) {
+                                          unsigned char *obj) {
   return set_result_text< std::vector<long int> >(x, obj);
+}
+
+
+int colvarscript::set_result_real(cvm::real const &x, unsigned char *obj) {
+  return set_result_text<cvm::real>(x, obj);
+}
+
+int colvarscript::set_result_real_vec(std::vector<cvm::real> const &x,
+                                      unsigned char *obj) {
+  return set_result_text< std::vector<cvm::real> >(x, obj);
+}
+
+
+int colvarscript::set_result_rvector(cvm::rvector const &x, unsigned char *obj) {
+  return set_result_text<cvm::rvector>(x, obj);
+}
+
+int colvarscript::set_result_rvector_vec(std::vector<cvm::rvector> const &x,
+                                         unsigned char *obj) {
+  return set_result_text< std::vector<cvm::rvector> >(x, obj);
 }

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -137,12 +137,6 @@ public:
   template<colvarscript::Object_type T>
   int cmd_arg_shift();
 
-  /// Use scripting language to get the string representation of an object
-  inline char const *obj_to_str(unsigned char *const obj)
-  {
-    return (obj == NULL ? NULL : proxy_->script_obj_to_str(obj));
-  }
-
   /// Get names of all commands
   inline char const **get_command_names() const
   {
@@ -181,6 +175,12 @@ public:
   {
     return this->proxy_;
   }
+
+  /// Get the string representation of an object (by default, a simple cast)
+  char *obj_to_str(unsigned char *obj);
+
+  /// Get a list of strings from an object (does not work with a simple cast)
+  std::vector<std::string> obj_to_str_vector(unsigned char *obj);
 
 private:
 

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -216,14 +216,6 @@ private:
                    int n_args_min, int n_args_max, char const *arghelp,
                    int (*fn)(void *, int, unsigned char * const *));
 
-  /// Execute a script command
-  inline int exec_command(command c,
-                          void *pobj,
-                          int objc, unsigned char * const *objv)
-  {
-    return (*(cmd_fns[c]))(pobj, objc, objv);
-  }
-
 public: // TODO this function will be removed soon
 
   /// Run subcommands on base colvardeps object (colvar, bias, ...)

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -238,6 +238,13 @@ public:
   int set_result_rvector_vec(std::vector<cvm::rvector> const &x,
                              unsigned char *obj = NULL);
 
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_colvarvalue(colvarvalue const &x, unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_colvarvalue_vec(std::vector<colvarvalue> const &x,
+                                 unsigned char *obj = NULL);
+
 private:
 
   /// Set up all script API functions

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -143,9 +143,32 @@ public:
     return cmd_names;
   }
 
+  /// Get one-line help summary for a command
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  char const *get_command_help(char const *cmd);
+
+  /// Get description of the return value of a command
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  char const *get_command_rethelp(char const *cmd);
+
+  /// Get description of the argument of a command (excluding prefix)
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  /// \param i Index of the argument; 0 is the first argument after the
+  /// prefix, e.g. "value" has an index of 0 in the array of arguments:
+  /// { "cv", "colvar", "xi", "value" }
+  char const *get_command_arghelp(char const *cmd, int i);
+
+  /// Get number of required arguments (excluding prefix)
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  int get_command_n_args_min(char const *cmd);
+
+  /// Get number of total arguments (excluding prefix)
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  int get_command_n_args_max(char const *cmd);
+
   /// Get help string for a command (does not specify how it is launched)
   /// \param cmd Name of the command's function (e.g. "cv_units")
-  std::string get_command_help(char const *cmd);
+  char const *get_command_full_help(char const *cmd);
 
   /// Get summary of command line syntax for all commands of a given context
   /// \param t One of use_module, use_colvar or use_bias
@@ -218,6 +241,9 @@ private: // TODO
   /// Help strings for each command
   std::vector<std::string> cmd_help;
 
+  /// Description of the return values of each command (may be empty)
+  std::vector<std::string> cmd_rethelp;
+
   /// Minimum number of arguments for each command
   std::vector<size_t> cmd_n_args_min;
 
@@ -226,6 +252,9 @@ private: // TODO
 
   /// Help strings for each command argument
   std::vector< std::vector<std::string> > cmd_arghelp;
+
+  /// Full help strings for each command
+  std::vector<std::string> cmd_full_help;
 
   /// Implementations of each command
   std::vector<int (*)(void *, int, unsigned char * const *)> cmd_fns;
@@ -306,12 +335,12 @@ int colvarscript::check_cmd_nargs(char const *cmd,
   int const shift = cmd_arg_shift<T>();
   if (objc < shift+n_args_min) {
     add_error_msg("Missing arguments for script function \""+std::string(cmd)+
-                  "\":\n"+get_command_help(cmd));
+                  "\":\n"+get_command_full_help(cmd));
     return COLVARSCRIPT_ERROR;
   }
   if (objc > shift+n_args_max) {
     add_error_msg("Too many arguments for script function \""+std::string(cmd)+
-                  "\":\n"+get_command_help(cmd));
+                  "\":\n"+get_command_full_help(cmd));
     return COLVARSCRIPT_ERROR;
   }
   return COLVARSCRIPT_OK;

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -224,6 +224,20 @@ public:
   int set_result_long_int_vec(std::vector<long int> const &x,
                               unsigned char *obj = NULL);
 
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_real(cvm::real const &x, unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_real_vec(std::vector<cvm::real> const &x,
+                          unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_rvector(cvm::rvector const &x, unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_rvector_vec(std::vector<cvm::rvector> const &x,
+                             unsigned char *obj = NULL);
+
 private:
 
   /// Set up all script API functions

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -334,12 +334,14 @@ int colvarscript::check_cmd_nargs(char const *cmd,
 {
   int const shift = cmd_arg_shift<T>();
   if (objc < shift+n_args_min) {
-    add_error_msg("Missing arguments for script function \""+std::string(cmd)+
+    add_error_msg("Insufficient number of arguments ("+cvm::to_str(objc)+
+                  ") for script function \""+std::string(cmd)+
                   "\":\n"+get_command_full_help(cmd));
     return COLVARSCRIPT_ERROR;
   }
   if (objc > shift+n_args_max) {
-    add_error_msg("Too many arguments for script function \""+std::string(cmd)+
+    add_error_msg("Too many arguments ("+cvm::to_str(objc)+
+                  ") for script function \""+std::string(cmd)+
                   "\":\n"+get_command_full_help(cmd));
     return COLVARSCRIPT_ERROR;
   }

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -46,9 +46,8 @@ public:
   /// COLVARSCRIPT_ERROR
   int proxy_error;
 
-  /// If an error is returned by one of the methods, it should set this to the
-  /// error message
-  std::string result;
+  /// String representation of the result of a script call
+  std::string str_result_;
 
   /// Run a script command with space-separated positional arguments (objects)
   int run(int objc, unsigned char *const objv[]);
@@ -56,13 +55,13 @@ public:
   /// Get the string result of the current scripting call
   inline std::string const &str_result() const
   {
-    return result;
+    return str_result_;
   }
 
   /// Modify the string result of the current scripting call
   inline std::string &modify_str_result()
   {
-    return result;
+    return str_result_;
   }
 
   /// Set the return value to the given string
@@ -199,11 +198,31 @@ public:
     return this->proxy_;
   }
 
+  // Input functions - get the string reps of script argument objects
+
   /// Get the string representation of an object (by default, a simple cast)
   char *obj_to_str(unsigned char *obj);
 
   /// Get a list of strings from an object (does not work with a simple cast)
   std::vector<std::string> obj_to_str_vector(unsigned char *obj);
+
+
+  // Output functions - convert internal objects to representations suitable
+  // for use in the scripting language.  At the moment only conversion to C
+  // strings is supported, and obj is assumed to be a char * pointer.
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_int(int const &x, unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_int_vec(std::vector<int> const &x, unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_long_int(long int const &x, unsigned char *obj = NULL);
+
+  /// Copy x into obj if not NULL, or into the script object's result otherwise
+  int set_result_long_int_vec(std::vector<long int> const &x,
+                              unsigned char *obj = NULL);
 
 private:
 
@@ -261,6 +280,18 @@ private: // TODO
     }
     return NULL;
   }
+
+  /// Set obj equal to x, using its string representation
+  template <typename T>
+  int set_result_text(T const &x, unsigned char *obj);
+
+  /// Code reused by instances of set_result_text()
+  template <typename T>
+  int pack_vector_elements_text(std::vector<T> const &x, std::string &x_str);
+
+  /// Code reused by all instances of set_result_text()
+  int set_result_text_from_str(std::string const &x_str, unsigned char *obj);
+
 
 };
 

--- a/src/colvarscript_commands.cpp
+++ b/src/colvarscript_commands.cpp
@@ -33,6 +33,54 @@ char const **cvscript_command_names()
 }
 
 
+extern "C"
+char const *cvscript_command_help(char const *c)
+{
+  colvarscript *script = colvarscript_obj();
+  return script->get_command_help(c);
+}
+
+
+extern "C"
+char const *cvscript_command_rethelp(char const *c)
+{
+  colvarscript *script = colvarscript_obj();
+  return script->get_command_rethelp(c);
+}
+
+
+extern "C"
+char const *cvscript_command_arghelp(char const *c, int i)
+{
+  colvarscript *script = colvarscript_obj();
+  return script->get_command_arghelp(c, i);
+}
+
+
+extern "C"
+char const *cvscript_command_full_help(char const *c)
+{
+  colvarscript *script = colvarscript_obj();
+  return script->get_command_full_help(c);
+}
+
+
+extern "C"
+int cvscript_command_n_args_min(char const *c)
+{
+  colvarscript *script = colvarscript_obj();
+  return script->get_command_n_args_min(c);
+}
+
+
+extern "C"
+int cvscript_command_n_args_max(char const *c)
+{
+  colvarscript *script = colvarscript_obj();
+  return script->get_command_n_args_max(c);
+}
+
+
 // Instantiate the body of all script commands
 
 #define CVSCRIPT_COMM_FN(COMM,N_ARGS_MIN,N_ARGS_MAX,ARGS,FN_BODY)       \

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -285,7 +285,7 @@ CVSCRIPT(cv_getenergy,
          "E : float - Amount of energy (internal units)",
          0, 0,
          "",
-         script->set_result_str(cvm::to_str(cvm::main()->total_bias_energy));
+         script->set_result_real(cvm::main()->total_bias_energy);
          return COLVARS_OK;
          )
 

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -195,7 +195,7 @@ CVSCRIPT(cv_getatomappliedforces,
          "forces : array of arrays of floats - Atomic forces",
          0, 0,
          "",
-         script->set_result_rvector_vec(*(script->proxy()->modify_atom_applied_forces()));
+         script->set_result_rvector_vec(*(script->proxy()->get_atom_applied_forces()));
          return COLVARS_OK;
          )
 
@@ -240,7 +240,7 @@ CVSCRIPT(cv_getatomcharges,
          "charges : array of floats - Atomic charges",
          0, 0,
          "",
-         script->set_result_real_vec(*(script->proxy()->modify_atom_charges()));
+         script->set_result_real_vec(*(script->proxy()->get_atom_charges()));
          return COLVARS_OK;
          )
 
@@ -249,7 +249,7 @@ CVSCRIPT(cv_getatommasses,
          "masses : array of floats - Atomic masses",
          0, 0,
          "",
-         script->set_result_real_vec(*(script->proxy()->modify_atom_masses()));
+         script->set_result_real_vec(*(script->proxy()->get_atom_masses()));
          return COLVARS_OK;
          )
 
@@ -258,7 +258,7 @@ CVSCRIPT(cv_getatompositions,
          "positions : array of arrays of floats - Atomic positions",
          0, 0,
          "",
-         script->set_result_rvector_vec(*(script->proxy()->modify_atom_positions()));
+         script->set_result_rvector_vec(*(script->proxy()->get_atom_positions()));
          return COLVARS_OK;
          )
 
@@ -267,7 +267,7 @@ CVSCRIPT(cv_getatomtotalforces,
          "forces : array of arrays of floats - Atomic total foces",
          0, 0,
          "",
-         script->set_result_rvector_vec(*(script->proxy()->modify_atom_positions()));
+         script->set_result_rvector_vec(*(script->proxy()->get_atom_positions()));
          return COLVARS_OK;
          )
 

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -172,7 +172,7 @@ CVSCRIPT(cv_frame,
          if (arg == NULL) {
            long int f = -1;
            if (script->proxy()->get_frame(f) == COLVARS_OK) {
-             script->set_result_str(cvm::to_str(f));
+             script->set_result_long_int(f);
              return COLVARS_OK;
            } else {
              script->add_error_msg("Frame number is not available");
@@ -337,7 +337,7 @@ CVSCRIPT(cv_molid,
          if (arg == NULL) {
            int molid = -1;
            script->proxy()->get_molid(molid);
-           script->set_result_str(cvm::to_str(molid));
+           script->set_result_int(molid);
            return COLVARS_OK;
          } else {
            script->add_error_msg("Error: To change the molecule ID in VMD, use cv delete first.");

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -267,7 +267,7 @@ CVSCRIPT(cv_getatomtotalforces,
          "forces : array of arrays of floats - Atomic total foces",
          0, 0,
          "",
-         script->set_result_rvector_vec(*(script->proxy()->get_atom_positions()));
+         script->set_result_rvector_vec(*(script->proxy()->get_atom_total_forces()));
          return COLVARS_OK;
          )
 

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -190,6 +190,60 @@ CVSCRIPT(cv_frame,
          return COLVARS_OK;
          )
 
+CVSCRIPT(cv_getatomappliedforces,
+         "Get the list of forces applied by Colvars to atoms\n"
+         "forces : array of arrays of floats - Atomic forces",
+         0, 0,
+         "",
+         script->set_result_rvector_vec(*(script->proxy()->modify_atom_applied_forces()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatomids,
+         "Get the list of indices of atoms used in Colvars\n"
+         "indices : array of ints - Atomic indices",
+         0, 0,
+         "",
+         script->set_result_int_vec(*(script->proxy()->get_atom_ids()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatomcharges,
+         "Get the list of charges of atoms used in Colvars\n"
+         "charges : array of floats - Atomic charges",
+         0, 0,
+         "",
+         script->set_result_real_vec(*(script->proxy()->modify_atom_charges()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatommasses,
+         "Get the list of masses of atoms used in Colvars\n"
+         "masses : array of floats - Atomic masses",
+         0, 0,
+         "",
+         script->set_result_real_vec(*(script->proxy()->modify_atom_masses()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatompositions,
+         "Get the list of cached positions of atoms used in Colvars\n"
+         "positions : array of arrays of floats - Atomic positions",
+         0, 0,
+         "",
+         script->set_result_rvector_vec(*(script->proxy()->modify_atom_positions()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatomtotalforces,
+         "Get the list of cached total forces of atoms used in Colvars\n"
+         "forces : array of arrays of floats - Atomic total foces",
+         0, 0,
+         "",
+         script->set_result_rvector_vec(*(script->proxy()->modify_atom_positions()));
+         return COLVARS_OK;
+         )
+
 CVSCRIPT(cv_getconfig,
          "Get the module's configuration string read so far\n"
          "conf : string - Current configuration string",

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -25,7 +25,8 @@
 
 // COMM = the id of the command (must be a member of colvarscript::command)
 
-// HELP = a one-line description (C string literal) for the command
+// HELP = short description (C string literal) for the command; the second line
+//        is optional, and documents the return value (if any)
 
 // N_ARGS_MIN = the lowest number of arguments allowed
 
@@ -67,6 +68,33 @@ extern "C" {
 
   /// Get the names of all commands (array of strings)
   char const ** cvscript_command_names();
+
+  /// Get the help summary of the given command
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  char const *cvscript_command_help(char const *cmd);
+
+  /// Get description of the return value of a command
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  char const *cvscript_command_rethelp(char const *cmd);
+
+  /// Get description of the arguments of a command (excluding prefix)
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  /// \param i Index of the argument; 0 is the first argument after the
+  /// prefix, e.g. "value" has an index of 0 in the array of arguments:
+  /// { "cv", "colvar", "xi", "value" }
+  char const *cvscript_command_arghelp(char const *cmd, int i);
+
+  /// Get the full help string of a command
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  char const *cvscript_command_full_help(char const *cmd);
+
+  /// Get number of required arguments (excluding prefix)
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  int cvscript_command_n_args_min(char const *cmd);
+
+  /// Get number of total arguments (excluding prefix)
+  /// \param cmd Name of the command's function (e.g. "cv_units")
+  int cvscript_command_n_args_max(char const *cmd);
 
 }
 
@@ -135,7 +163,8 @@ CVSCRIPT(cv_delete,
          )
 
 CVSCRIPT(cv_frame,
-         "Get or set current frame number (VMD only)",
+         "Get or set current frame number (VMD only)\n"
+         "frame : integer - Frame number",
          0, 1,
          "frame : integer - Frame number",
          char const *arg =
@@ -162,7 +191,8 @@ CVSCRIPT(cv_frame,
          )
 
 CVSCRIPT(cv_getconfig,
-         "Get the module's configuration string read so far",
+         "Get the module's configuration string read so far\n"
+         "conf : string - Current configuration string",
          0, 0,
          "",
          script->set_result_str(cvm::main()->get_config());
@@ -170,7 +200,8 @@ CVSCRIPT(cv_getconfig,
          )
 
 CVSCRIPT(cv_getenergy,
-         "Get the current Colvars energy",
+         "Get the current Colvars energy\n"
+         "E : float - Amount of energy (internal units)",
          0, 0,
          "",
          script->set_result_str(cvm::to_str(cvm::main()->total_bias_energy));
@@ -178,7 +209,8 @@ CVSCRIPT(cv_getenergy,
          )
 
 CVSCRIPT(cv_help,
-         "Get the help string of the Colvars scripting interface",
+         "Get the help string of the Colvars scripting interface\n"
+         "help : string - Help string",
          0, 1,
          "command : string - Get the help string of this specific command",
          unsigned char *const cmdobj =
@@ -205,7 +237,8 @@ CVSCRIPT(cv_help,
          )
 
 CVSCRIPT(cv_list,
-         "Return a list of all variables or biases",
+         "Return a list of all variables or biases\n"
+         "list : sequence of strings - List of elements",
          0, 1,
          "param : string - \"colvars\" or \"biases\"; default is \"colvars\"",
          std::string res;
@@ -235,7 +268,8 @@ CVSCRIPT(cv_list,
          )
 
 CVSCRIPT(cv_listcommands,
-         "Get the list of script functions, prefixed with \"cv_\", \"colvar_\" or \"bias_\"",
+         "Get the list of script functions, prefixed with \"cv_\", \"colvar_\" or \"bias_\"\n"
+         "list : sequence of strings - List of commands",
          0, 0,
          "",
          int const n_commands = cvscript_n_commands();
@@ -294,9 +328,10 @@ CVSCRIPT(cv_loadfromstring,
          )
 
 CVSCRIPT(cv_molid,
-         "Get or set the molecule ID on which Colvars is defined (VMD only)",
+         "Get or set the molecule ID on which Colvars is defined (VMD only)\n"
+         "molid : integer - Current molecule ID",
          0, 1,
-         "molid : integer - Molecule ID; -1 means undefined",
+         "molid : integer - New molecule ID; -1 means undefined",
          char const *arg =
            script->obj_to_str(script->get_module_cmd_arg(0, objc, objv));
          if (arg == NULL) {
@@ -311,7 +346,8 @@ CVSCRIPT(cv_molid,
          )
 
 CVSCRIPT(cv_printframe,
-         "Return the values that would be written to colvars.traj",
+         "Return the values that would be written to colvars.traj\n"
+         "values : string - The values\n",
          0, 0,
          "",
          std::ostringstream os;
@@ -321,7 +357,8 @@ CVSCRIPT(cv_printframe,
          )
 
 CVSCRIPT(cv_printframelabels,
-         "Return the labels that would be written to colvars.traj",
+         "Return the labels that would be written to colvars.traj\n"
+         "Labels : string - The labels",
          0, 0,
          "",
          std::ostringstream os;
@@ -362,14 +399,16 @@ CVSCRIPT(cv_save,
          )
 
 CVSCRIPT(cv_savetostring,
-         "Write the Colvars state to a string and return it",
+         "Write the Colvars state to a string and return it\n"
+         "state : string - The saved state",
          0, 0,
          "",
          return script->module()->write_restart_string(script->modify_str_result());
          )
 
 CVSCRIPT(cv_units,
-         "Get or set the current Colvars unit system",
+         "Get or set the current Colvars unit system\n"
+         "units : string - The current unit system",
          0, 1,
          "units : string - The new unit system",
          char const *argstr =
@@ -404,7 +443,8 @@ CVSCRIPT(cv_update,
          )
 
 CVSCRIPT(cv_version,
-         "Get the Colvars Module version number",
+         "Get the Colvars Module version number\n"
+         "version : string - Colvars version",
          0, 0,
          "",
          script->set_result_str(COLVARS_VERSION);

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -199,6 +199,33 @@ CVSCRIPT(cv_getatomappliedforces,
          return COLVARS_OK;
          )
 
+CVSCRIPT(cv_getatomappliedforcesmax,
+         "Get the maximum norm of forces applied by Colvars to atoms\n"
+         "force : float - Maximum atomic force",
+         0, 0,
+         "",
+         script->set_result_real(script->proxy()->max_atoms_applied_force());
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatomappliedforcesmaxid,
+         "Get the atom ID with the largest applied force\n"
+         "id : int - ID of the atom with the maximum atomic force",
+         0, 0,
+         "",
+         script->set_result_int(script->proxy()->max_atoms_applied_force_id());
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getatomappliedforcesrms,
+         "Get the root-mean-square norm of forces applied by Colvars to atoms\n"
+         "force : float - RMS atomic force",
+         0, 0,
+         "",
+         script->set_result_real(script->proxy()->rms_atoms_applied_force());
+         return COLVARS_OK;
+         )
+
 CVSCRIPT(cv_getatomids,
          "Get the list of indices of atoms used in Colvars\n"
          "indices : array of ints - Atomic indices",

--- a/src/colvarscript_commands_bias.h
+++ b/src/colvarscript_commands_bias.h
@@ -13,7 +13,7 @@ CVSCRIPT(bias_bin,
          "bin : integer - Bin index",
          0, 0,
          "",
-         script->set_result_str(cvm::to_str(this_bias->current_bin()));
+         script->set_result_int(this_bias->current_bin());
          return COLVARS_OK;
          )
 
@@ -32,7 +32,7 @@ CVSCRIPT(bias_bincount,
              return COLVARSCRIPT_ERROR;
            }
          }
-         script->set_result_str(cvm::to_str(this_bias->bin_count(index)));
+         script->set_result_int(this_bias->bin_count(index));
          return COLVARS_OK;
          )
 
@@ -47,7 +47,7 @@ CVSCRIPT(bias_binnum,
                                  this_bias->name);
            return COLVARSCRIPT_ERROR;
          }
-         script->set_result_str(cvm::to_str(r));
+         script->set_result_int(r);
          return COLVARS_OK;
          )
 

--- a/src/colvarscript_commands_bias.h
+++ b/src/colvarscript_commands_bias.h
@@ -9,7 +9,8 @@
 
 
 CVSCRIPT(bias_bin,
-         "Get the current grid bin index (1D ABF only for now)",
+         "Get the current grid bin index (1D ABF only for now)\n"
+         "bin : integer - Bin index",
          0, 0,
          "",
          script->set_result_str(cvm::to_str(this_bias->current_bin()));
@@ -17,7 +18,8 @@ CVSCRIPT(bias_bin,
          )
 
 CVSCRIPT(bias_bincount,
-         "Get the number of samples at the given grid bin (1D ABF only for now)",
+         "Get the number of samples at the given grid bin (1D ABF only for now)\n"
+         "samples : integer - Number of samples",
          0, 1,
          "index : integer - Grid index; defaults to current bin",
          int index = this_bias->current_bin();
@@ -35,7 +37,8 @@ CVSCRIPT(bias_bincount,
          )
 
 CVSCRIPT(bias_binnum,
-         "Get the total number of grid points of this bias (1D ABF only for now)",
+         "Get the total number of grid points of this bias (1D ABF only for now)\n"
+         "Bins : integer - Number of grid points",
          0, 0,
          "",
          int r = this_bias->bin_num();
@@ -57,7 +60,8 @@ CVSCRIPT(bias_delete,
          )
 
 CVSCRIPT(bias_energy,
-         "Get the current energy of this bias",
+         "Get the current energy of this bias\n"
+         "E : float - Energy value",
          0, 0,
          "",
          script->set_result_str(cvm::to_str(this_bias->get_energy()));
@@ -65,14 +69,16 @@ CVSCRIPT(bias_energy,
          )
 
 CVSCRIPT(bias_get,
-         "Get the value of the given feature for this bias",
+         "Get the value of the given feature for this bias\n"
+         "state : 1/0 - State of the given feature",
          1, 1,
          "feature : string - Name of the feature",
          return script->proc_features(this_bias, objc, objv);
          )
 
 CVSCRIPT(bias_getconfig,
-         "Return the configuration string of this bias",
+         "Return the configuration string of this bias\n"
+         "conf : string - Current configuration string",
          0, 0,
          "",
          script->set_result_str(this_bias->get_config());
@@ -80,7 +86,8 @@ CVSCRIPT(bias_getconfig,
          )
 
 CVSCRIPT(bias_help,
-         "Get a help summary or the help string of one bias subcommand",
+         "Get a help summary or the help string of one bias subcommand\n"
+         "help : string - Help string",
          0, 1,
          "command : string - Get the help string of this specific command",
          unsigned char *const cmdobj =
@@ -129,7 +136,8 @@ CVSCRIPT(bias_save,
          )
 
 CVSCRIPT(bias_savetostring,
-         "Save data from this bias into a string and return it",
+         "Save data from this bias into a string and return it\n"
+         "state : string - The bias state",
          0, 0,
          "",
          return this_bias->write_state_string(script->modify_str_result());
@@ -156,7 +164,8 @@ CVSCRIPT(bias_share,
          )
 
 CVSCRIPT(bias_state,
-         "Print a string representation of the feature state of this bias",
+         "Print a string representation of the feature state of this bias\n"
+         "state : string - String representation of the bias features",
          0, 0,
          "",
          this_bias->print_state();
@@ -164,7 +173,8 @@ CVSCRIPT(bias_state,
          )
 
 CVSCRIPT(bias_update,
-         "Recompute this bias and return its up-to-date energy",
+         "Recompute this bias and return its up-to-date energy\n"
+         "E : float - Energy value",
          0, 0,
          "",
          this_bias->update();

--- a/src/colvarscript_commands_bias.h
+++ b/src/colvarscript_commands_bias.h
@@ -64,7 +64,7 @@ CVSCRIPT(bias_energy,
          "E : float - Energy value",
          0, 0,
          "",
-         script->set_result_str(cvm::to_str(this_bias->get_energy()));
+         script->set_result_real(this_bias->get_energy());
          return COLVARS_OK;
          )
 
@@ -178,6 +178,6 @@ CVSCRIPT(bias_update,
          0, 0,
          "",
          this_bias->update();
-         script->set_result_str(cvm::to_str(this_bias->get_energy()));
+         script->set_result_colvarvalue(this_bias->get_energy());
          return COLVARS_OK;
          )

--- a/src/colvarscript_commands_colvar.h
+++ b/src/colvarscript_commands_colvar.h
@@ -24,7 +24,7 @@ CVSCRIPT(colvar_addforce,
            return COLVARSCRIPT_ERROR;
          }
          this_colvar->add_bias_force(force);
-         script->set_result_str(force.to_simple_string());
+         script->set_result_colvarvalue(force);
          return COLVARS_OK;
          )
 
@@ -69,7 +69,7 @@ CVSCRIPT(colvar_getappliedforce,
          "force : float - Applied force; matches the colvar dimensionality",
          0, 0,
          "",
-         script->set_result_str((this_colvar->applied_force()).to_simple_string());
+         script->set_result_colvarvalue(this_colvar->applied_force());
          return COLVARS_OK;
          )
 
@@ -126,7 +126,7 @@ CVSCRIPT(colvar_gettotalforce,
          "force : float - Total force; matches the colvar dimensionality",
          0, 0,
          "",
-         script->set_result_str((this_colvar->total_force()).to_simple_string());
+         script->set_result_colvarvalue(this_colvar->total_force());
          return COLVARS_OK;
          )
 
@@ -183,7 +183,7 @@ CVSCRIPT(colvar_run_ave,
          "value : float or array - Averaged value; matches the colvar dimensionality",
          0, 0,
          "",
-         script->set_result_str(this_colvar->run_ave().to_simple_string());
+         script->set_result_colvarvalue(this_colvar->run_ave());
          return COLVARS_OK;
          )
 
@@ -220,7 +220,7 @@ CVSCRIPT(colvar_update,
          "",
          this_colvar->calc();
          this_colvar->update_forces_energy();
-         script->set_result_str((this_colvar->value()).to_simple_string());
+         script->set_result_colvarvalue(this_colvar->value());
          return COLVARS_OK;
          )
 
@@ -229,7 +229,7 @@ CVSCRIPT(colvar_value,
          "value : float or array - Current value; matches the colvar dimensionality",
          0, 0,
          "",
-         script->set_result_str(this_colvar->value().to_simple_string());
+         script->set_result_colvarvalue(this_colvar->value());
          return COLVARS_OK;
          )
 

--- a/src/colvarscript_commands_colvar.h
+++ b/src/colvarscript_commands_colvar.h
@@ -9,7 +9,8 @@
 
 
 CVSCRIPT(colvar_addforce,
-         "Apply the given force onto this colvar and return the same",
+         "Apply the given force onto this colvar and return the same\n"
+         "force : float or array - Applied force; matches colvar dimensionality",
          1, 1,
          "force : float or array - Applied force; must match colvar dimensionality",
          std::string const f_str(script->obj_to_str(script->get_colvar_cmd_arg(0, objc, objv)));
@@ -56,14 +57,16 @@ CVSCRIPT(colvar_delete,
          )
 
 CVSCRIPT(colvar_get,
-         "Get the value of the given feature for this colvar",
+         "Get the value of the given feature for this colvar\n"
+         "state : 1/0 - State of the given feature",
          1, 1,
          "feature : string - Name of the feature",
          return script->proc_features(this_colvar, objc, objv);
          )
 
 CVSCRIPT(colvar_getappliedforce,
-         "Return the total of the forces applied to this colvar",
+         "Return the total of the forces applied to this colvar\n"
+         "force : float - Applied force; matches the colvar dimensionality",
          0, 0,
          "",
          script->set_result_str((this_colvar->applied_force()).to_simple_string());
@@ -71,7 +74,8 @@ CVSCRIPT(colvar_getappliedforce,
          )
 
 CVSCRIPT(colvar_getatomgroups,
-         "Return the atom indices used by this colvar as a list of lists",
+         "Return the atom indices used by this colvar as a list of lists\n"
+         "groups : array of arrays of ints - Atom indices",
          0, 0,
          "",
          std::string result;
@@ -91,7 +95,8 @@ CVSCRIPT(colvar_getatomgroups,
          )
 
 CVSCRIPT(colvar_getatomids,
-         "Return the list of atom indices used by this colvar",
+         "Return the list of atom indices used by this colvar\n"
+         "indices : array of ints - Atom indices",
          0, 0,
          "",
          std::string result;
@@ -105,7 +110,8 @@ CVSCRIPT(colvar_getatomids,
          )
 
 CVSCRIPT(colvar_getconfig,
-         "Return the configuration string of this colvar",
+         "Return the configuration string of this colvar\n"
+         "conf : string - Current configuration string",
          0, 0,
          "",
          script->set_result_str(this_colvar->get_config());
@@ -113,7 +119,8 @@ CVSCRIPT(colvar_getconfig,
          )
 
 CVSCRIPT(colvar_getgradients,
-         "Return the atomic gradients of this colvar",
+         "Return the atomic gradients of this colvar\n"
+         "gradients : array of arrays of floats - Atomic gradients",
          0, 0,
          "",
          std::string result;
@@ -133,7 +140,8 @@ CVSCRIPT(colvar_getgradients,
          )
 
 CVSCRIPT(colvar_gettotalforce,
-         "Return the sum of internal and external forces to this colvar",
+         "Return the sum of internal and external forces to this colvar\n"
+         "force : float - Total force; matches the colvar dimensionality",
          0, 0,
          "",
          script->set_result_str((this_colvar->total_force()).to_simple_string());
@@ -156,7 +164,8 @@ CVSCRIPT(colvar_getvolmapids,
          )
 
 CVSCRIPT(colvar_help,
-         "Get a help summary or the help string of one colvar subcommand",
+         "Get a help summary or the help string of one colvar subcommand\n"
+         "help : string - Help string",
          0, 1,
          "command : string - Get the help string of this specific command",
          unsigned char *const cmdobj =
@@ -195,7 +204,8 @@ CVSCRIPT(colvar_modifycvcs,
          )
 
 CVSCRIPT(colvar_run_ave,
-         "Get the current running average of the value of this colvar",
+         "Get the current running average of the value of this colvar\n"
+         "value : float or array - Averaged value; matches the colvar dimensionality",
          0, 0,
          "",
          script->set_result_str(this_colvar->run_ave().to_simple_string());
@@ -211,7 +221,8 @@ CVSCRIPT(colvar_set,
          )
 
 CVSCRIPT(colvar_state,
-         "Print a string representation of the feature state of this colvar",
+         "Print a string representation of the feature state of this colvar\n"
+         "state : string - The feature state",
          0, 0,
          "",
          this_colvar->print_state();
@@ -219,7 +230,8 @@ CVSCRIPT(colvar_state,
          )
 
 CVSCRIPT(colvar_type,
-         "Get the type description of this colvar",
+         "Get the type description of this colvar\n"
+         "type : string - Type description",
          0, 0,
          "",
          script->set_result_str(this_colvar->value().type_desc(this_colvar->value().value_type));
@@ -227,7 +239,8 @@ CVSCRIPT(colvar_type,
          )
 
 CVSCRIPT(colvar_update,
-         "Recompute this colvar and return its up-to-date value",
+         "Recompute this colvar and return its up-to-date value\n"
+         "value : float or array - Current value; matches the colvar dimensionality",
          0, 0,
          "",
          this_colvar->calc();
@@ -237,7 +250,8 @@ CVSCRIPT(colvar_update,
          )
 
 CVSCRIPT(colvar_value,
-         "Get the current value of this colvar",
+         "Get the current value of this colvar\n"
+         "value : float or array - Current value; matches the colvar dimensionality",
          0, 0,
          "",
          script->set_result_str(this_colvar->value().to_simple_string());
@@ -245,7 +259,8 @@ CVSCRIPT(colvar_value,
          )
 
 CVSCRIPT(colvar_width,
-         "Get the width of this colvar",
+         "Get the width of this colvar\n"
+         "width : float - Value of the width",
          0, 0,
          "",
          script->set_result_str(cvm::to_str(this_colvar->width, 0,

--- a/src/colvarscript_commands_colvar.h
+++ b/src/colvarscript_commands_colvar.h
@@ -182,7 +182,7 @@ CVSCRIPT(colvar_modifycvcs,
          "Modify configuration of individual components by passing string arguments",
          1, 1,
          "confs : sequence of strings - New configurations; empty strings are skipped",
-         std::vector<std::string> const confs(script->proxy()->script_obj_to_str_vector(script->get_colvar_cmd_arg(0, objc, objv)));
+         std::vector<std::string> const confs(script->obj_to_str_vector(script->get_colvar_cmd_arg(0, objc, objv)));
          cvm::increase_depth();
          int res = this_colvar->update_cvc_config(confs);
          cvm::decrease_depth();

--- a/src/colvarscript_commands_colvar.h
+++ b/src/colvarscript_commands_colvar.h
@@ -99,13 +99,7 @@ CVSCRIPT(colvar_getatomids,
          "indices : array of ints - Atom indices",
          0, 0,
          "",
-         std::string result;
-         std::vector<int>::iterator li = this_colvar->atom_ids.begin();
-         for ( ; li != this_colvar->atom_ids.end(); ++li) {
-           result += cvm::to_str(*li);
-           result += " ";
-         }
-         script->set_result_str(result);
+         script->set_result_int_vec(this_colvar->atom_ids);
          return COLVARS_OK;
          )
 
@@ -152,14 +146,7 @@ CVSCRIPT(colvar_getvolmapids,
          "Return the list of volumetric map indices used by this colvar",
          0, 0,
          "",
-         std::string result;
-         std::vector<int> const &ids = this_colvar->get_volmap_ids();
-         for (std::vector<int>::const_iterator li = ids.begin();
-              li != ids.end(); ++li) {
-           result += cvm::to_str(*li);
-           result += " ";
-         }
-         script->set_result_str(result);
+         script->set_result_int_vec(this_colvar->get_volmap_ids());
          return COLVARS_OK;
          )
 

--- a/src/colvarscript_commands_colvar.h
+++ b/src/colvarscript_commands_colvar.h
@@ -117,19 +117,7 @@ CVSCRIPT(colvar_getgradients,
          "gradients : array of arrays of floats - Atomic gradients",
          0, 0,
          "",
-         std::string result;
-         std::vector<cvm::rvector>::iterator li =
-           this_colvar->atomic_gradients.begin();
-         for ( ; li != this_colvar->atomic_gradients.end(); ++li) {
-           result += "{";
-           int j;
-           for (j = 0; j < 3; ++j) {
-             result += cvm::to_str((*li)[j]);
-             result += " ";
-           }
-           result += "} ";
-         }
-         script->set_result_str(result);
+         script->set_result_rvector_vec(this_colvar->atomic_gradients);
          return COLVARS_OK;
          )
 

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -426,44 +426,6 @@ int colvarproxy_vmd::run_colvar_gradient_callback(
 #endif
 
 
-char const *colvarproxy_vmd::script_obj_to_str(unsigned char *obj)
-{
-#ifdef VMDTCL // is TCL ever off?
-  return colvarproxy_tcl::tcl_get_str(obj);
-#else
-  // This is most likely not going to be executed
-  return colvarproxy::script_obj_to_str(obj);
-#endif
-}
-
-
-std::vector<std::string> colvarproxy_vmd::script_obj_to_str_vector(unsigned char *obj)
-{
-  if (cvm::debug()) {
-    cvm::log("Called colvarproxy_namd::script_obj_to_str_vector().\n");
-  }
-  std::vector<std::string> result;
-#ifdef VMDTCL
-  Tcl_Interp *interp = reinterpret_cast<Tcl_Interp *>(tcl_interp_);
-  Tcl_Obj *tcl_obj = reinterpret_cast<Tcl_Obj *>(obj);
-  Tcl_Obj **tcl_list_elems = NULL;
-  int count = 0;
-  if (Tcl_ListObjGetElements(interp, tcl_obj, &count, &tcl_list_elems) ==
-      TCL_OK) {
-    result.reserve(count);
-    for (int i = 0; i < count; i++) {
-      result.push_back(Tcl_GetString(tcl_list_elems[i]));
-    }
-  } else {
-    Tcl_SetResult(interp,
-                  const_cast<char *>("Cannot parse Tcl list."), TCL_STATIC);
-  }
-#endif
-  return result;
-}
-
-
-
 enum e_pdb_field {
   e_pdb_none,
   e_pdb_occ,

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -68,10 +68,6 @@ public:
 
   virtual void init_tcl_pointers();
 
-  virtual char const *script_obj_to_str(unsigned char *obj);
-
-  virtual std::vector<std::string> script_obj_to_str_vector(unsigned char *obj);
-
   virtual void add_energy(cvm::real energy);
 
   virtual void request_total_force(bool yesno);

--- a/vmd/src/colvars_files.pl
+++ b/vmd/src/colvars_files.pl
@@ -60,6 +60,7 @@ $colvars_defines = " -DVMDCOLVARS";
                     'colvargrid.h',
                     'colvar.h',
                     'colvarmodule.h',
+                    'colvarmodule_utils.h',
                     'colvarparams.h',
                     'colvarparse.h',
                     'colvarproxy.h',

--- a/vmd/tests/interface/007_access_atomic_data/AutoDiff/test.colvars.out
+++ b/vmd/tests/interface/007_access_atomic_data/AutoDiff/test.colvars.out
@@ -1,0 +1,113 @@
+colvars: ----------------------------------------------------------------------
+colvars: Initializing the collective variables module, version "2021-01-19".
+colvars: Please cite Fiorin et al, Mol Phys 2013:
+colvars:  https://dx.doi.org/10.1080/00268976.2013.813594
+colvars: in any publication based on this calculation.
+colvars: This version was built without the C++11 standard: some features are disabled.
+colvars: Please see the following link for details:
+colvars: https://colvars.github.io/README-c++11.html
+colvars: Using VMD interface, version "2020-10-22".
+colvars: Redefining the Tcl "cv" command to the new script interface.
+colvars: ----------------------------------------------------------------------
+colvars: Reading new configuration from file "test.in":
+colvars: # units = "" [default]
+colvars: # smp = on [default]
+colvars: # colvarsTrajFrequency = 1
+colvars: # colvarsRestartFrequency = 0
+colvars: # scriptedColvarForces = off [default]
+colvars: # scriptingAfterBiases = off [default]
+colvars: ----------------------------------------------------------------------
+colvars:   Initializing a new collective variable.
+colvars:   # name = "rmsd"
+colvars:   Initializing a new "rmsd" component.
+colvars:     # name = "" [default]
+colvars:     # componentCoeff = 1 [default]
+colvars:     # componentExp = 1 [default]
+colvars:     # period = 0 [default]
+colvars:     # wrapAround = 0 [default]
+colvars:     # forceNoPBC = off [default]
+colvars:     # scalable = on [default]
+colvars:       Initializing atom group "atoms".
+colvars:       # name = "" [default]
+colvars:       # centerToOrigin = off [default]
+colvars:       # centerToReference = off [default]
+colvars:       # rotateToReference = off [default]
+colvars:       # atomsOfGroup = "" [default]
+colvars:       # indexGroup = "" [default]
+colvars:       # psfSegID = { BH }
+colvars:       # atomsFile = "" [default]
+colvars:       # dummyAtom = ( 0 , 0 , 0 ) [default]
+colvars:       # enableFitGradients = on [default]
+colvars:       # printAtomIDs = off [default]
+colvars:       Atom group "atoms" defined with 10 atoms requested: total mass = 120.11, total charge = 0.53.
+colvars:     # refPositions =  [default]
+colvars:     # refPositionsFile = "../Common/da-rotated-Calpha.xyz"
+colvars:     # refPositionsCol = "" [default]
+colvars:     Warning: beginning from 2019-11-26 the XYZ file reader assumes Angstrom units.
+colvars:     Enabling "centerToReference" and "rotateToReference", to minimize RMSD before calculating it as a variable: if this is not the desired behavior, disable them explicitly within the "atoms" block.
+colvars:     This is a standard minimum RMSD, derivatives of the optimal rotation will not be computed as they cancel out in the gradients.
+colvars:   All components initialized.
+colvars:   # timeStepFactor = 1 [default]
+colvars:   # width = 0.01
+colvars:   # lowerBoundary = 0 [default]
+colvars:   # upperBoundary = 0.1
+colvars:   # hardLowerBoundary = on [default]
+colvars:   # hardUpperBoundary = off [default]
+colvars:   # expandBoundaries = off [default]
+colvars:   # extendedLagrangian = off [default]
+colvars:   # outputValue = on [default]
+colvars:   # outputVelocity = off [default]
+colvars:   # outputTotalForce = off [default]
+colvars:   # outputAppliedForce = on
+colvars:   # subtractAppliedForce = off [default]
+colvars:   # runAve = off [default]
+colvars:   # corrFunc = off [default]
+colvars: ----------------------------------------------------------------------
+colvars: Collective variables initialized, 1 in total.
+colvars: ----------------------------------------------------------------------
+colvars:   Initializing a new "harmonic" instance.
+colvars:   # name = "harmonic1" [default]
+colvars:   # colvars = { rmsd }
+colvars:   # stepZeroData = off [default]
+colvars:   # outputEnergy = on
+colvars:   # outputFreq = 0 [default]
+colvars:   # timeStepFactor = 1 [default]
+colvars:   # writeTISamples = off [default]
+colvars:   # writeTIPMF = off [default]
+colvars:   # centers = { 0 }
+colvars:   # targetCenters = { 0.2 }
+colvars:   # targetNumSteps = 20
+colvars:   # targetNumStages = 0 [default]
+colvars:   # outputAccumulatedWork = on
+colvars:   # outputCenters = on
+colvars:   # forceConstant = 1 [default]
+colvars:   # targetForceConstant = -1 [default]
+colvars:   The force constant for colvar "rmsd" will be rescaled to 10000 according to the specified width (0.01).
+colvars: ----------------------------------------------------------------------
+colvars: Collective variables biases initialized, 1 in total.
+colvars: ----------------------------------------------------------------------
+colvars: Collective variables module (re)initialized.
+colvars: ----------------------------------------------------------------------
+colvars: Re-initialized atom group for variable "rmsd":0/0. 10 atoms: total mass = 120.11, total charge = 0.53.
+colvars: Atom IDs:
+colvars:   3 13 23 33 43 53 63 73 83 98
+colvars: Atom masses:
+colvars:   12.011 12.011 12.011 12.011 12.011 12.011 12.011 12.011 12.011 12.011
+colvars: Atom charges:
+colvars:   -0.1 0.07 0.07 0.07 0.07 0.07 0.07 0.07 0.07 0.07
+colvars: 
+colvars: Colvar's atomic gradients:
+colvars:   { -1.28478803354062e-01 3.36199833274528e-02 7.08473719465345e-02 } { -1.08225559288295e-01 1.49940230975935e-02 6.02729661384996e-05 } { -7.66060814719083e-02 -5.53803314833301e-02 2.42026172427016e-03 } { -2.46071925716959e-02 -3.60323396070867e-02 5.53026542550409e-02 } { -1.16652248092887e-02 3.51309719765031e-02 3.07224621232129e-02 } { 4.91065922003313e-03 1.73046315416593e-02 -4.17542125213569e-02 } { 4.34942811486279e-02 -4.15120004377934e-02 -2.31135021157530e-02 } { 8.99612691580958e-02 -9.38617712983383e-03 2.63802343972017e-02 } { 9.45852510114326e-02 4.40660170358094e-02 -2.65814400344915e-02 } { 1.16631400956873e-01 -2.80477832191629e-03 -9.42841027414459e-02 }
+colvars: Applied atomic forces:
+colvars:   { 2.98784077853502e-01 -7.81850037026011e-02 -1.64759214304436e-01 } { 2.51684115106685e-01 -3.48693733719068e-02 -1.40167888687121e-04 } { 1.78151390058310e-01 1.28789814673697e-01 -5.62844335853106e-03 } { 5.72252943610972e-02 8.37950625422542e-02 -1.28609172276518e-01 } { 2.71280814158279e-02 -8.16988856688697e-02 -7.14466688296962e-02 } { -1.14199910678418e-02 -4.02428123767689e-02 9.71015728587758e-02 } { -1.01148192119139e-01 9.65382961769945e-02 5.37516402342948e-02 } { -2.09209567230006e-01 2.18280385954293e-02 -6.13485944931006e-02 } { -2.19962875308797e-01 -1.02477793386957e-01 6.18165085709650e-02 } { -2.71232333069201e-01 6.52265652091908e-03 2.19262539488442e-01 }
+colvars: Comparison of the unit vectors (1st atom only):
+colvars:   -0.8535628238933343 0.22335799493045438 0.4706821770238216
+colvars:   0.853562823893334 -0.22335799493045436 -0.4706821770238218
+colvars: Total Colvars energy:
+colvars:   0.000270409
+colvars: RMS of applied atomic forces:
+colvars:   0.232555
+colvars: Largest applied atomic force:
+colvars:   0.350043
+colvars: Atom with largest applied atomic force:
+colvars:   3

--- a/vmd/tests/interface/007_access_atomic_data/test.in
+++ b/vmd/tests/interface/007_access_atomic_data/test.in
@@ -1,0 +1,33 @@
+# adapted from NAMD's 3rd reg test
+
+colvarsTrajFrequency    1
+colvarsRestartFrequency 0
+
+
+colvar {
+    name rmsd
+
+#    outputSystemForce on
+    outputAppliedForce on
+    width 0.01
+
+    upperBoundary 0.1
+
+    rmsd {
+        atoms {
+            psfSegID BH
+            atomNameResidueRange CA 1-10
+        }
+        refpositionsfile ../Common/da-rotated-Calpha.xyz
+    }
+} 
+
+harmonic {
+    colvars        rmsd
+    centers        0.0
+    targetCenters  0.2
+    targetNumSteps 20
+    outputEnergy   yes
+    outputAccumulatedWork  yes
+    outputCenters  yes
+}

--- a/vmd/tests/interface/007_access_atomic_data/test.vmd
+++ b/vmd/tests/interface/007_access_atomic_data/test.vmd
@@ -1,0 +1,45 @@
+# -*- tcl -*-
+mol new ../Common/da.psf type psf
+mol addfile ../Common/da.pdb type pdb waitfor all
+
+cv molid top
+cv configfile test.in
+
+cv colvar rmsd set collect_gradient 1
+
+cv update
+
+puts "colvars: Atom IDs:"
+puts "colvars:   [cv getatomids]"
+puts "colvars: Atom masses:"
+puts "colvars:   [cv getatommasses]"
+puts "colvars: Atom charges:"
+puts "colvars:   [cv getatomcharges]"
+puts "colvars: "
+puts "colvars: Colvar's atomic gradients:"
+puts "colvars:   [cv colvar rmsd getgradients]"
+puts "colvars: Applied atomic forces:"
+puts "colvars:   [cv getatomappliedforces]"
+
+set grad [lindex [cv colvar rmsd getgradients] 0]; list
+set grad_length [veclength ${grad}]; list
+set grad_unit [vecscale [expr 1.0/${grad_length}] ${grad}]; list
+
+set force [lindex [cv getatomappliedforces] 0]; list
+set force_length [veclength ${force}]; list
+set force_unit [vecscale [expr 1.0/${force_length}] ${force}]; list
+
+puts "colvars: Comparison of the unit vectors (1st atom only):"
+puts "colvars:   ${grad_unit}"
+puts "colvars:   ${force_unit}"
+
+puts "colvars: Total Colvars energy:"
+puts "colvars:   [cv getenergy]"
+puts "colvars: RMS of applied atomic forces:"
+puts "colvars:   [cv getatomappliedforcesrms]"
+puts "colvars: Largest applied atomic force:"
+puts "colvars:   [cv getatomappliedforcesmax]"
+puts "colvars: Atom with largest applied atomic force:"
+puts "colvars:   [cv getatomappliedforcesmaxid]"
+
+quit


### PR DESCRIPTION
This PR adds the capability to retrieve the current values of atomic data arrays in the `colvarproxy` class, to test their current content and evaluate whether a certain input may lead to unstable dynamics (or if it has already, find out which atomic coordinates may be the culprits).

Additionally, the root-mean-square and maximum force are also computed and returned. Hopefully this will help significantly in setting up a simulation, and possibly during a simulation as well if we e.g. print warnings about a large atomic force before things blow up in the MD integrator.

Because the scripting interface still deals only with string representations at the moment, internal data can't be modified yet. However, the new feature can be useful to achieve things like the example below. @jhenin Perhaps the same or similar summary can also be produced by the Dashboard GUI?
```
puts "Total Colvars energy:"
puts "  [cv getenergy]"
puts "RMS of applied atomic forces:"
puts "  [cv getatomappliedforcesrms]"
puts "Largest applied atomic force:"
puts "  [cv getatomappliedforcesmax]"
puts "Atom with largest applied atomic force:"
puts "  [cv getatomappliedforcesmaxid]"
```

While adding the new methods I've introduced type-specific stringification functions, like `set_result_int_vec(...)`. These have already eliminated some duplicated code, and will eventually prove useful when the script interface will also use the script language's optimal representation for each output. Eventually, the only uses of the current function `set_result_str(...)` should be when really a string of text is returned.

Little rant: to remain VMD-compatible, the templates that I added can't use `std::is_same<>`, so I had to make several explicit template specializations (one for each instance!). This is silly, but couldn't be avoided I'm afraid. Eventually when C++11-isms are allowed in VMD as well, I am hopeful that those templates could be streamlined further.