### PR TITLE
Warn when non-ASCII characters are used in a configuration

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -757,32 +757,27 @@ A corresponding ``\texttt{save}'' function is also available:
 
 \cvsubsec{Configuration syntax used by the Colvars module}{sec:colvars_config_syntax}
 
-\cvnamdonly{All the parameters defining variables and their biasing or analysis algorithms are read from the file specified by the configuration option \texttt{colvarsConfig}, or by the Tcl commands \texttt{cv config} and \texttt{cv configfile}.
-\emph{None of the keywords described in the remainder of this manual are recognized directly in the NAMD configuration file, unless as arguments of \texttt{cv config}.}}
-\cvvmdonly{The Colvars configuration is usually read using the commands \texttt{cv configfile} (with a filename as argument) or \texttt{cv config} (with the configuration as a string argument).}
-Each configuration line follows the format ``\texttt{keyword value}'', where the keyword and its value are separated by any white space.
-The following rules apply:
+Configuration for the Colvars module is passed using an external file\ifdefined\cvvmdornamd{, or inlined as a string in a \MDENGINE{} script using the Tcl command \texttt{cv config "..."}}\fi.
+Configuration lines follow the format ``\texttt{keyword value}'' or ``\texttt{keyword \{ ... \}}'', where the keyword and its value must be separated by one or more space characters.
+The following formatting rules apply:
 
 \begin{itemize}
 
-\item keywords are case-insensitive (\texttt{upperBoundary} is the same as \texttt{upperboundary} and \texttt{UPPERBOUNDARY}): their string values are however case-sensitive (e.g.~file names);
+\item \emph{Keywords are case-insensitive}; for example, \texttt{upperBoundary} is the same as \texttt{upperboundary} and \texttt{UPPERBOUNDARY}); note that their string values are however still case-sensitive (e.g.{} names of variables, file names).
 
-\item a long value, or a list of multiple values, can be distributed across multiple lines by using curly braces, ``\texttt{\{}'' and ``\texttt{\}}'': the opening brace ``\texttt{\{}'' must occur on the same line as the keyword, following a space character or other white space; the closing brace ``\texttt{\}}'' can be at any position after that; any keywords following the closing brace on the same line are not valid (they should appear instead on a different line);
+\item A long value, or a list of multiple values, can be distributed across multiple lines by using \emph{curly braces}, ``\texttt{\{}'' and ``\texttt{\}}'': the opening brace ``\texttt{\{}'' must occur on the same line as the keyword, following at least one space character; the closing brace ``\texttt{\}}'' may be at any position after that; any keywords following the closing brace on the same line are not valid (they should appear instead on a different line).
 
-\item many keywords are nested, and are only meaningful within a specific context: for every keyword documented in the following, the ``parent'' keyword that defines such context is also indicated\cvnamdugonly{ in parentheses};
+\item Many keywords are nested, and are only meaningful within the specific context of another keyword; for example, the keyword  \texttt{name} is available inside the block of the keyword \texttt{colvar \{...\}}, but not outside of it; for every keyword documented in the following, the \emph{``parent'' keyword} that defines such context is also indicated\cvnamdugonly{ in parentheses}.
 
-\cvnamdonly{%
-\item the `\texttt{=}' sign between a keyword and its value, deprecated in the NAMD main configuration file, is not allowed;
+\item If a keyword requiring a boolean value (\texttt{yes|on|true} or \texttt{no|off|false}) is provided without an explicit value, it defaults to `\texttt{yes|on|true}'; for example, `\texttt{outputAppliedForce}' may be used as shorthand for `\texttt{outputAppliedForce on}'.
 
-\item Tcl syntax is generally not available, but it is possible to use Tcl variables or bracket expansion of commands within a configuration string, when this is passed via the command \texttt{cv config \ldots}; this is particularly useful when combined with parameter introspection\cvnamdugonly{ (see \ref{section:tclscripting})}, e.g.{} \texttt{cv config "colvarsTrajFrequency [DCDFreq]"};
-}
+\item The hash character ``\texttt{\#}'' indicates a \emph{comment}: all text in the same line following this character will be ignored.
 
-\cvvmdonly{%
-\item Tcl syntax is generally not available, but it is possible to use Tcl variables or bracket expansion of commands within a configuration string, when this is passed via the command \texttt{cv config \ldots}: for example, it is possible to convert the atom selection \$\emph{sel} into an atom group (see \ref{sec:colvar_atom_groups_sel}) using \texttt{cv config "atomNumbers \{ [\$sel get serial] \}"};}
+\item Outside of comments, \emph{only ASCII characters} are allowed for defining keywords, and the only white-space characters supported are spaces, tabs and newlines: a warning will be printed upon detection of non-ASCII characters in a configuration line, which include both characters that are visibly ``special'', as well as those with a very similar appearance to ASCII ones (for instance, \href{https://en.wikipedia.org/wiki/Non-breaking_space}{non-breaking spaces}); common ways to identify/remove non-ASCII characters are using the Emacs text editor, or using \texttt{LC_ALL=C vi}.
 
-\item if a keyword requiring a boolean value (\texttt{yes|on|true} or \texttt{no|off|false}) is provided without an explicit value, it defaults to `\texttt{yes|on|true}'; for example, `\texttt{outputAppliedForce}' may be used as shorthand for `\texttt{outputAppliedForce on}';
-
-\item the hash character \texttt{\#} indicates a comment: all text in the same line following this character will be ignored.
+\ifdefined\cvvmdornamd{
+\item Tcl syntax is generally not available inside a Colvars configuration file/string, but it is possible to use Tcl variables or bracket expansion of commands when configuration is passed via the command \texttt{cv config "..."}; \cvnamdonly{for example, this is particularly useful when combined with NAMD's parameter introspection, e.g.{} \texttt{cv config "colvarsTrajFrequency [DCDFreq]"} allows synchronizing the output frequencies of NAMD and Colvars trajectory files.} \cvvmdonly{for example, it is possible to convert the atom selection \$\emph{sel} into an atom group (see \ref{sec:colvar_atom_groups_sel}) using \texttt{cv config "atomNumbers \{ [\$sel get serial] \}"}}.
+\fi
 
 \end{itemize}
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -773,9 +773,9 @@ The following formatting rules apply:
 
 \item The hash character ``\texttt{\#}'' indicates a \emph{comment}: all text in the same line following this character will be ignored.
 
-\item Outside of comments, \emph{only ASCII characters} are allowed for defining keywords, and the only white-space characters supported are spaces, tabs and newlines: a warning will be printed upon detection of non-ASCII characters in a configuration line, which include both characters that are visibly ``special'', as well as those with a very similar appearance to ASCII ones (for instance, \href{https://en.wikipedia.org/wiki/Non-breaking_space}{non-breaking spaces}); common ways to identify/remove non-ASCII characters are using the Emacs text editor, or using \texttt{LC_ALL=C vi}.
+\item Outside of comments, \emph{only ASCII characters} are allowed for defining keywords, and the only white-space characters supported are spaces, tabs and newlines: a warning will be printed upon detection of non-ASCII characters in a configuration line, which include both characters that are visibly ``special'', as well as those with a very similar appearance to ASCII ones (for instance, \href{https://en.wikipedia.org/wiki/Non-breaking_space}{non-breaking spaces}); common ways to identify/remove non-ASCII characters are using the Emacs text editor, or using \texttt{LC\_ALL=C vi}.
 
-\ifdefined\cvvmdornamd{
+\ifdefined\cvvmdornamd
 \item Tcl syntax is generally not available inside a Colvars configuration file/string, but it is possible to use Tcl variables or bracket expansion of commands when configuration is passed via the command \texttt{cv config "..."}; \cvnamdonly{for example, this is particularly useful when combined with NAMD's parameter introspection, e.g.{} \texttt{cv config "colvarsTrajFrequency [DCDFreq]"} allows synchronizing the output frequencies of NAMD and Colvars trajectory files.} \cvvmdonly{for example, it is possible to convert the atom selection \$\emph{sel} into an atom group (see \ref{sec:colvar_atom_groups_sel}) using \texttt{cv config "atomNumbers \{ [\$sel get serial] \}"}}.
 \fi
 

--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -35,16 +35,43 @@
 \texttt{frame : integer - Frame number}
 \item \texttt{cv getatomappliedforces}
 \\
-\texttt{Return the list of forces applied by Colvars to atoms}
+\texttt{Get the list of forces applied by Colvars to atoms}
 \\
 \texttt{Returns}
 \\
 \texttt{-------}
 \\
 \texttt{forces : array of arrays of floats - Atomic forces}
+\item \texttt{cv getatomappliedforcesmax}
+\\
+\texttt{Get the maximum norm of forces applied by Colvars to atoms}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{force : float - Maximum atomic force}
+\item \texttt{cv getatomappliedforcesmaxid}
+\\
+\texttt{Get the atom ID with the largest applied force}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{id : int - ID of the atom with the maximum atomic force}
+\item \texttt{cv getatomappliedforcesrms}
+\\
+\texttt{Get the root-mean-square norm of forces applied by Colvars to atoms}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{force : float - RMS atomic force}
 \item \texttt{cv getatomids}
 \\
-\texttt{Return the list of indices of atoms used in Colvars}
+\texttt{Get the list of indices of atoms used in Colvars}
 \\
 \texttt{Returns}
 \\
@@ -53,7 +80,7 @@
 \texttt{indices : array of ints - Atomic indices}
 \item \texttt{cv getatomcharges}
 \\
-\texttt{Return the list of charges of atoms used in Colvars}
+\texttt{Get the list of charges of atoms used in Colvars}
 \\
 \texttt{Returns}
 \\
@@ -62,7 +89,7 @@
 \texttt{charges : array of floats - Atomic charges}
 \item \texttt{cv getatommasses}
 \\
-\texttt{Return the list of masses of atoms used in Colvars}
+\texttt{Get the list of masses of atoms used in Colvars}
 \\
 \texttt{Returns}
 \\
@@ -71,7 +98,7 @@
 \texttt{masses : array of floats - Atomic masses}
 \item \texttt{cv getatompositions}
 \\
-\texttt{Return the list of cached positions of atoms used in Colvars}
+\texttt{Get the list of cached positions of atoms used in Colvars}
 \\
 \texttt{Returns}
 \\
@@ -80,7 +107,7 @@
 \texttt{positions : array of arrays of floats - Atomic positions}
 \item \texttt{cv getatomtotalforces}
 \\
-\texttt{Return the list of cached total forces of atoms used in Colvars}
+\texttt{Get the list of cached total forces of atoms used in Colvars}
 \\
 \texttt{Returns}
 \\

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -186,6 +186,7 @@ std::istream & colvarmodule::getline(std::istream &is, std::string &line)
     size_t const sz = l.size();
     if (sz > 0) {
       if (l[sz-1] == '\r' ) {
+        // Replace Windows newlines with Unix newlines
         line = l.substr(0, sz-1);
       } else {
         line = l;
@@ -200,6 +201,7 @@ std::istream & colvarmodule::getline(std::istream &is, std::string &line)
 
 int colvarmodule::parse_config(std::string &conf)
 {
+  // Auto-generated additional configuration
   extra_conf.clear();
 
   // Check that the input has matching braces
@@ -207,6 +209,9 @@ int colvarmodule::parse_config(std::string &conf)
     return cvm::error("Error: unmatched curly braces in configuration.\n",
                       INPUT_ERROR);
   }
+
+  // Check that the input has only ASCII characters, and warn otherwise
+  colvarparse::check_ascii(conf);
 
   // Parse global options
   if (catch_input_errors(parse_global_params(conf))) {

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -923,6 +923,26 @@ int colvarparse::check_braces(std::string const &conf,
   return (brace_count != 0) ? INPUT_ERROR : COLVARS_OK;
 }
 
+
+int colvarparse::check_ascii(std::string const &conf)
+{
+  // Check for non-ASCII characters
+  std::string line;
+  std::istringstream is(conf);
+  while (cvm::getline(is, line)) {
+    unsigned char const * const uchars =
+      reinterpret_cast<unsigned char const *>(line.c_str());
+    for (size_t i = 0; i < line.size(); i++) {
+      if (uchars[i] & 0x80U) {
+        cvm::log("Warning: non-ASCII character detected in this line: \""+
+                 line+"\".\n");
+      }
+    }
+  }
+  return COLVARS_OK;
+}
+
+
 void colvarparse::split_string(const std::string& data, const std::string& delim, std::vector<std::string>& dest) {
     size_t index = 0, new_index = 0;
     std::string tmpstr;

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -321,6 +321,10 @@ public:
   /// from this position
   static int check_braces(std::string const &conf, size_t const start_pos);
 
+  /// \brief Check that a config string contains non-ASCII characters
+  /// \param conf The configuration string
+  static int check_ascii(std::string const &conf);
+
   /// \brief Split a string with a specified delimiter into a vector
   /// \param data The string to be splitted
   /// \param delim A delimiter


### PR DESCRIPTION
Fixes a confusing issue reported to @jhenin by private email.

A check is now provided, which is based on a similar improvement in LAMMPS:
https://github.com/lammps/lammps/pull/2564

Only a warning is issued, because output files' names may still contain non-ASCII characters, sometimes without the user's ability to change this (e.g. if the characters are part of a path). 

Unlike in the LAMMPS PR, no attempts to correct the input are made, so that there is no risk of incurring the same error when using the same characters e.g. in a Tcl script. (The Tcl parser is similarly affected by these errors, but that cannot obviously be fixed by us.)