### PR TITLE
Add a table to map engine versions vs. Colvars versions (fixes #392)

### DIFF
--- a/README-versions.md
+++ b/README-versions.md
@@ -1,0 +1,37 @@
+## List of Colvars versions included in simulation/analysis packages
+
+### Versions included in LAMMPS
+LAMMPS version | Colvars version
+-------------- | ---------------
+stable_29Oct2020 | [2020-09-17](https://github.com/Colvars/colvars/releases/tag/lammps-stable_29Oct2020)
+stable_3Mar2020 | [2020-01-27](https://github.com/Colvars/colvars/releases/tag/lammps-stable_3Mar2020)
+stable_7Aug2019 | [2019-08-05](https://github.com/Colvars/colvars/releases/tag/lammps-stable_7Aug2019)
+stable_5Jun2019 | [2019-04-26](https://github.com/Colvars/colvars/releases/tag/lammps-stable_5Jun2019)
+stable_12Dec2018 | [2018-11-16](https://github.com/Colvars/colvars/releases/tag/lammps-stable_12Dec2018)
+stable_22Aug2018 | [2018-04-29](https://github.com/Colvars/colvars/releases/tag/lammps-stable_22Aug2018)
+stable_16Mar2018 | [2018-01-17](https://github.com/Colvars/colvars/releases/tag/lammps-stable_16Mar2018)
+stable_11Aug2017 | [2017-07-15](https://github.com/Colvars/colvars/releases/tag/lammps-stable_11Aug2017)
+stable_31Mar2017 | [2017-03-09](https://github.com/Colvars/colvars/releases/tag/lammps-stable_31Mar2017)
+stable_17Nov2016 | [2016-10-21](https://github.com/Colvars/colvars/releases/tag/lammps-stable_17Nov2016)
+stable_5Nov2016 | [2016-10-21](https://github.com/Colvars/colvars/releases/tag/lammps-stable_5Nov2016)
+stable_4Nov2016 | [2016-10-21](https://github.com/Colvars/colvars/releases/tag/lammps-stable_4Nov2016)
+
+### Versions included in NAMD
+NAMD version | Colvars version
+-------------- | ---------------
+2.14 | [2020-07-07](https://github.com/Colvars/colvars/releases/tag/namd-2.14)
+2.13b2 | [2018-10-12](https://github.com/Colvars/colvars/releases/tag/namd-2.13b2)
+2.13b1 | [2018-09-07](https://github.com/Colvars/colvars/releases/tag/namd-2.13b1)
+2.13 | [2018-10-16](https://github.com/Colvars/colvars/releases/tag/namd-2.13)
+2.12b1 | [2016-11-28](https://github.com/Colvars/colvars/releases/tag/namd-2.12b1)
+2.11 | [2015-09-16](https://github.com/Colvars/colvars/releases/tag/namd-2.11)
+2.10 | [2014-10-23](https://github.com/Colvars/colvars/releases/tag/namd-2.10)
+
+### Versions included in VMD
+VMD version | Colvars version
+-------------- | ---------------
+1.9.4a49 | [2020-10-22](https://github.com/Colvars/colvars/releases/tag/vmd-1.9.4a49)
+1.9.4a12 | [2017-10-11](https://github.com/Colvars/colvars/releases/tag/vmd-1.9.4a12)
+1.9.3 | [2016-10-26](https://github.com/Colvars/colvars/releases/tag/vmd-1.9.3)
+1.9.2 | [2014-10-13](https://github.com/Colvars/colvars/releases/tag/vmd-1.9.2)
+

--- a/README-versions.md
+++ b/README-versions.md
@@ -1,5 +1,11 @@
 ## List of Colvars versions included in simulation/analysis packages
 
+[Versions included in LAMMPS](#versions-included-in-LAMMPS)
+
+[Versions included in NAMD](#versions-included-in-NAMD)
+
+[Versions included in VMD](#versions-included-in-VMD)
+
 ### Versions included in LAMMPS
 LAMMPS version | Colvars version
 -------------- | ---------------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,3 +1,4 @@
+.PHONY: all pdf clean clean-all
 
 PDF=colvars-refman-lammps.pdf colvars-refman-namd.pdf colvars-refman-vmd.pdf colvars-refman-gromacs.pdf
 BIBTEX=colvars-refman.bib
@@ -18,4 +19,7 @@ clean:
 
 clean-all: clean
 	rm -f $(PDF)
+
+version-list:
+	./print_engine_versions.sh > ../README-versions.md
 

--- a/doc/print_engine_versions.sh
+++ b/doc/print_engine_versions.sh
@@ -30,7 +30,10 @@ print_tag_versions() {
 
 echo "## List of Colvars versions included in simulation/analysis packages"
 echo
-
+for package in LAMMPS NAMD VMD ; do
+    echo "[Versions included in ${package}](#versions-included-in-${package})"
+    echo
+done
 
 sort_versions(){
     sort -r

--- a/doc/print_engine_versions.sh
+++ b/doc/print_engine_versions.sh
@@ -47,6 +47,9 @@ sort_lammps_versions(){
 
 for package in LAMMPS NAMD VMD ; do
     echo "### Versions included in ${package}"
+    if [ ${package} = NAMD ] ; then
+        echo "(Note: the Colvars version included in NAMD 2.12 is the same as the one included in 2.12b1 with only bugfixes applied: therefore, NAMD 2.12 does not correspond to a specific version of the Colvars source tree)"
+    fi
     echo "${package} version | Colvars version"
     echo "-------------- | ---------------"
     sort_command=sort_versions

--- a/doc/print_engine_versions.sh
+++ b/doc/print_engine_versions.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+source ../devel-tools/version_functions.sh
+
+
+reformat_lammps_version() {
+    local lammpsversion=$1
+    python3 -c "
+import datetime
+print(datetime.datetime.strptime('${lammpsversion}','%d%b%Y').strftime('%Y-%m-%d'))
+"
+}
+
+
+print_tag_versions() {
+    local package=$1
+    local tag_prefix=$2
+    local tag
+    local colvars_version
+    local lammps_version=""
+    for tag in $(git tag -l|grep ^${tag_prefix}); do
+        local package_version=${tag#${tag_prefix}}
+        colvars_version=$(get_colvarmodule_version ${tag})
+        if [ ${package} = LAMMPS ] ; then
+            lammps_version=$(reformat_lammps_version ${package_version#*_})" "
+        fi
+        echo "${lammps_version}${package_version} | [${colvars_version}](https://github.com/Colvars/colvars/releases/tag/${tag})"
+    done
+}
+
+echo "## List of Colvars versions included in simulation/analysis packages"
+echo
+
+
+sort_versions(){
+    sort -r
+}
+
+
+sort_lammps_versions(){
+    sort -r | cut -d' ' -f2-
+}
+
+
+for package in LAMMPS NAMD VMD ; do
+    echo "### Versions included in ${package}"
+    echo "${package} version | Colvars version"
+    echo "-------------- | ---------------"
+    sort_command=sort_versions
+    if [ ${package} = LAMMPS ] ; then
+        sort_command=sort_lammps_versions
+    fi
+    print_tag_versions ${package} $(echo ${package}- | tr '[:upper:]' '[:lower:]') | ${sort_command}
+    echo
+done


### PR DESCRIPTION
A Bash script in the `doc` folder populates a Markdown document `README-versions.md`.

Once finalized I'd like to copy it over to the website repository, so that it can be automatically converted to HTML with the URL https://colvars.github.io/README-versions.html

There are probably several places where that page could be linked, including the ref manual, so that people reading it could navigate to the version they need.  Once we have a few more versions of the doc built (right now we pretty much only have [NAMD 2.14](https://colvars.github.io/namd-2.14/colvars-refman-namd/colvars-refman-namd.html)), we could also link those versions of the manual from the document introduced in this PR.