### PR TITLE
Generate citation report while running computations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,6 +30,16 @@ jobs:
     - name: Test build recipes
       run: bash devel-tools/check_build_recipes
 
+    - name: Convert BibTeX references to code
+      shell: bash
+      working-directory: doc
+      run: |
+        make update-code-refs
+        if [ -n "$(git status --porcelain ../src/colvarmodule_refs.h)" ] ; then
+            echo "Please update the code references in the doc folder" >& 2
+            exit 1
+        fi
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all pdf clean clean-all
+.PHONY: all pdf clean clean-all update-code-refs
 
 PDF=colvars-refman-lammps.pdf colvars-refman-namd.pdf colvars-refman-vmd.pdf colvars-refman-gromacs.pdf
 BIBTEX=colvars-refman.bib
@@ -23,3 +23,6 @@ clean-all: clean
 version-list:
 	./print_engine_versions.sh > ../README-versions.md
 
+
+update-code-refs:
+	python3 extract_code_refs.py > ../src/colvarmodule_refs.h

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,20 @@
+## Building the documentation
+
+This folder contains LaTeX files needed to build the Colvars documentation in PDF format.  On a computer with a working LaTeX installation, use the following to build the PDF manuals for all supported backends in parallel:
+```
+$ make -j
+```
+The HTML version of the doc is built from within a worktree of the [colvars.github.io](https://github.com/Colvars/colvars.github.io) repository, which is the GitHub Pages repository responsible for the main Colvars webpage.
+
+The file `colvars-refman-main.tex` is the main file, which includes content that is conditionally rendered by LaTeX depending on the version of the documentation being generated.  There are specific LaTeX files for each backend that include this file to generate the specific version of the doc, e.g. `colvars-refman-gromacs.tex` to generate the doc for Gromacs users.
+
+## Citations to software
+
+The file `colvars-code-refs.bib` contains BibTeX entries for all papers or preprints describing software implementations of specific features, either implemented within Colvars or outside (e.g. the publications of the back-end code and some of their features are included as well).  One or more comment lines (preceded by `%`) describe the feature(s) associated to that publication.  Descriptions must be short and unique, because they are used by the code to generate a citation report during a run.
+
+Each BibTeX entry must contain a `url = {https://...}` field, pointing to a URL that can be used to access the corresponding publication (preferably a `https://doi.org/...` link).
+
+The contents of the file `colvars-code-refs.bib` are converted to C++ code using:
+```
+make update-code-refs
+```

--- a/doc/colvars-code-refs.bib
+++ b/doc/colvars-code-refs.bib
@@ -196,12 +196,14 @@
 }
 
 % Poisson integration of 2D/3D free energy surfaces
-@article{Henin2021,
+@misc{Henin2021,
   author = {H\'enin, J\'er\^ome},
   title = {Fast and accurate multidimensional free energy integration},
-  journal = {J. Chem. Theory Comput.},
-  year = {2021},
-  note = {in press}
+  year={2021},
+  eprint={2107.08511},
+  archivePrefix={arXiv},
+  primaryClass={physics.comp-ph}
+  url = {https://arxiv.org/abs/2107.08511},
 }
 
 % Ensemble-biased metadynamics (ebMetaD)

--- a/doc/colvars-code-refs.bib
+++ b/doc/colvars-code-refs.bib
@@ -1,0 +1,302 @@
+
+% GROMACS engine
+@article{Abraham2015,
+  title = {{GROMACS}: High performance molecular simulations through multi-level parallelism from laptops to supercomputers},
+  author = {Abraham, Mark J.{} and Murtola, Teemu and Schulz, Roland and Páll, Szil\'ard and Smith, Jeremy C.{} and Hess, Berk and Lindahl, Erik},
+  journal = {{SoftwareX}},
+  volume = {1--2},
+  year = {2015},
+  pages = {19--25},
+  doi = {10.1016/j.softx.2015.06.001},
+  url = {https://doi.org/10.1016/j.softx.2015.06.001}
+}
+
+% reweightaMD colvar bias implementation (NAMD)
+@article{Chen2021,
+  author = {Chen, Haochuan and Fu, Haohao and Chipot, Christophe and Shao, Xueguang and Cai, Wensheng},
+  title = {Overcoming free-energy barriers with a seamless combination of a biasing force and a collective variable-independent boost potential},
+  journal = {J. Chem. Theory Comput.},
+  year = {2021},
+  volume = {17},
+  number = {7},
+  pages = {3886--3894},
+  doi = {10.1021/acs.jctc.1c00103},
+  url = {https://doi.org/10.1021/acs.jctc.1c00103}
+}
+
+% Multiple-walker ABF implementation
+@article{Comer2014c,
+  author = {Comer, Jeffrey and Phillips, James C.{} and Schulten, Klaus and Chipot, Christophe},
+  title = {Multiple-walker strategies for free-energy calculations in {NAMD}: {Shared} adaptive biasing force and walker selection rules},
+  journal = {J. Chem. Theor. Comput.},
+  year = {2014},
+  volume = {10},
+  number = {12},
+  pages = {5276--5285},
+  doi = {10.1021/ct500874p},
+  pmid = {26583211},
+  url = {https://doi.org/10.1021/ct500874p}
+}
+
+% Colvars module
+% Colvars-NAMD interface
+% Colvars-LAMMPS interface
+% Colvars-VMD interface (command line)
+% distance colvar component
+% distanceXY colvar component
+% distanceZ colvar component
+% distanceVec colvar component
+% distanceDir colvar component
+% angle colvar component
+% dihedral colvar component
+% coordNum colvar component
+% selfCoordNum colvar component
+% hBond colvar component
+% rmsd colvar component
+% eigenvector colvar component
+% gyration colvar component
+% inertia colvar component
+% inertiaZ colvar component
+% orientation colvar component
+% Moving frame of reference
+% orientationAngle colvar component
+% orientationProj colvar component
+% spinAngle colvar component
+% tilt colvar component
+% alpha colvar component
+% dihedralPC colvar component
+% cartesian colvar component
+% Linear and polynomial combination of colvar components
+% Metadynamics colvar bias implementation
+% Multiple-walker metadynamics colvar bias implementation
+% Harmonic colvar bias implementation
+% harmonicWalls colvar bias implementation
+% Linear colvar bias implementation
+% Histogram colvar bias implementation
+@article{Fiorin2013,
+  author = {Fiorin, Giacomo and Klein, Michael L.{} and H\'enin, J\'er\^ome},
+  title = {Using collective variables to drive molecular dynamics simulations},
+  journal = {Mol. Phys.},
+  year = {2013},
+  volume = {111},
+  number = {22-23},
+  pages = {3345--3362},
+  publisher = {Taylor & Francis},
+  doi = {10.1080/00268976.2013.813594},
+  URL = {https://doi.org/10.1080/00268976.2013.813594}
+}
+
+% mapTotal colvar component (volumetric-map and Multi-Map colvar components)
+@article{Fiorin2020,
+  author = {Fiorin, Giacomo and Marinelli, Fabrizio and {Faraldo-G\'omez}, Jos\'e D.},
+  title = {Direct Derivation of Free Energies of Membrane Deformation and Other Solvent Density Variations From Enhanced Sampling Molecular Dynamics},
+  journal = {J. Comp. Chem.},
+  year = {2020},
+  volume = {41},
+  number = {5},
+  pages = {449--459},
+  doi = {10.1002/jcc.26075},
+  pmid = {31602694},
+  url = {https://doi.org/10.1002/jcc.26075}
+}
+
+% Umbrella-integration eABF estimator
+@article{Fu2016,
+  author = {Fu, Haohao and Shao, Xueguang and Chipot, Cristophe and Cai, Wensheng},
+  title = {Extended adaptive biasing force algorithm. {An} on--the--fly implementation for accurate free--energy calculations},
+  journal = {J. Chem. Theory Comput.},
+  year = {2016},
+  volume = {12},
+  number = {8},
+  pages = {3506-–3513},
+  pmid = {27398726},
+  doi = {10.1021/acs.jctc.6b00447},
+  pmid = {27398726},
+  url = {https://doi.org/10.1021/acs.jctc.6b00447}
+}
+
+% polarTheta colvar component
+% polarPhi colvar component
+% eulerPhi colvar component
+% eulerTheta colvar component
+% eulerPsi colvar component
+@article{Fu2017,
+  author = {Fu, Haohao and Cai, Wensheng and H\'enin, J\'er\^ome and Roux, Beno\^it and Chipot, Christophe},
+  title = {New Coarse Variables for the Accurate Determination of Standard Binding Free Energies},
+  journal = {J. Chem. Theory. Comput.},
+  year = {2017},
+  volume = {13},
+  number = {11},
+  pages = {5173-5178},
+  doi = {10.1021/acs.jctc.7b00791},
+  pmid = {28965398},
+  url = {https://doi.org/10.1021/acs.jctc.7b00791}
+}
+
+% dipoleAngle colvar component
+% dipoleMagnitude colvar component
+@article{Garate2019,
+  author = {Garate, Jos\'e Antonio and Bernardin, Alejandro and Escalona, Yerko and Yanez, Carlos and English, Niall J.{} and {Perez-Acle}, Tomas},
+  title = {Orientational and Folding Thermodynamics via Electric Dipole Moment Restraining},
+  journal = {J. Phys. Chem. {B}},
+  year = {2019},
+  volume = {123},
+  number = {12},
+  pages = {2599--2608},
+  doi = {10.1021/acs.jpcb.8b09374},
+  pmid = {30831028},
+  url = {https://doi.org/10.1021/acs.jpcb.8b09374}
+}
+
+% ABF colvar bias implementation
+% Internal-forces free energy estimator
+@article{Henin2010,
+  author = {H\'enin, J\'er\^ome and Fiorin, Giacomo and Chipot, Cristophe and Klein, Michael L.},
+  title = {Exploring multidimensional free energy landscapes using time-dependent biases on collective variables},
+  journal = {J. Chem. Theory Comput.},
+  year = {2010},
+  volume = {6},
+  pages = {35-47},
+  number = {1},
+  doi = {10.1021/ct9004432},
+  pmid = {26614317},
+  url = {https://doi.org/10.1021/ct9004432}
+}
+
+% VMD engine
+@article{Humphrey1996,
+  title = {{VMD}: visual molecular dynamics},
+  author = {Humphrey, William and Dalke, Andrew and Schulten, Klaus},
+  journal = {J. Mol. Graph.},
+  year = {1996},
+  volume = {14},
+  number = {1},
+  pages = {33--38},
+  doi = {10.1016/0263-7855(96)00018-5},
+  url = {https://doi.org/10.1016/0263-7855(96)00018-5}
+}
+
+% eABF implementation
+% CZAR eABF estimator
+@article{Lesage2017,
+  author = {Lesage, Adrien and Leli\`evre, Tony and Stoltz, Gabriel and H\'enin, J\'er\^ome},
+  title = {Smoothed biasing forces yield unbiased free energies with the extended-system adaptive biasing force method},
+  journal = {J. Phys. Chem. {B}},
+  year = {2017},
+  volume = {121},
+  number = {15},
+  pages = {3676-3685},
+  doi = {10.1021/acs.jpcb.6b10055},
+  pmid = {27959559},
+  url = {https://doi.org/10.1021/acs.jpcb.6b10055}
+}
+
+% Poisson integration of 2D/3D free energy surfaces
+@article{Henin2021,
+  author = {H\'enin, J\'er\^ome},
+  title = {Fast and accurate multidimensional free energy integration},
+  journal = {J. Chem. Theory Comput.},
+  year = {2021},
+  note = {in press}
+}
+
+% Ensemble-biased metadynamics (ebMetaD)
+@article{Marinelli2015,
+  author = {Marinelli, Fabrizio and Faraldo-G\'omez, Jos\'e D.},
+  title = {Ensemble-Biased Metadynamics: A Molecular Simulation Method to Sample Experimental Distributions},
+  journal = {Biophys. J.},
+  year = {2015},
+  volume = {108},
+  number = {12},
+  pages = {2779--2782},
+  doi = {10.1016/j.bpj.2015.05.024},
+  pmid = {26083917},
+  url = {https://doi.org/10.1016/j.bpj.2015.05.024}
+}
+
+% NAMD engine
+% Scalable center-of-mass computation (NAMD)
+@article{Phillips2020,
+  author = {Phillips, James C.{} and Hardy, David J.{} and Maia, Julio D. C.{} and Stone, John E.{} and Ribeiro, Jo\~ao V.{} and Bernardi, Rafael C.{} and Buch, Ronak and Fiorin, Giacomo and H\'enin, J\'er\^ome and Jiang, Wei and McGreevy, Ryan and Melo, Marcelo C. R.{} and Radak, Brian K.{} and Skeel, Robert D.{} and Singharoy, Abhishek and Wang, Yi and Roux, Beno\^it and Aksimentiev, Aleksei and Luthey-Schulten, Zaida and Kal\'e, Laxmikant V.{} and Schulten, Klaus and Chipot, Christophe and Tajkhorshid, Emad},
+  title = {Scalable molecular dynamics on {CPU} and {GPU} architectures with {NAMD}},
+  journal = {J. Chem. Phys.},
+  year = {2020},
+  volume = {153},
+  number = {4},
+  pages = {044130},
+  doi = {10.1063/5.0014475},
+  pmid = {32752662},
+  url = {https://doi.org/10.1063/5.0014475}
+}
+
+% LAMMPS engine
+@article{Plimpton1995,
+  title = {Fast parallel algorithms for short-range molecular dynamics},
+  author = {Plimpton, Steve},
+  journal = {J. Comp. Phys.},
+  year = {1995},
+  volume = {117},
+  number = {1},
+  pages = {1--19},
+  doi = {10.1006/jcph.1995.1039},
+  url = {https://doi.org/10.1006/jcph.1995.1039}
+}
+
+% distancePairs colvar component
+% histogramRestraint colvar bias implementation
+@article{Shen2015,
+  title = {Structural refinement of proteins by restrained molecular dynamics simulations with non-interacting molecular fragments},
+  author = {Shen, Rong and Han, Wei and Fiorin, Giacomo and Islam, Shahidul M and Schulten, Klaus and Roux, Beno{\^\i}t},
+  journal = {{PLoS} Comput. Biol.},
+  volume = {11},
+  year = {2015},
+  number = {10},
+  pages = {e1004368},
+  doi = {10.1371/journal.pcbi.1004368},
+  pmid = {26505197},
+  url = {https://doi.org/10.1371/journal.pcbi.1004368}
+}
+
+% GridForces volumetric map implementation for NAMD
+@article{Wells2007,
+  author = {Wells, David B. and Abramkina, Volha and Aksimentiev, Aleksei},
+  title = {Exploring transmembrane transport through $\alpha$-hemolysin with grid-steered molecular dynamics},
+  journal = {J. Chem. Phys.},
+  year = {2007},
+  volume = {127},
+  number = {12},
+  pages = {125101},
+  doi = {10.1063/1.2770738},
+  pmid = {17902937},
+  url = {https://doi.org/10.1063/1.2770738}
+}
+
+% ALB colvar bias implementation
+@article{White2014,
+  author = {White, Andrew D.{} and Voth, Gregory A.{}},
+  title = {Efficient and minimal method to bias molecular simulations with experimental data},
+  journal = {J. Chem. Theory Comput.},
+  year = {2014},
+  volume = {10},
+  number = {8},
+  pages = {3023-–3030},
+  doi = {10.1021/ct500320c},
+  pmid = {26588273},
+  url = {https://doi.org/10.1021/ct500320c}
+}
+
+
+% --- NO CITATIONS AVAILABLE YET FOR THESE FEATURES ---
+% Colvars-GROMACS interface
+% Colvars Dashboard (Colvars-VMD graphical user interface)
+% gspath colvar component
+% gzpath colvar component
+% linearCombination colvar component
+% gspathCV colvar component
+% gzpathCV colvar component
+% aspathCV colvar component
+% azpathCV colvar component
+% coordNum pairlist
+% Custom functions (Lepton)
+% Scripted functions (Tcl)
+% --- END ---

--- a/doc/colvars-code-refs.bib
+++ b/doc/colvars-code-refs.bib
@@ -47,10 +47,12 @@
 % distanceZ colvar component
 % distanceVec colvar component
 % distanceDir colvar component
+% distanceInv colvar component
 % angle colvar component
 % dihedral colvar component
 % coordNum colvar component
 % selfCoordNum colvar component
+% groupCoord colvar component
 % hBond colvar component
 % rmsd colvar component
 % eigenvector colvar component
@@ -83,10 +85,12 @@
   pages = {3345--3362},
   publisher = {Taylor & Francis},
   doi = {10.1080/00268976.2013.813594},
-  URL = {https://doi.org/10.1080/00268976.2013.813594}
+  url = {https://doi.org/10.1080/00268976.2013.813594}
 }
 
-% mapTotal colvar component (volumetric-map and Multi-Map colvar components)
+% mapTotal colvar component
+% Volumetric map-based collective variables
+% Multi-Map collective variables
 @article{Fiorin2020,
   author = {Fiorin, Giacomo and Marinelli, Fabrizio and {Faraldo-G\'omez}, Jos\'e D.},
   title = {Direct Derivation of Free Energies of Membrane Deformation and Other Solvent Density Variations From Enhanced Sampling Molecular Dynamics},

--- a/doc/colvars-refman.bib
+++ b/doc/colvars-refman.bib
@@ -1,16 +1,3 @@
-@ARTICLE{Abraham2015,
-title = "{GROMACS}: High performance molecular simulations through multi-level parallelism from laptops to supercomputers",
-journal = "{SoftwareX}",
-volume = "1-2",
-pages = "19 - 25",
-year = "2015",
-issn = "2352-7110",
-doi = "https://doi.org/10.1016/j.softx.2015.06.001",
-url = "https://doi.org/10.1016/j.softx.2015.06.001",
-author = "Abraham, Mark J.{} and Murtola, Teemu and Schulz, Roland and Páll, Szil\'ard and Smith, Jeremy C.{} and Hess, Berk and Lindahl, Erik",
-keywords = "Molecular dynamics, GPU, SIMD, Free energy",
-}
-
 @ARTICLE{Altis2007,
   author = {Altis, Alexandros and Nguyen, Phuong H. and Hegger, Rainer and Stock,
 	Gerhard},
@@ -73,16 +60,6 @@ keywords = "Molecular dynamics, GPU, SIMD, Free energy",
   volume = {6},
   pages = {1809--1814},
   number = {9}
-}
-
-@ARTICLE{Comer2014c,
-  author = {Comer, J. and Phillips, J. and Schulten, K. and Chipot, C.},
-  title = {Multiple-walker strategies for free-energy calculations in NAMD:
-    Shared adaptive biasing force and walker selection rules},
-  journal = {J. Chem. Theor. Comput.},
-  year = {2014},
-  volume = {10},
-  pages = {5276-5285},
 }
 
 @ARTICLE{Coutsias2004,
@@ -149,43 +126,6 @@ keywords = "Molecular dynamics, GPU, SIMD, Free energy",
   doi           = {10.1021/ct5007086}
 }
 
-@ARTICLE{Fiorin2013,
-  author = {Fiorin, Giacomo and Klein, Michael L.{} and H\'enin, J\'er\^ome},
-  title = {Using collective variables to drive molecular dynamics simulations},
-  journal = {Mol. Phys.},
-  year = {2013},
-  volume = {111},
-  pages = {3345--3362},
-  number = {22-23},
-  publisher = {Taylor & Francis},
-  doi = {10.1080/00268976.2013.813594},
-  URL = {https://doi.org/10.1080/00268976.2013.813594},
-  eprint = {https://doi.org/10.1080/00268976.2013.813594}
-}
-
-@ARTICLE{Fiorin2020,
-  author = {Fiorin, Giacomo and Marinelli, Fabrizio and Faraldo-G\'omez, Jos\'e D.},
-  title = {Direct Derivation of Free Energies of Membrane Deformation and Other Solvent Density Variations From Enhanced Sampling Molecular Dynamics},
-  journal = {J. Comp. Chem.},
-  volume = {41},
-  number = {5},
-  pages = {449--459},
-  doi = {10.1002/jcc.26075},
-  url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/jcc.26075},
-  eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/jcc.26075},
-  year = {2020}
-}
-
-@ARTICLE{Fu2016,
-  author = {Fu, H. and Shao, X. and Chipot, C. and Cai, W.},
-  title = {Extended adaptive biasing force algorithm. An on--the--fly implementation
-    for accurate free--energy calculations},
-  journal = {J. Chem. Theory Comput.},
-  year = {2016},
-  pmid = {27398726},
-  url = {http://dx.doi.org/10.1021/acs.jctc.6b00447}
-}
-
 @ARTICLE{Glykos2006,
   author = {Nicholas M Glykos},
   title = {Carma: a molecular dynamics analysis program},
@@ -232,17 +172,6 @@ keywords = "Molecular dynamics, GPU, SIMD, Free energy",
   pages = {2904--2914}
 }
 
-@ARTICLE{Henin2010,
-  author = {H\'enin, J. and Fiorin, G. and Chipot, C. and Klein, M. L.},
-  title = {Exploring Multidimensional Free Energy Landscapes Using Time-Dependent
-	Biases on Collective Variables},
-  journal = {J. Chem. Theory Comput.},
-  year = {2010},
-  volume = {6},
-  pages = {35-47},
-  number = {1}
-}
-
 @ARTICLE{Hovan2019,
     author = {L. Hovan, F. Comitani and F. L. Gervasio},
     title = {Defining an Optimal Metric for the Path Collective Variables},
@@ -264,21 +193,6 @@ keywords = "Molecular dynamics, GPU, SIMD, Free energy",
   month = {DEC},
   sourceid = {ISI:A1994QA06400005}
 }
-
-@ARTICLE{Humphrey1996,
-  title={{VMD}: visual molecular dynamics},
-  author={Humphrey, William and Dalke, Andrew and Schulten, Klaus},
-  journal={Journal of Molecular Graphics},
-  volume={14},
-  number={1},
-  pages={33--38},
-  year={1996},
-  publisher={Guildford: Butterworth Scientific Limited, c1983-c1996.},
-  doi = {10.1016/0263-7855(96)00018-5},
-  url = {https://doi.org/10.1016/0263-7855(96)00018-5},
-  eprint = {https://doi.org/10.1016/0263-7855(96)000185}
-}
-
 
 @ARTICLE{Iannuzzi2003,
   author = {Iannuzzi, M. and Laio, A. and Parrinello, M.},
@@ -318,26 +232,6 @@ keywords = "Molecular dynamics, GPU, SIMD, Free energy",
     year = {2012},
     volume = {109},
     pages = {020601},
-}
-
-@article{Lesage2017,
-author = {Lesage, Adrien and Leli\`evre, Tony and Stoltz, Gabriel and H\'enin, J\'er\^ome},
-title = {Smoothed Biasing Forces Yield Unbiased Free Energies with the Extended-System Adaptive Biasing Force Method},
-journal = {J. Phys. Chem. B},
-volume = {121},
-number = {15},
-pages = {3676-3685},
-year = {2017}
-}
-
-@article{Marinelli2015,
-  author = {Marinelli, Fabrizio and Faraldo-G\'omez, Jos\'e D.},
-  title = {Ensemble-Biased Metadynamics: A Molecular Simulation Method to Sample Experimental Distributions},
-  journal = {Biophysical Journal},
-  year = {2015},
-  volume = {108},
-  number = {12},
-  pages = {2779 - 2782},
 }
 
 @ARTICLE{Marinelli2009,
@@ -387,19 +281,6 @@ year = {2011}
   number = {1}
 }
 
-@ARTICLE{Phillips2020,
-author = {Phillips, James C.{} and Hardy, David J.{} and Maia, Julio D. C.{} and Stone, John E.{} and Ribeiro, Jo\~ao V.{} and Bernardi, Rafael C.{} and Buch, Ronak and Fiorin, Giacomo and H\'enin, J\'er\^ome and Jiang, Wei and McGreevy, Ryan and Melo, Marcelo C. R.{} and Radak, Brian K.{} and Skeel, Robert D.{} and Singharoy, Abhishek and Wang, Yi and Roux, Beno\^it and Aksimentiev, Aleksei and Luthey-Schulten, Zaida and Kal\'e, Laxmikant V.{} and Schulten, Klaus and Chipot, Christophe and Tajkhorshid, Emad}, 
-title = {Scalable molecular dynamics on {CPU} and {GPU} architectures with {NAMD}},
-journal = {Journal of Chemical Physics},
-volume = {153},
-number = {4},
-pages = {044130},
-year = {2020},
-doi = {10.1063/5.0014475},
-URL = {https://doi.org/10.1063/5.0014475},
-eprint = {https://doi.org/10.1063/5.0014475}
-}
-
 @ARTICLE{Pitera2012,
     author = {Pitera, Jed W. and Chodera, John D.},
     journal = {J. Chem. Theory Comput.},
@@ -407,19 +288,6 @@ eprint = {https://doi.org/10.1063/5.0014475}
     title = {On the Use of Experimental Observations to Bias Simulated Ensembles},
     volume = {8},
     year = {2012}
-}
-
-@ARTICLE{Plimpton1995,
-title = "Fast Parallel Algorithms for Short-Range Molecular Dynamics",
-journal = "Journal of Computational Physics",
-volume = "117",
-number = "1",
-pages = "1 - 19",
-year = "1995",
-issn = "0021-9991",
-doi = "https://doi.org/10.1006/jcph.1995.1039",
-url = "https://doi.org/10.1006/jcph.1995.1039",
-author = "Plimpton, Steve",
 }
 
 @ARTICLE{Raiteri2006,
@@ -454,17 +322,6 @@ author = "Plimpton, Steve",
   doi          = {10.1021/acs.jctc.8b00447},
 }
 
-@ARTICLE{Shen2015,
-  title={Structural Refinement of Proteins by Restrained Molecular Dynamics Simulations with Non-interacting Molecular Fragments},
-  author={Shen, Rong and Han, Wei and Fiorin, Giacomo and Islam, Shahidul M and Schulten, Klaus and Roux, Beno{\^\i}t},
-  journal={{PLoS} Comput. Biol.},
-  volume={11},
-  number={10},
-  pages={e1004368},
-  year={2015},
-  publisher={Public Library of Science}
-}
-
 @ARTICLE{Vant2020,
 	author = {Vant, John W. and Sarkar, Daipayan and Fiorin, Giacomo and Skeel, Robert and Vermaas, Josh V. and Singharoy, Abhishek},
 	title = {Data-guided Multi-Map variables for ensemble refinement of molecular movies},
@@ -478,15 +335,6 @@ author = "Plimpton, Steve",
 	journal = {bioRxiv}
 }
 
-@ARTICLE{White2014,
-author = {White, A. D. and Voth, G. A.},
-    journal = {J. Chem. Theory Comput.},
-title = {Efficient and Minimal Method to Bias Molecular Simulations with Experimental Data},
-volume = {ASAP},
-year = {2014}
-
-}
-
 @ARTICLE{Zheng2012,
   author = {L. Zheng and W. Yang},
   title = {Practically efficient and robust free energy calculations: Double-integration
@@ -495,32 +343,6 @@ year = {2014}
   year = {2012},
   volume = {8},
   pages = {810-823},
-}
-
-@article{Wells2007,
-author = {Wells, David B. and Abramkina, Volha and Aksimentiev, Aleksei},
-doi = {10.1063/1.2770738},
-issn = {0021-9606},
-journal = {J. Chem. Phys.},
-month = {sep},
-number = {12},
-pages = {125101},
-title = {{Exploring transmembrane transport through $\alpha$-hemolysin with grid-steered molecular dynamics}},
-url = {http://aip.scitation.org/doi/10.1063/1.2770738},
-volume = {127},
-year = {2007}
-}
-
-@article{Fu2017,
-author = {Fu, Haohao and Cai, Wensheng and H\'enin, J\'er\^ome and Roux, Beno\^it and Chipot, Christophe},
-title = {New Coarse Variables for the Accurate Determination of Standard Binding Free Energies},
-journal = {J. Chem. Theory. Comput.},
-volume = {13},
-number = {11},
-pages = {5173-5178},
-year = {2017},
-doi = {10.1021/acs.jctc.7b00791},
-URL = {https://doi.org/10.1021/acs.jctc.7b00791},
 }
 
 @article{hamelberg2004,
@@ -537,18 +359,6 @@ URL = {https://doi.org/10.1021/acs.jctc.7b00791},
   month = jun,
   year = {2004},
   pages = {11919--11929}
-}
-
-@article{Chen2021,
-  title = {Overcoming {Free}-{Energy} {Barriers} with a {Seamless} {Combination} of a {Biasing} {Force} and a {Collective} {Variable}-{Independent} {Boost} {Potential}},
-  copyright = {{\textcopyright} 2021 American Chemical Society},
-  url = {https://pubs.acs.org/doi/pdf/10.1021/acs.jctc.1c00103},
-  doi = {10.1021/acs.jctc.1c00103},
-  urldate = {2021-07-07},
-  journal = {J. Chem. Theory Comput},
-  author = {Chen, Haochuan and Fu, Haohao and Chipot, Christophe and Shao, Xueguang and Cai, Wensheng},
-  month = jun,
-  year = {2021}
 }
 
 @article{Miao2015,

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -275,6 +275,7 @@ cv.#1(#2)
 %\addtocontents{toc}{\contentsline {section}{References}{\thepage}}
 \bibliographystyle{unsrt}
 \bibliography{colvars-refman}
+\bibliography{colvars-code-refs}
 
 \ifdefined\HCode
 \HCode{</div>

--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -24,6 +24,15 @@
 \item \texttt{cv delete}
 \\
 \texttt{Delete this Colvars module instance (VMD only)}
+\item \texttt{cv featurereport}
+\\
+\texttt{Return a summary of Colvars features used so far and their citations}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{report : string - Feature report and citations}
 \item \texttt{cv frame [frame]}
 \\
 \texttt{Get or set current frame number (VMD only)}

--- a/doc/extract_code_refs.py
+++ b/doc/extract_code_refs.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
 # Extract BibTeX entries
 
 import re
@@ -71,6 +75,7 @@ with open('colvars-code-refs.bib') as bib:
             url = ""
 
     print("""
+  paper_count_[std::string("n/a")] = 0;
   paper_url_[std::string("n/a")] = "";
   paper_bibtex_[std::string("n/a")] = "";""")
 

--- a/doc/extract_code_refs.py
+++ b/doc/extract_code_refs.py
@@ -1,0 +1,77 @@
+# Extract BibTeX entries
+
+import re
+
+
+def gen_cplusplus_entry(entry, key, url):
+    key_year_sep = re.search('\d', key).start()
+    key_author = key[0:key_year_sep]
+    key_year = key[key_year_sep:]
+    result = """
+  paper_count_[std::string("%s")] = 0;
+  paper_url_[std::string("%s")] = "%s";""" % (key, key, url)
+    result += """
+  paper_bibtex_[std::string("%s")] =
+    \"\\n\"""" % key
+    for line in entry.splitlines():
+        result += """
+    \"%s\\n\"""" % line
+    result += ';'
+    return result
+
+
+features = {}
+
+
+def print_cplusplus_features(features):
+    for key in features.keys():
+        if features[key] is None:
+            features[key] = 'n/a'
+        print("""
+  feature_count_[std::string("%s")] = 0;
+  feature_paper_map_[std::string("%s")] = "%s";""" % (key, key, features[key]))
+
+
+def assign_undef_features(entry):
+    for key in features.keys():
+        if features[key] is None:
+            features[key] = entry
+
+
+with open('colvars-code-refs.bib') as bib:
+    entry = ""
+    for line in bib.readlines():
+        first_char = None
+        if len(line.lstrip()) > 0:
+            first_char = line.lstrip()[0]
+        if first_char == '%':
+            if not line.lstrip()[2:5] == '---':
+                feature = line.lstrip('%').lstrip().rstrip()
+                features[feature] = None
+            continue
+        if first_char == None:
+            continue
+        if first_char == '@':
+            words = re.split('@|{|}',
+                             line.lstrip(first_char).rstrip('\n').rstrip(','))
+            key = words[1]
+        else:
+            if line.lstrip().lower()[0:3] == 'url':
+                words = re.split(' |=|{|}', line.lstrip())
+                for word in words:
+                    if len(word) > 5:
+                        if word[0:5] == 'https':
+                            url = word
+        entry += line.replace('\\', '\\\\')
+        if first_char == '}':
+            # Closing an entry
+            print(gen_cplusplus_entry(entry, key, url))
+            assign_undef_features(key)
+            entry = ""
+            url = ""
+
+    print("""
+  paper_url_[std::string("n/a")] = "";
+  paper_bibtex_[std::string("n/a")] = "";""")
+
+    print_cplusplus_features(features)

--- a/lammps/lib/colvars/Makefile.deps
+++ b/lammps/lib/colvars/Makefile.deps
@@ -295,7 +295,7 @@ $(COLVARS_OBJ_DIR)colvarmodule.o: colvarmodule.cpp colvarmodule.h \
  colvarbias_restraint.h colvarscript.h colvarscript_commands.h \
  colvarscript_commands_colvar.h colvarscript_commands_bias.h \
  colvaratoms.h colvarcomp.h colvar_arithmeticpath.h \
- colvar_geometricpath.h
+ colvar_geometricpath.h colvarmodule_refs.h
 $(COLVARS_OBJ_DIR)colvarparams.o: colvarparams.cpp colvarmodule.h \
  colvars_version.h colvarvalue.h colvartypes.h colvarparams.h
 $(COLVARS_OBJ_DIR)colvarparse.o: colvarparse.cpp colvarmodule.h \

--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -131,6 +131,9 @@ void colvarproxy_lammps::init(const char *conf_file)
   cvm::log("Using LAMMPS interface, version "+
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
+  colvars->cite_feature("LAMMPS engine");
+  colvars->cite_feature("Colvars-LAMMPS interface");
+
   my_angstrom  = _lmp->force->angstrom;
   // Front-end unit is the same as back-end
   angstrom_value = my_angstrom;

--- a/lammps/src/COLVARS/fix_colvars.cpp
+++ b/lammps/src/COLVARS/fix_colvars.cpp
@@ -46,16 +46,6 @@
 #include <memory>
 #include <vector>
 
-static const char colvars_pub[] =
-  "fix colvars command:\n\n"
-  "@Article{fiorin13,\n"
-  " author =  {G.~Fiorin and M.{\\,}L.~Klein and J.~H{\\'e}nin},\n"
-  " title =   {Using collective variables to drive molecular"
-  " dynamics simulations},\n"
-  " journal = {Mol.~Phys.},\n"
-  " year =    2013,\n"
-  " note =    {doi: 10.1080/00268976.2013.813594}\n"
-  "}\n\n";
 
 /* struct for packed data communication of coordinates and forces. */
 struct LAMMPS_NS::commdata {
@@ -356,8 +346,6 @@ FixColvars::FixColvars(LAMMPS *lmp, int narg, char **arg) :
 
   /* storage required to communicate a single coordinate or force. */
   size_one = sizeof(struct commdata);
-
-  if (lmp->citeme) lmp->citeme->add(colvars_pub);
 }
 
 /*********************************
@@ -988,6 +976,9 @@ void FixColvars::post_run()
 {
   if (me == 0) {
     proxy->post_run();
+    if (lmp->citeme) {
+      lmp->citeme->add(proxy->colvars->feature_report(1));
+    }
   }
 }
 

--- a/namd/colvars/Make.depends
+++ b/namd/colvars/Make.depends
@@ -403,6 +403,7 @@ obj/colvarmodule.o: \
 	colvars/src/colvar_UIestimator.h \
 	colvars/src/colvarbias_alb.h \
 	colvars/src/colvarbias_histogram.h \
+	colvars/src/colvarbias_histogram_reweight_amd.h \
 	colvars/src/colvarbias_meta.h \
 	colvars/src/colvarbias_restraint.h \
 	colvars/src/colvarscript.h \
@@ -412,7 +413,8 @@ obj/colvarmodule.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvar_arithmeticpath.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvarmodule_refs.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarmodule.o $(COPTC) colvars/src/colvarmodule.cpp
 obj/colvarparams.o: \
 	obj/.exists \

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -265,6 +265,11 @@ int colvarproxy_namd::setup()
   }
 #endif
 
+  if (first_timestep) {
+    // Nag only once, there may be many run commands
+    log(colvars->feature_report(0));
+  }
+
   return COLVARS_OK;
 }
 

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -129,6 +129,8 @@ colvarproxy_namd::colvarproxy_namd()
   colvars = new colvarmodule(this);
   cvm::log("Using NAMD interface, version "+
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
+  colvars->cite_feature("NAMD engine");
+  colvars->cite_feature("Colvars-NAMD interface");
 
   errno = 0;
   if (config) {
@@ -1108,6 +1110,8 @@ int colvarproxy_namd::init_atom_group(std::vector<int> const &atoms_ids)
     cvm::log("Reguesting from NAMD a group of size "+cvm::to_str(atoms_ids.size())+
         " for collective variables calculation.\n");
 
+  colvars->cite_feature("Scalable center-of-mass computation (NAMD)");
+
   // Note: modifyRequestedGroups is supposed to be in sync with the colvarproxy arrays,
   // and to stay that way during a simulation
 
@@ -1233,6 +1237,7 @@ int colvarproxy_namd::init_volmap_by_id(int volmap_id)
   if (error_code == COLVARS_OK) {
     index = add_volmap_slot(volmap_id);
     modifyRequestedGridObjects().add(volmap_id);
+    colvars->cite_feature("GridForces volumetric map implementation for NAMD");
   }
 
   return (error_code == COLVARS_OK) ? index : -1;
@@ -1275,6 +1280,7 @@ int colvarproxy_namd::init_volmap_by_name(char const *volmap_name)
 
     index = add_volmap_slot(volmap_id);
     modifyRequestedGridObjects().add(volmap_id);
+    colvars->cite_feature("GridForces volumetric map implementation for NAMD");
   }
 
   return (error_code == COLVARS_OK) ? index : -1;

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -97,6 +97,7 @@ int colvar::init(std::string const &conf)
 
     enable(f_cv_scripted);
     cvm::log("This colvar uses scripted function \"" + scripted_function + "\".\n");
+    cvm::main()->cite_feature("Scripted functions (Tcl)");
 
     std::string type_str;
     get_keyval(conf, "scriptedFunctionType", type_str, "scalar");
@@ -327,6 +328,8 @@ int colvar::init_custom_function(std::string const &conf)
   if (!key_lookup(conf, "customFunction", &expr_in, &pos)) {
     return COLVARS_OK;
   }
+
+  cvm::main()->cite_feature("Custom functions (Lepton)");
 
   enable(f_cv_custom_function);
   cvm::log("This colvar uses a custom function.\n");
@@ -769,6 +772,8 @@ template<typename def_class_name> int colvar::init_components_type(std::string c
                  MEMORY_ERROR);
       return MEMORY_ERROR;
     }
+
+    cvm::main()->cite_feature(std::string(def_config_key)+" colvar component");
 
     if ( (cvcp->period != 0.0) || (cvcp->wrap_center != 0.0) ) {
       if ( (cvcp->function_type != std::string("distance_z")) &&

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -407,11 +407,17 @@ int cvm::atom_group::parse(std::string const &group_conf)
   b_defined_center |= get_keyval_feature(this, group_conf, "centerToReference", f_ag_center, is_enabled(f_ag_center));
 
   if (is_enabled(f_ag_center_origin) && ! is_enabled(f_ag_center)) {
-    return cvm::error("centerToReference may not be disabled if centerToOrigin is enabled.\n");
+    return cvm::error("centerToReference may not be disabled if centerToOrigin"
+                      "is enabled.\n", INPUT_ERROR);
   }
   // Legacy alias
   bool b_defined_rotate = get_keyval_feature(this, group_conf, "rotateReference", f_ag_rotate, false, parse_deprecated);
   b_defined_rotate |= get_keyval_feature(this, group_conf, "rotateToReference", f_ag_rotate, is_enabled(f_ag_rotate));
+
+  if (is_enabled(f_ag_rotate) || is_enabled(f_ag_center) ||
+      is_enabled(f_ag_center_origin)) {
+    cvm::main()->cite_feature("Moving frame of reference");
+  }
 
   // is the user setting explicit options?
   b_user_defined_fit = b_defined_center || b_defined_rotate;

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -717,6 +717,10 @@ int colvarbias_ti::init(std::string const &conf)
     }
   }
 
+  if (is_enabled(f_cvb_write_ti_pmf) || is_enabled(f_cvb_write_ti_samples)) {
+    cvm::main()->cite_feature("Internal-forces free energy estimator");
+  }
+
   return error_code;
 }
 

--- a/src/colvarbias_alb.cpp
+++ b/src/colvarbias_alb.cpp
@@ -37,6 +37,7 @@ colvarbias_alb::colvarbias_alb(char const *key)
 int colvarbias_alb::init(std::string const &conf)
 {
   colvarbias::init(conf);
+  cvm::main()->cite_feature("ALB colvar bias implementation");
 
   enable(f_cvb_scalar_variables);
 

--- a/src/colvarbias_histogram.cpp
+++ b/src/colvarbias_histogram.cpp
@@ -24,6 +24,7 @@ colvarbias_histogram::colvarbias_histogram(char const *key)
 int colvarbias_histogram::init(std::string const &conf)
 {
   colvarbias::init(conf);
+  cvm::main()->cite_feature("Histogram colvar bias implementation");
 
   enable(f_cvb_scalar_variables);
   enable(f_cvb_history_dependent);

--- a/src/colvarbias_histogram_reweight_amd.cpp
+++ b/src/colvarbias_histogram_reweight_amd.cpp
@@ -52,6 +52,7 @@ int colvarbias_reweightaMD::init(std::string const &conf) {
   if (cvm::proxy->accelMD_enabled() == false) {
     cvm::error("Error: accelerated MD in your MD engine is not enabled.\n", INPUT_ERROR);
   }
+  cvm::main()->cite_feature("reweightaMD colvar bias implementation (NAMD)");
   int baseclass_init_code = colvarbias_histogram::init(conf);
   get_keyval(conf, "CollectAfterSteps", start_after_steps, 0);
   get_keyval(conf, "CumulantExpansion", b_use_cumulant_expansion, true);
@@ -92,7 +93,7 @@ int colvarbias_reweightaMD::update() {
     if (cvm::step_relative() > 0) {
       previous_bin = bin;
     }
-    
+
     // assign a valid bin size
     bin.assign(num_variables(), 0);
 

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -71,6 +71,8 @@ int colvarbias_meta::init(std::string const &conf)
   error_code |= colvarbias::init(conf);
   error_code |= colvarbias_ti::init(conf);
 
+  cvm::main()->cite_feature("Metadynamics colvar bias implementation");
+
   enable(f_cvb_calc_pmf);
 
   get_keyval(conf, "hillWeight", hill_weight, 0.0);
@@ -117,10 +119,12 @@ int colvarbias_meta::init(std::string const &conf)
   {
     bool b_replicas = false;
     get_keyval(conf, "multipleReplicas", b_replicas, false);
-    if (b_replicas)
-      comm = multiple_replicas;
-    else
+    if (b_replicas) {
+      cvm::main()->cite_feature("Multiple-walker metadynamics colvar bias implementation");
+  comm = multiple_replicas;
+    } else {
       comm = single_replica;
+    }
   }
 
   get_keyval(conf, "useGrids", use_grids, use_grids);
@@ -266,6 +270,7 @@ int colvarbias_meta::init_ebmeta_params(std::string const &conf)
   target_dist = NULL;
   get_keyval(conf, "ebMeta", ebmeta, false);
   if(ebmeta){
+    cvm::main()->cite_feature("Ensemble-biased metadynamics (ebMetaD)");
     if (use_grids && expand_grids) {
       cvm::fatal_error("Error: expandBoundaries is not supported with "
                        "ebMeta please allocate wide enough boundaries for "

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -726,6 +726,8 @@ int colvarbias_restraint_harmonic::init(std::string const &conf)
   colvarbias_restraint_centers_moving::init(conf);
   colvarbias_restraint_k_moving::init(conf);
 
+  cvm::main()->cite_feature("Harmonic colvar bias implementation");
+
   for (size_t i = 0; i < num_variables(); i++) {
     cvm::real const w = variables(i)->width;
     cvm::log("The force constant for colvar \""+variables(i)->name+
@@ -879,6 +881,8 @@ int colvarbias_restraint_harmonic_walls::init(std::string const &conf)
   colvarbias_restraint::init(conf);
   colvarbias_restraint_moving::init(conf);
   colvarbias_restraint_k_moving::init(conf);
+
+  cvm::main()->cite_feature("harmonicWalls colvar bias implementation");
 
   enable(f_cvb_scalar_variables);
 
@@ -1148,6 +1152,8 @@ int colvarbias_restraint_linear::init(std::string const &conf)
   colvarbias_restraint_centers_moving::init(conf);
   colvarbias_restraint_k_moving::init(conf);
 
+  cvm::main()->cite_feature("harmonicWalls colvar bias implementation");
+
   for (size_t i = 0; i < num_variables(); i++) {
     if (variables(i)->is_enabled(f_cv_periodic)) {
       cvm::error("Error: linear biases cannot be applied to periodic variables.\n",
@@ -1298,6 +1304,8 @@ int colvarbias_restraint_histogram::init(std::string const &conf)
 {
   colvarbias::init(conf);
   enable(f_cvb_apply_force);
+
+  cvm::main()->cite_feature("histogramRestraint colvar bias implementation");
 
   get_keyval(conf, "lowerBoundary", lower_boundary, lower_boundary);
   get_keyval(conf, "upperBoundary", upper_boundary, upper_boundary);

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -68,8 +68,10 @@ int colvar::cvc::init(std::string const &conf)
     }
   }
 
-  get_keyval(conf, "componentCoeff", sup_coeff, sup_coeff);
-  get_keyval(conf, "componentExp", sup_np, sup_np);
+  if (get_keyval(conf, "componentCoeff", sup_coeff, sup_coeff) ||
+      get_keyval(conf, "componentExp", sup_np, sup_np)) {
+    cvm::main()->cite_feature("Linear and polynomial combination of colvar components");
+  }
   // TODO these could be condensed into get_keyval()
   register_param("componentCoeff", reinterpret_cast<void *>(&sup_coeff));
   register_param("componentExp", reinterpret_cast<void *>(&sup_np));

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -68,8 +68,9 @@ int colvar::cvc::init(std::string const &conf)
     }
   }
 
-  if (get_keyval(conf, "componentCoeff", sup_coeff, sup_coeff) ||
-      get_keyval(conf, "componentExp", sup_np, sup_np)) {
+  get_keyval(conf, "componentCoeff", sup_coeff, sup_coeff);
+  get_keyval(conf, "componentExp", sup_np, sup_np);
+  if (sup_coeff != 1.0 || sup_np != 0) {
     cvm::main()->cite_feature("Linear and polynomial combination of colvar components");
   }
   // TODO these could be condensed into get_keyval()

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -162,6 +162,7 @@ colvar::coordnum::coordnum(std::string const &conf)
 
   get_keyval(conf, "tolerance", tolerance, 0.0);
   if (tolerance > 0) {
+    cvm::main()->cite_feature("coordNum pairlist");
     get_keyval(conf, "pairListFrequency", pairlist_freq, 100);
     if ( ! (pairlist_freq > 0) ) {
       cvm::error("Error: non-positive pairlistfrequency provided.\n",

--- a/src/colvarcomp_volmaps.cpp
+++ b/src/colvarcomp_volmaps.cpp
@@ -46,6 +46,8 @@ int colvar::map_total::init(std::string const &conf)
   get_keyval(conf, "mapID", volmap_id, volmap_id);
   register_param("mapID", reinterpret_cast<void *>(&volmap_id));
 
+  cvm::main()->cite_feature("Volumetric map-based collective variables");
+
   if ((volmap_name.size() > 0) && (volmap_id >= 0)) {
     error_code |=
       cvm::error("Error: mapName and mapID are mutually exclusive.\n");

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -2300,18 +2300,17 @@ int colvarmodule::usage::cite_feature(std::string const &feature)
     feature_count_[feature] += 1;
     return cite_paper(feature_paper_map_[feature]);
   }
-  return cvm::error("Error: cannot cite unknown feature \""+feature+"\"\n",
-                    INPUT_ERROR);
+  cvm::log("Warning: cannot cite unknown feature \""+feature+"\"\n");
+  return COLVARS_OK;
 }
 
 int colvarmodule::usage::cite_paper(std::string const &paper)
 {
   if (paper_count_.count(paper) > 0) {
     paper_count_[paper] += 1;
-    return COLVARS_OK;
   }
-  return cvm::error("Error: cannot cite unknown paper \""+paper+"\"\n",
-                    INPUT_ERROR);
+  cvm::log("Warning: cannot cite unknown paper \""+paper+"\"\n");
+  return COLVARS_OK;
 }
 
 std::string colvarmodule::usage::report(int flag)

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -2317,6 +2317,15 @@ int colvarmodule::usage::cite_paper(std::string const &paper)
 std::string colvarmodule::usage::report(int flag)
 {
   std::string result;
+  if (flag == 0) {
+    // Text
+    result += "SUMMARY OF COLVARS FEATURES USED SO FAR AND THEIR CITATIONS:\n";
+  }
+  if (flag == 1) {
+    // LAMMPS log friendly (one-line summary, lowercase message)
+    result += "Colvars module (Fiorin2013, plus other works listed for specific features)\n\n";
+  }
+
   std::map<std::string, int>::iterator p_iter = paper_count_.begin();
   for ( ; p_iter != paper_count_.end(); p_iter++) {
     std::string const paper = p_iter->first;
@@ -2345,11 +2354,6 @@ std::string colvarmodule::usage::report(int flag)
         result += paper_bibtex_[paper] + "\n";
       }
     }
-  }
-
-  if (result.size() > 0) {
-    return "\n\nSUMMARY OF COLVARS FEATURES USED SO FAR AND THEIR CITATIONS:\n" +
-      result + "\n";
   }
 
   return result;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -2283,6 +2283,12 @@ int colvarmodule::cite_feature(std::string const &feature)
   return usage_->cite_feature(feature);
 }
 
+std::string colvarmodule::feature_report(int flag)
+{
+  return usage_->report(flag);
+}
+
+
 colvarmodule::usage::usage()
 {
 #include "colvarmodule_refs.h"

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -642,6 +642,9 @@ public:
   /// Track usage of the given Colvars feature
   int cite_feature(std::string const &feature);
 
+  /// Report usage of the Colvars features
+  std::string feature_report(int flag = 0);
+
   /// Print a message to the main log
   /// \param message Message to print
   /// \param min_log_level Only print if cvm::log_level() >= min_log_level

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -188,13 +188,13 @@ public:
     return ::log(static_cast<double>(x));
   }
 
-
+  // Forward declarations
   class rvector;
   template <class T> class vector1d;
   template <class T> class matrix2d;
   class quaternion;
   class rotation;
-
+  class usage;
 
   /// Residue identifier
   typedef int residue_id;
@@ -336,10 +336,11 @@ public:
     return COLVARS_DEBUG;
   }
 
-  /// \brief How many objects are configured yet?
+  /// How many objects (variables and biases) are configured yet?
   size_t size() const;
 
-  /// \brief Constructor
+  /// Constructor
+  /// \param Pointer to instance of the proxy class (communicate with engine)
   colvarmodule(colvarproxy *proxy);
 
   /// Destructor
@@ -638,6 +639,9 @@ public:
   /// Request calculation of total force from MD engine
   static void request_total_force();
 
+  /// Track usage of the given Colvars feature
+  int cite_feature(std::string const &feature);
+
   /// Print a message to the main log
   /// \param message Message to print
   /// \param min_log_level Only print if cvm::log_level() >= min_log_level
@@ -787,6 +791,9 @@ protected:
 
   /// Track how many times the XYZ reader has been used
   int xyz_reader_use_count;
+
+  /// Track usage of Colvars features
+  usage *usage_;
 
 public:
 

--- a/src/colvarmodule_refs.h
+++ b/src/colvarmodule_refs.h
@@ -184,15 +184,17 @@
     "}\n";
 
   paper_count_[std::string("Henin2021")] = 0;
-  paper_url_[std::string("Henin2021")] = "";
+  paper_url_[std::string("Henin2021")] = "https://arxiv.org/abs/2107.08511";
   paper_bibtex_[std::string("Henin2021")] =
     "\n"
-    "@article{Henin2021,\n"
+    "@misc{Henin2021,\n"
     "  author = {H\\'enin, J\\'er\\^ome},\n"
     "  title = {Fast and accurate multidimensional free energy integration},\n"
-    "  journal = {J. Chem. Theory Comput.},\n"
-    "  year = {2021},\n"
-    "  note = {in press}\n"
+    "  year={2021},\n"
+    "  eprint={2107.08511},\n"
+    "  archivePrefix={arXiv},\n"
+    "  primaryClass={physics.comp-ph}\n"
+    "  url = {https://arxiv.org/abs/2107.08511},\n"
     "}\n";
 
   paper_count_[std::string("Marinelli2015")] = 0;

--- a/src/colvarmodule_refs.h
+++ b/src/colvarmodule_refs.h
@@ -61,7 +61,7 @@
     "  pages = {3345--3362},\n"
     "  publisher = {Taylor & Francis},\n"
     "  doi = {10.1080/00268976.2013.813594},\n"
-    "  URL = {https://doi.org/10.1080/00268976.2013.813594}\n"
+    "  url = {https://doi.org/10.1080/00268976.2013.813594}\n"
     "}\n";
 
   paper_count_[std::string("Fiorin2020")] = 0;
@@ -217,7 +217,7 @@
   paper_bibtex_[std::string("Phillips2020")] =
     "\n"
     "@article{Phillips2020,\n"
-    "  author = {Phillips, James C.{} and Hardy, David J.{} and Maia, Julio D. C.{} and Stone, John E.{} and Ribeiro, Jo\\~ao V.{} and Bernardi, Rafael C.{} and Buch, Ronak and Fiorin, Giacomo and H\\'enin, J\\'er\\^ome and Jiang, Wei and McGreevy, Ryan and Melo, Marcelo C. R.{} and Radak, Brian K.{} and Skeel, Robert D.{} and Singharoy, Abhishek and Wang, Yi and Roux, Beno\\^it and Aksimentiev, Aleksei and Luthey-Schulten, Zaida and Kal\\'e, Laxmikant V.{} and Schulten, Klaus and Chipot, Christophe and Tajkhorshid, Emad}, \n"
+    "  author = {Phillips, James C.{} and Hardy, David J.{} and Maia, Julio D. C.{} and Stone, John E.{} and Ribeiro, Jo\\~ao V.{} and Bernardi, Rafael C.{} and Buch, Ronak and Fiorin, Giacomo and H\\'enin, J\\'er\\^ome and Jiang, Wei and McGreevy, Ryan and Melo, Marcelo C. R.{} and Radak, Brian K.{} and Skeel, Robert D.{} and Singharoy, Abhishek and Wang, Yi and Roux, Beno\\^it and Aksimentiev, Aleksei and Luthey-Schulten, Zaida and Kal\\'e, Laxmikant V.{} and Schulten, Klaus and Chipot, Christophe and Tajkhorshid, Emad},\n"
     "  title = {Scalable molecular dynamics on {CPU} and {GPU} architectures with {NAMD}},\n"
     "  journal = {J. Chem. Phys.},\n"
     "  year = {2020},\n"
@@ -296,6 +296,7 @@
     "  url = {https://doi.org/10.1021/ct500320c}\n"
     "}\n";
 
+  paper_count_[std::string("n/a")] = 0;
   paper_url_[std::string("n/a")] = "";
   paper_bibtex_[std::string("n/a")] = "";
 
@@ -335,6 +336,9 @@
   feature_count_[std::string("distanceDir colvar component")] = 0;
   feature_paper_map_[std::string("distanceDir colvar component")] = "Fiorin2013";
 
+  feature_count_[std::string("distanceInv colvar component")] = 0;
+  feature_paper_map_[std::string("distanceInv colvar component")] = "Fiorin2013";
+
   feature_count_[std::string("angle colvar component")] = 0;
   feature_paper_map_[std::string("angle colvar component")] = "Fiorin2013";
 
@@ -344,8 +348,11 @@
   feature_count_[std::string("coordNum colvar component")] = 0;
   feature_paper_map_[std::string("coordNum colvar component")] = "Fiorin2013";
 
-  feature_count_[std::string("selfCoordNum colvar component (@jhenin should this be a different paper?)")] = 0;
-  feature_paper_map_[std::string("selfCoordNum colvar component (@jhenin should this be a different paper?)")] = "Fiorin2013";
+  feature_count_[std::string("selfCoordNum colvar component")] = 0;
+  feature_paper_map_[std::string("selfCoordNum colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("groupCoord colvar component")] = 0;
+  feature_paper_map_[std::string("groupCoord colvar component")] = "Fiorin2013";
 
   feature_count_[std::string("hBond colvar component")] = 0;
   feature_paper_map_[std::string("hBond colvar component")] = "Fiorin2013";
@@ -392,8 +399,8 @@
   feature_count_[std::string("cartesian colvar component")] = 0;
   feature_paper_map_[std::string("cartesian colvar component")] = "Fiorin2013";
 
-  feature_count_[std::string("linear and polynomial combination of colvar components")] = 0;
-  feature_paper_map_[std::string("linear and polynomial combination of colvar components")] = "Fiorin2013";
+  feature_count_[std::string("Linear and polynomial combination of colvar components")] = 0;
+  feature_paper_map_[std::string("Linear and polynomial combination of colvar components")] = "Fiorin2013";
 
   feature_count_[std::string("Metadynamics colvar bias implementation")] = 0;
   feature_paper_map_[std::string("Metadynamics colvar bias implementation")] = "Fiorin2013";
@@ -404,17 +411,26 @@
   feature_count_[std::string("Harmonic colvar bias implementation")] = 0;
   feature_paper_map_[std::string("Harmonic colvar bias implementation")] = "Fiorin2013";
 
+  feature_count_[std::string("harmonicWalls colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("harmonicWalls colvar bias implementation")] = "Fiorin2013";
+
   feature_count_[std::string("Linear colvar bias implementation")] = 0;
   feature_paper_map_[std::string("Linear colvar bias implementation")] = "Fiorin2013";
 
-  feature_count_[std::string("histogram colvar bias implementation")] = 0;
-  feature_paper_map_[std::string("histogram colvar bias implementation")] = "Fiorin2013";
+  feature_count_[std::string("Histogram colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("Histogram colvar bias implementation")] = "Fiorin2013";
 
-  feature_count_[std::string("mapTotal colvar component (volumetric-map and Multi-Map colvar components)")] = 0;
-  feature_paper_map_[std::string("mapTotal colvar component (volumetric-map and Multi-Map colvar components)")] = "Fiorin2020";
+  feature_count_[std::string("mapTotal colvar component")] = 0;
+  feature_paper_map_[std::string("mapTotal colvar component")] = "Fiorin2020";
 
-  feature_count_[std::string("eABF implementation (umbrella-integration version)")] = 0;
-  feature_paper_map_[std::string("eABF implementation (umbrella-integration version)")] = "Fu2016";
+  feature_count_[std::string("Volumetric map-based collective variables")] = 0;
+  feature_paper_map_[std::string("Volumetric map-based collective variables")] = "Fiorin2020";
+
+  feature_count_[std::string("Multi-Map collective variables")] = 0;
+  feature_paper_map_[std::string("Multi-Map collective variables")] = "Fiorin2020";
+
+  feature_count_[std::string("Umbrella-integration eABF estimator")] = 0;
+  feature_paper_map_[std::string("Umbrella-integration eABF estimator")] = "Fu2016";
 
   feature_count_[std::string("polarTheta colvar component")] = 0;
   feature_paper_map_[std::string("polarTheta colvar component")] = "Fu2017";
@@ -437,8 +453,8 @@
   feature_count_[std::string("dipoleMagnitude colvar component")] = 0;
   feature_paper_map_[std::string("dipoleMagnitude colvar component")] = "Garate2019";
 
-  feature_count_[std::string("ABF implementation (internal forces)")] = 0;
-  feature_paper_map_[std::string("ABF implementation (internal forces)")] = "Henin2010";
+  feature_count_[std::string("ABF colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("ABF colvar bias implementation")] = "Henin2010";
 
   feature_count_[std::string("Internal-forces free energy estimator")] = 0;
   feature_paper_map_[std::string("Internal-forces free energy estimator")] = "Henin2010";
@@ -449,8 +465,8 @@
   feature_count_[std::string("eABF implementation")] = 0;
   feature_paper_map_[std::string("eABF implementation")] = "Lesage2017";
 
-  feature_count_[std::string("CZAR estimator")] = 0;
-  feature_paper_map_[std::string("CZAR estimator")] = "Lesage2017";
+  feature_count_[std::string("CZAR eABF estimator")] = 0;
+  feature_paper_map_[std::string("CZAR eABF estimator")] = "Lesage2017";
 
   feature_count_[std::string("Poisson integration of 2D/3D free energy surfaces")] = 0;
   feature_paper_map_[std::string("Poisson integration of 2D/3D free energy surfaces")] = "Henin2021";
@@ -476,8 +492,8 @@
   feature_count_[std::string("GridForces volumetric map implementation for NAMD")] = 0;
   feature_paper_map_[std::string("GridForces volumetric map implementation for NAMD")] = "Wells2007";
 
-  feature_count_[std::string("ALB colvar bias")] = 0;
-  feature_paper_map_[std::string("ALB colvar bias")] = "White2014";
+  feature_count_[std::string("ALB colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("ALB colvar bias implementation")] = "White2014";
 
   feature_count_[std::string("Colvars-GROMACS interface")] = 0;
   feature_paper_map_[std::string("Colvars-GROMACS interface")] = "n/a";
@@ -509,8 +525,8 @@
   feature_count_[std::string("coordNum pairlist")] = 0;
   feature_paper_map_[std::string("coordNum pairlist")] = "n/a";
 
-  feature_count_[std::string("custom functions (Lepton)")] = 0;
-  feature_paper_map_[std::string("custom functions (Lepton)")] = "n/a";
+  feature_count_[std::string("Custom functions (Lepton)")] = 0;
+  feature_paper_map_[std::string("Custom functions (Lepton)")] = "n/a";
 
-  feature_count_[std::string("scripted functions (Tcl)")] = 0;
-  feature_paper_map_[std::string("scripted functions (Tcl)")] = "n/a";
+  feature_count_[std::string("Scripted functions (Tcl)")] = 0;
+  feature_paper_map_[std::string("Scripted functions (Tcl)")] = "n/a";

--- a/src/colvarmodule_refs.h
+++ b/src/colvarmodule_refs.h
@@ -1,0 +1,516 @@
+
+  paper_count_[std::string("Abraham2015")] = 0;
+  paper_url_[std::string("Abraham2015")] = "https://doi.org/10.1016/j.softx.2015.06.001";
+  paper_bibtex_[std::string("Abraham2015")] =
+    "\n"
+    "@article{Abraham2015,\n"
+    "  title = {{GROMACS}: High performance molecular simulations through multi-level parallelism from laptops to supercomputers},\n"
+    "  author = {Abraham, Mark J.{} and Murtola, Teemu and Schulz, Roland and Páll, Szil\\'ard and Smith, Jeremy C.{} and Hess, Berk and Lindahl, Erik},\n"
+    "  journal = {{SoftwareX}},\n"
+    "  volume = {1--2},\n"
+    "  year = {2015},\n"
+    "  pages = {19--25},\n"
+    "  doi = {10.1016/j.softx.2015.06.001},\n"
+    "  url = {https://doi.org/10.1016/j.softx.2015.06.001}\n"
+    "}\n";
+
+  paper_count_[std::string("Chen2021")] = 0;
+  paper_url_[std::string("Chen2021")] = "https://doi.org/10.1021/acs.jctc.1c00103";
+  paper_bibtex_[std::string("Chen2021")] =
+    "\n"
+    "@article{Chen2021,\n"
+    "  author = {Chen, Haochuan and Fu, Haohao and Chipot, Christophe and Shao, Xueguang and Cai, Wensheng},\n"
+    "  title = {Overcoming free-energy barriers with a seamless combination of a biasing force and a collective variable-independent boost potential},\n"
+    "  journal = {J. Chem. Theory Comput.},\n"
+    "  year = {2021},\n"
+    "  volume = {17},\n"
+    "  number = {7},\n"
+    "  pages = {3886--3894},\n"
+    "  doi = {10.1021/acs.jctc.1c00103},\n"
+    "  url = {https://doi.org/10.1021/acs.jctc.1c00103}\n"
+    "}\n";
+
+  paper_count_[std::string("Comer2014c")] = 0;
+  paper_url_[std::string("Comer2014c")] = "https://doi.org/10.1021/ct500874p";
+  paper_bibtex_[std::string("Comer2014c")] =
+    "\n"
+    "@article{Comer2014c,\n"
+    "  author = {Comer, Jeffrey and Phillips, James C.{} and Schulten, Klaus and Chipot, Christophe},\n"
+    "  title = {Multiple-walker strategies for free-energy calculations in {NAMD}: {Shared} adaptive biasing force and walker selection rules},\n"
+    "  journal = {J. Chem. Theor. Comput.},\n"
+    "  year = {2014},\n"
+    "  volume = {10},\n"
+    "  number = {12},\n"
+    "  pages = {5276--5285},\n"
+    "  doi = {10.1021/ct500874p},\n"
+    "  pmid = {26583211},\n"
+    "  url = {https://doi.org/10.1021/ct500874p}\n"
+    "}\n";
+
+  paper_count_[std::string("Fiorin2013")] = 0;
+  paper_url_[std::string("Fiorin2013")] = "https://doi.org/10.1080/00268976.2013.813594";
+  paper_bibtex_[std::string("Fiorin2013")] =
+    "\n"
+    "@article{Fiorin2013,\n"
+    "  author = {Fiorin, Giacomo and Klein, Michael L.{} and H\\'enin, J\\'er\\^ome},\n"
+    "  title = {Using collective variables to drive molecular dynamics simulations},\n"
+    "  journal = {Mol. Phys.},\n"
+    "  year = {2013},\n"
+    "  volume = {111},\n"
+    "  number = {22-23},\n"
+    "  pages = {3345--3362},\n"
+    "  publisher = {Taylor & Francis},\n"
+    "  doi = {10.1080/00268976.2013.813594},\n"
+    "  URL = {https://doi.org/10.1080/00268976.2013.813594}\n"
+    "}\n";
+
+  paper_count_[std::string("Fiorin2020")] = 0;
+  paper_url_[std::string("Fiorin2020")] = "https://doi.org/10.1002/jcc.26075";
+  paper_bibtex_[std::string("Fiorin2020")] =
+    "\n"
+    "@article{Fiorin2020,\n"
+    "  author = {Fiorin, Giacomo and Marinelli, Fabrizio and {Faraldo-G\\'omez}, Jos\\'e D.},\n"
+    "  title = {Direct Derivation of Free Energies of Membrane Deformation and Other Solvent Density Variations From Enhanced Sampling Molecular Dynamics},\n"
+    "  journal = {J. Comp. Chem.},\n"
+    "  year = {2020},\n"
+    "  volume = {41},\n"
+    "  number = {5},\n"
+    "  pages = {449--459},\n"
+    "  doi = {10.1002/jcc.26075},\n"
+    "  pmid = {31602694},\n"
+    "  url = {https://doi.org/10.1002/jcc.26075}\n"
+    "}\n";
+
+  paper_count_[std::string("Fu2016")] = 0;
+  paper_url_[std::string("Fu2016")] = "https://doi.org/10.1021/acs.jctc.6b00447";
+  paper_bibtex_[std::string("Fu2016")] =
+    "\n"
+    "@article{Fu2016,\n"
+    "  author = {Fu, Haohao and Shao, Xueguang and Chipot, Cristophe and Cai, Wensheng},\n"
+    "  title = {Extended adaptive biasing force algorithm. {An} on--the--fly implementation for accurate free--energy calculations},\n"
+    "  journal = {J. Chem. Theory Comput.},\n"
+    "  year = {2016},\n"
+    "  volume = {12},\n"
+    "  number = {8},\n"
+    "  pages = {3506-–3513},\n"
+    "  pmid = {27398726},\n"
+    "  doi = {10.1021/acs.jctc.6b00447},\n"
+    "  pmid = {27398726},\n"
+    "  url = {https://doi.org/10.1021/acs.jctc.6b00447}\n"
+    "}\n";
+
+  paper_count_[std::string("Fu2017")] = 0;
+  paper_url_[std::string("Fu2017")] = "https://doi.org/10.1021/acs.jctc.7b00791";
+  paper_bibtex_[std::string("Fu2017")] =
+    "\n"
+    "@article{Fu2017,\n"
+    "  author = {Fu, Haohao and Cai, Wensheng and H\\'enin, J\\'er\\^ome and Roux, Beno\\^it and Chipot, Christophe},\n"
+    "  title = {New Coarse Variables for the Accurate Determination of Standard Binding Free Energies},\n"
+    "  journal = {J. Chem. Theory. Comput.},\n"
+    "  year = {2017},\n"
+    "  volume = {13},\n"
+    "  number = {11},\n"
+    "  pages = {5173-5178},\n"
+    "  doi = {10.1021/acs.jctc.7b00791},\n"
+    "  pmid = {28965398},\n"
+    "  url = {https://doi.org/10.1021/acs.jctc.7b00791}\n"
+    "}\n";
+
+  paper_count_[std::string("Garate2019")] = 0;
+  paper_url_[std::string("Garate2019")] = "https://doi.org/10.1021/acs.jpcb.8b09374";
+  paper_bibtex_[std::string("Garate2019")] =
+    "\n"
+    "@article{Garate2019,\n"
+    "  author = {Garate, Jos\\'e Antonio and Bernardin, Alejandro and Escalona, Yerko and Yanez, Carlos and English, Niall J.{} and {Perez-Acle}, Tomas},\n"
+    "  title = {Orientational and Folding Thermodynamics via Electric Dipole Moment Restraining},\n"
+    "  journal = {J. Phys. Chem. {B}},\n"
+    "  year = {2019},\n"
+    "  volume = {123},\n"
+    "  number = {12},\n"
+    "  pages = {2599--2608},\n"
+    "  doi = {10.1021/acs.jpcb.8b09374},\n"
+    "  pmid = {30831028},\n"
+    "  url = {https://doi.org/10.1021/acs.jpcb.8b09374}\n"
+    "}\n";
+
+  paper_count_[std::string("Henin2010")] = 0;
+  paper_url_[std::string("Henin2010")] = "https://doi.org/10.1021/ct9004432";
+  paper_bibtex_[std::string("Henin2010")] =
+    "\n"
+    "@article{Henin2010,\n"
+    "  author = {H\\'enin, J\\'er\\^ome and Fiorin, Giacomo and Chipot, Cristophe and Klein, Michael L.},\n"
+    "  title = {Exploring multidimensional free energy landscapes using time-dependent biases on collective variables},\n"
+    "  journal = {J. Chem. Theory Comput.},\n"
+    "  year = {2010},\n"
+    "  volume = {6},\n"
+    "  pages = {35-47},\n"
+    "  number = {1},\n"
+    "  doi = {10.1021/ct9004432},\n"
+    "  pmid = {26614317},\n"
+    "  url = {https://doi.org/10.1021/ct9004432}\n"
+    "}\n";
+
+  paper_count_[std::string("Humphrey1996")] = 0;
+  paper_url_[std::string("Humphrey1996")] = "https://doi.org/10.1016/0263-7855(96)00018-5";
+  paper_bibtex_[std::string("Humphrey1996")] =
+    "\n"
+    "@article{Humphrey1996,\n"
+    "  title = {{VMD}: visual molecular dynamics},\n"
+    "  author = {Humphrey, William and Dalke, Andrew and Schulten, Klaus},\n"
+    "  journal = {J. Mol. Graph.},\n"
+    "  year = {1996},\n"
+    "  volume = {14},\n"
+    "  number = {1},\n"
+    "  pages = {33--38},\n"
+    "  doi = {10.1016/0263-7855(96)00018-5},\n"
+    "  url = {https://doi.org/10.1016/0263-7855(96)00018-5}\n"
+    "}\n";
+
+  paper_count_[std::string("Lesage2017")] = 0;
+  paper_url_[std::string("Lesage2017")] = "https://doi.org/10.1021/acs.jpcb.6b10055";
+  paper_bibtex_[std::string("Lesage2017")] =
+    "\n"
+    "@article{Lesage2017,\n"
+    "  author = {Lesage, Adrien and Leli\\`evre, Tony and Stoltz, Gabriel and H\\'enin, J\\'er\\^ome},\n"
+    "  title = {Smoothed biasing forces yield unbiased free energies with the extended-system adaptive biasing force method},\n"
+    "  journal = {J. Phys. Chem. {B}},\n"
+    "  year = {2017},\n"
+    "  volume = {121},\n"
+    "  number = {15},\n"
+    "  pages = {3676-3685},\n"
+    "  doi = {10.1021/acs.jpcb.6b10055},\n"
+    "  pmid = {27959559},\n"
+    "  url = {https://doi.org/10.1021/acs.jpcb.6b10055}\n"
+    "}\n";
+
+  paper_count_[std::string("Henin2021")] = 0;
+  paper_url_[std::string("Henin2021")] = "";
+  paper_bibtex_[std::string("Henin2021")] =
+    "\n"
+    "@article{Henin2021,\n"
+    "  author = {H\\'enin, J\\'er\\^ome},\n"
+    "  title = {Fast and accurate multidimensional free energy integration},\n"
+    "  journal = {J. Chem. Theory Comput.},\n"
+    "  year = {2021},\n"
+    "  note = {in press}\n"
+    "}\n";
+
+  paper_count_[std::string("Marinelli2015")] = 0;
+  paper_url_[std::string("Marinelli2015")] = "https://doi.org/10.1016/j.bpj.2015.05.024";
+  paper_bibtex_[std::string("Marinelli2015")] =
+    "\n"
+    "@article{Marinelli2015,\n"
+    "  author = {Marinelli, Fabrizio and Faraldo-G\\'omez, Jos\\'e D.},\n"
+    "  title = {Ensemble-Biased Metadynamics: A Molecular Simulation Method to Sample Experimental Distributions},\n"
+    "  journal = {Biophys. J.},\n"
+    "  year = {2015},\n"
+    "  volume = {108},\n"
+    "  number = {12},\n"
+    "  pages = {2779--2782},\n"
+    "  doi = {10.1016/j.bpj.2015.05.024},\n"
+    "  pmid = {26083917},\n"
+    "  url = {https://doi.org/10.1016/j.bpj.2015.05.024}\n"
+    "}\n";
+
+  paper_count_[std::string("Phillips2020")] = 0;
+  paper_url_[std::string("Phillips2020")] = "https://doi.org/10.1063/5.0014475";
+  paper_bibtex_[std::string("Phillips2020")] =
+    "\n"
+    "@article{Phillips2020,\n"
+    "  author = {Phillips, James C.{} and Hardy, David J.{} and Maia, Julio D. C.{} and Stone, John E.{} and Ribeiro, Jo\\~ao V.{} and Bernardi, Rafael C.{} and Buch, Ronak and Fiorin, Giacomo and H\\'enin, J\\'er\\^ome and Jiang, Wei and McGreevy, Ryan and Melo, Marcelo C. R.{} and Radak, Brian K.{} and Skeel, Robert D.{} and Singharoy, Abhishek and Wang, Yi and Roux, Beno\\^it and Aksimentiev, Aleksei and Luthey-Schulten, Zaida and Kal\\'e, Laxmikant V.{} and Schulten, Klaus and Chipot, Christophe and Tajkhorshid, Emad}, \n"
+    "  title = {Scalable molecular dynamics on {CPU} and {GPU} architectures with {NAMD}},\n"
+    "  journal = {J. Chem. Phys.},\n"
+    "  year = {2020},\n"
+    "  volume = {153},\n"
+    "  number = {4},\n"
+    "  pages = {044130},\n"
+    "  doi = {10.1063/5.0014475},\n"
+    "  pmid = {32752662},\n"
+    "  url = {https://doi.org/10.1063/5.0014475}\n"
+    "}\n";
+
+  paper_count_[std::string("Plimpton1995")] = 0;
+  paper_url_[std::string("Plimpton1995")] = "https://doi.org/10.1006/jcph.1995.1039";
+  paper_bibtex_[std::string("Plimpton1995")] =
+    "\n"
+    "@article{Plimpton1995,\n"
+    "  title = {Fast parallel algorithms for short-range molecular dynamics},\n"
+    "  author = {Plimpton, Steve},\n"
+    "  journal = {J. Comp. Phys.},\n"
+    "  year = {1995},\n"
+    "  volume = {117},\n"
+    "  number = {1},\n"
+    "  pages = {1--19},\n"
+    "  doi = {10.1006/jcph.1995.1039},\n"
+    "  url = {https://doi.org/10.1006/jcph.1995.1039}\n"
+    "}\n";
+
+  paper_count_[std::string("Shen2015")] = 0;
+  paper_url_[std::string("Shen2015")] = "https://doi.org/10.1371/journal.pcbi.1004368";
+  paper_bibtex_[std::string("Shen2015")] =
+    "\n"
+    "@article{Shen2015,\n"
+    "  title = {Structural refinement of proteins by restrained molecular dynamics simulations with non-interacting molecular fragments},\n"
+    "  author = {Shen, Rong and Han, Wei and Fiorin, Giacomo and Islam, Shahidul M and Schulten, Klaus and Roux, Beno{\\^\\i}t},\n"
+    "  journal = {{PLoS} Comput. Biol.},\n"
+    "  volume = {11},\n"
+    "  year = {2015},\n"
+    "  number = {10},\n"
+    "  pages = {e1004368},\n"
+    "  doi = {10.1371/journal.pcbi.1004368},\n"
+    "  pmid = {26505197},\n"
+    "  url = {https://doi.org/10.1371/journal.pcbi.1004368}\n"
+    "}\n";
+
+  paper_count_[std::string("Wells2007")] = 0;
+  paper_url_[std::string("Wells2007")] = "https://doi.org/10.1063/1.2770738";
+  paper_bibtex_[std::string("Wells2007")] =
+    "\n"
+    "@article{Wells2007,\n"
+    "  author = {Wells, David B. and Abramkina, Volha and Aksimentiev, Aleksei},\n"
+    "  title = {Exploring transmembrane transport through $\\alpha$-hemolysin with grid-steered molecular dynamics},\n"
+    "  journal = {J. Chem. Phys.},\n"
+    "  year = {2007},\n"
+    "  volume = {127},\n"
+    "  number = {12},\n"
+    "  pages = {125101},\n"
+    "  doi = {10.1063/1.2770738},\n"
+    "  pmid = {17902937},\n"
+    "  url = {https://doi.org/10.1063/1.2770738}\n"
+    "}\n";
+
+  paper_count_[std::string("White2014")] = 0;
+  paper_url_[std::string("White2014")] = "https://doi.org/10.1021/ct500320c";
+  paper_bibtex_[std::string("White2014")] =
+    "\n"
+    "@article{White2014,\n"
+    "  author = {White, Andrew D.{} and Voth, Gregory A.{}},\n"
+    "  title = {Efficient and minimal method to bias molecular simulations with experimental data},\n"
+    "  journal = {J. Chem. Theory Comput.},\n"
+    "  year = {2014},\n"
+    "  volume = {10},\n"
+    "  number = {8},\n"
+    "  pages = {3023-–3030},\n"
+    "  doi = {10.1021/ct500320c},\n"
+    "  pmid = {26588273},\n"
+    "  url = {https://doi.org/10.1021/ct500320c}\n"
+    "}\n";
+
+  paper_url_[std::string("n/a")] = "";
+  paper_bibtex_[std::string("n/a")] = "";
+
+  feature_count_[std::string("GROMACS engine")] = 0;
+  feature_paper_map_[std::string("GROMACS engine")] = "Abraham2015";
+
+  feature_count_[std::string("reweightaMD colvar bias implementation (NAMD)")] = 0;
+  feature_paper_map_[std::string("reweightaMD colvar bias implementation (NAMD)")] = "Chen2021";
+
+  feature_count_[std::string("Multiple-walker ABF implementation")] = 0;
+  feature_paper_map_[std::string("Multiple-walker ABF implementation")] = "Comer2014c";
+
+  feature_count_[std::string("Colvars module")] = 0;
+  feature_paper_map_[std::string("Colvars module")] = "Fiorin2013";
+
+  feature_count_[std::string("Colvars-NAMD interface")] = 0;
+  feature_paper_map_[std::string("Colvars-NAMD interface")] = "Fiorin2013";
+
+  feature_count_[std::string("Colvars-LAMMPS interface")] = 0;
+  feature_paper_map_[std::string("Colvars-LAMMPS interface")] = "Fiorin2013";
+
+  feature_count_[std::string("Colvars-VMD interface (command line)")] = 0;
+  feature_paper_map_[std::string("Colvars-VMD interface (command line)")] = "Fiorin2013";
+
+  feature_count_[std::string("distance colvar component")] = 0;
+  feature_paper_map_[std::string("distance colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("distanceXY colvar component")] = 0;
+  feature_paper_map_[std::string("distanceXY colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("distanceZ colvar component")] = 0;
+  feature_paper_map_[std::string("distanceZ colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("distanceVec colvar component")] = 0;
+  feature_paper_map_[std::string("distanceVec colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("distanceDir colvar component")] = 0;
+  feature_paper_map_[std::string("distanceDir colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("angle colvar component")] = 0;
+  feature_paper_map_[std::string("angle colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("dihedral colvar component")] = 0;
+  feature_paper_map_[std::string("dihedral colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("coordNum colvar component")] = 0;
+  feature_paper_map_[std::string("coordNum colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("selfCoordNum colvar component (@jhenin should this be a different paper?)")] = 0;
+  feature_paper_map_[std::string("selfCoordNum colvar component (@jhenin should this be a different paper?)")] = "Fiorin2013";
+
+  feature_count_[std::string("hBond colvar component")] = 0;
+  feature_paper_map_[std::string("hBond colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("rmsd colvar component")] = 0;
+  feature_paper_map_[std::string("rmsd colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("eigenvector colvar component")] = 0;
+  feature_paper_map_[std::string("eigenvector colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("gyration colvar component")] = 0;
+  feature_paper_map_[std::string("gyration colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("inertia colvar component")] = 0;
+  feature_paper_map_[std::string("inertia colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("inertiaZ colvar component")] = 0;
+  feature_paper_map_[std::string("inertiaZ colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("orientation colvar component")] = 0;
+  feature_paper_map_[std::string("orientation colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("Moving frame of reference")] = 0;
+  feature_paper_map_[std::string("Moving frame of reference")] = "Fiorin2013";
+
+  feature_count_[std::string("orientationAngle colvar component")] = 0;
+  feature_paper_map_[std::string("orientationAngle colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("orientationProj colvar component")] = 0;
+  feature_paper_map_[std::string("orientationProj colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("spinAngle colvar component")] = 0;
+  feature_paper_map_[std::string("spinAngle colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("tilt colvar component")] = 0;
+  feature_paper_map_[std::string("tilt colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("alpha colvar component")] = 0;
+  feature_paper_map_[std::string("alpha colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("dihedralPC colvar component")] = 0;
+  feature_paper_map_[std::string("dihedralPC colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("cartesian colvar component")] = 0;
+  feature_paper_map_[std::string("cartesian colvar component")] = "Fiorin2013";
+
+  feature_count_[std::string("linear and polynomial combination of colvar components")] = 0;
+  feature_paper_map_[std::string("linear and polynomial combination of colvar components")] = "Fiorin2013";
+
+  feature_count_[std::string("Metadynamics colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("Metadynamics colvar bias implementation")] = "Fiorin2013";
+
+  feature_count_[std::string("Multiple-walker metadynamics colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("Multiple-walker metadynamics colvar bias implementation")] = "Fiorin2013";
+
+  feature_count_[std::string("Harmonic colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("Harmonic colvar bias implementation")] = "Fiorin2013";
+
+  feature_count_[std::string("Linear colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("Linear colvar bias implementation")] = "Fiorin2013";
+
+  feature_count_[std::string("histogram colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("histogram colvar bias implementation")] = "Fiorin2013";
+
+  feature_count_[std::string("mapTotal colvar component (volumetric-map and Multi-Map colvar components)")] = 0;
+  feature_paper_map_[std::string("mapTotal colvar component (volumetric-map and Multi-Map colvar components)")] = "Fiorin2020";
+
+  feature_count_[std::string("eABF implementation (umbrella-integration version)")] = 0;
+  feature_paper_map_[std::string("eABF implementation (umbrella-integration version)")] = "Fu2016";
+
+  feature_count_[std::string("polarTheta colvar component")] = 0;
+  feature_paper_map_[std::string("polarTheta colvar component")] = "Fu2017";
+
+  feature_count_[std::string("polarPhi colvar component")] = 0;
+  feature_paper_map_[std::string("polarPhi colvar component")] = "Fu2017";
+
+  feature_count_[std::string("eulerPhi colvar component")] = 0;
+  feature_paper_map_[std::string("eulerPhi colvar component")] = "Fu2017";
+
+  feature_count_[std::string("eulerTheta colvar component")] = 0;
+  feature_paper_map_[std::string("eulerTheta colvar component")] = "Fu2017";
+
+  feature_count_[std::string("eulerPsi colvar component")] = 0;
+  feature_paper_map_[std::string("eulerPsi colvar component")] = "Fu2017";
+
+  feature_count_[std::string("dipoleAngle colvar component")] = 0;
+  feature_paper_map_[std::string("dipoleAngle colvar component")] = "Garate2019";
+
+  feature_count_[std::string("dipoleMagnitude colvar component")] = 0;
+  feature_paper_map_[std::string("dipoleMagnitude colvar component")] = "Garate2019";
+
+  feature_count_[std::string("ABF implementation (internal forces)")] = 0;
+  feature_paper_map_[std::string("ABF implementation (internal forces)")] = "Henin2010";
+
+  feature_count_[std::string("Internal-forces free energy estimator")] = 0;
+  feature_paper_map_[std::string("Internal-forces free energy estimator")] = "Henin2010";
+
+  feature_count_[std::string("VMD engine")] = 0;
+  feature_paper_map_[std::string("VMD engine")] = "Humphrey1996";
+
+  feature_count_[std::string("eABF implementation")] = 0;
+  feature_paper_map_[std::string("eABF implementation")] = "Lesage2017";
+
+  feature_count_[std::string("CZAR estimator")] = 0;
+  feature_paper_map_[std::string("CZAR estimator")] = "Lesage2017";
+
+  feature_count_[std::string("Poisson integration of 2D/3D free energy surfaces")] = 0;
+  feature_paper_map_[std::string("Poisson integration of 2D/3D free energy surfaces")] = "Henin2021";
+
+  feature_count_[std::string("Ensemble-biased metadynamics (ebMetaD)")] = 0;
+  feature_paper_map_[std::string("Ensemble-biased metadynamics (ebMetaD)")] = "Marinelli2015";
+
+  feature_count_[std::string("NAMD engine")] = 0;
+  feature_paper_map_[std::string("NAMD engine")] = "Phillips2020";
+
+  feature_count_[std::string("Scalable center-of-mass computation (NAMD)")] = 0;
+  feature_paper_map_[std::string("Scalable center-of-mass computation (NAMD)")] = "Phillips2020";
+
+  feature_count_[std::string("LAMMPS engine")] = 0;
+  feature_paper_map_[std::string("LAMMPS engine")] = "Plimpton1995";
+
+  feature_count_[std::string("distancePairs colvar component")] = 0;
+  feature_paper_map_[std::string("distancePairs colvar component")] = "Shen2015";
+
+  feature_count_[std::string("histogramRestraint colvar bias implementation")] = 0;
+  feature_paper_map_[std::string("histogramRestraint colvar bias implementation")] = "Shen2015";
+
+  feature_count_[std::string("GridForces volumetric map implementation for NAMD")] = 0;
+  feature_paper_map_[std::string("GridForces volumetric map implementation for NAMD")] = "Wells2007";
+
+  feature_count_[std::string("ALB colvar bias")] = 0;
+  feature_paper_map_[std::string("ALB colvar bias")] = "White2014";
+
+  feature_count_[std::string("Colvars-GROMACS interface")] = 0;
+  feature_paper_map_[std::string("Colvars-GROMACS interface")] = "n/a";
+
+  feature_count_[std::string("Colvars Dashboard (Colvars-VMD graphical user interface)")] = 0;
+  feature_paper_map_[std::string("Colvars Dashboard (Colvars-VMD graphical user interface)")] = "n/a";
+
+  feature_count_[std::string("gspath colvar component")] = 0;
+  feature_paper_map_[std::string("gspath colvar component")] = "n/a";
+
+  feature_count_[std::string("gzpath colvar component")] = 0;
+  feature_paper_map_[std::string("gzpath colvar component")] = "n/a";
+
+  feature_count_[std::string("linearCombination colvar component")] = 0;
+  feature_paper_map_[std::string("linearCombination colvar component")] = "n/a";
+
+  feature_count_[std::string("gspathCV colvar component")] = 0;
+  feature_paper_map_[std::string("gspathCV colvar component")] = "n/a";
+
+  feature_count_[std::string("gzpathCV colvar component")] = 0;
+  feature_paper_map_[std::string("gzpathCV colvar component")] = "n/a";
+
+  feature_count_[std::string("aspathCV colvar component")] = 0;
+  feature_paper_map_[std::string("aspathCV colvar component")] = "n/a";
+
+  feature_count_[std::string("azpathCV colvar component")] = 0;
+  feature_paper_map_[std::string("azpathCV colvar component")] = "n/a";
+
+  feature_count_[std::string("coordNum pairlist")] = 0;
+  feature_paper_map_[std::string("coordNum pairlist")] = "n/a";
+
+  feature_count_[std::string("custom functions (Lepton)")] = 0;
+  feature_paper_map_[std::string("custom functions (Lepton)")] = "n/a";
+
+  feature_count_[std::string("scripted functions (Tcl)")] = 0;
+  feature_paper_map_[std::string("scripted functions (Tcl)")] = "n/a";

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -162,6 +162,14 @@ CVSCRIPT(cv_delete,
          return script->proxy()->request_deletion();
          )
 
+CVSCRIPT(cv_featurereport,
+         "Return a summary of Colvars features used so far and their citations\n"
+         "report : string - Feature report and citations",
+         0, 0,
+         "",
+         return script->set_result_str(script->module()->feature_report());
+         )
+
 CVSCRIPT(cv_frame,
          "Get or set current frame number (VMD only)\n"
          "frame : integer - Frame number",

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -91,7 +91,7 @@ colvarproxy_vmd::colvarproxy_vmd(Tcl_Interp *interp, VMDApp *v, int molid)
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
   colvars->cite_feature("VMD engine");
-  colvars->cite_feature("Colvars-VMD interface");
+  colvars->cite_feature("Colvars-VMD interface (command line)");
 
   colvars->cv_traj_freq = 0; // I/O will be handled explicitly
   colvars->restart_out_freq = 0;

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -90,6 +90,9 @@ colvarproxy_vmd::colvarproxy_vmd(Tcl_Interp *interp, VMDApp *v, int molid)
   cvm::log("Using VMD interface, version "+
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
 
+  colvars->cite_feature("VMD engine");
+  colvars->cite_feature("Colvars-VMD interface");
+
   colvars->cv_traj_freq = 0; // I/O will be handled explicitly
   colvars->restart_out_freq = 0;
   cvm::rotation::monitor_crossings = false; // Avoid unnecessary error messages

--- a/vmd/src/colvars_files.pl
+++ b/vmd/src/colvars_files.pl
@@ -63,6 +63,7 @@ $colvars_defines = " -DVMDCOLVARS";
                     'colvargrid.h',
                     'colvar.h',
                     'colvarmodule.h',
+                    'colvarmodule_refs.h',
                     'colvarmodule_utils.h',
                     'colvarparams.h',
                     'colvarparse.h',


### PR DESCRIPTION
This PR adds a database of citations to papers referencing different pieces of the Colvars library, and introduces a mechanism to print during a run a report of all papers that should be cited.  The change is motivated in part by recent improvements in the LAMMPS [CiteMe class](https://github.com/lammps/lammps/pull/2545).  There is also a growing number of features that are not described in the Fiorin, 2013 Mol Phys paper, especially when written by people who weren't co-authors of it. These ought to be cited, in addition to and together with it.

Relevant citations are listed into their own BibTeX file, which is parsed by a Python script to generate a C++ source file that fills the database. Features listed in that file should be references verbatim in the code when they are used.

Here are the proposed criteria:

1. **_The code should cite only papers describing software implementation_**.  *Methodology* papers of course would still be cited in the *user documentation*.  For example, LAMMPS prints at runtime citations to relevant code but the manual also lists many more references to the theory behind that code.  There may be downsides in some cases, e.g. people who don't read the manual at all may not know where a method comes from.  But it is hard to deny that the academic publication and peer review process already *massively favors methodology work over implementation work*.  To correct this, there needs to be a place where the former will not dilute the latter.

2. **_A very brief 1-line max description of the code feature being credited is added to the report alongside the citation_**, to give the user a clear idea of what a paper is being cited for.  Most classes already have a clear correspondence with physical/mathematical quantities.  It would be of major help if those descriptions also matched section titles in the manual.  When multiple features reference the same paper, these should be all listed individually but the paper included once.

3. When dealing with **_inheritance and composition_** of objects, things may get a bit complicated.  Some classes are only thin wrappers around existing ones, while others significantly supersede the base class.  I would advocate for making the 1-line descriptions as accurate as possible, and **_reference all pieces of code that make up a user-facing feature unless it is abundantly clear that some pieces are really minor_**.  This is not a big issue at this time because most such "minor pieces" are part of the library itself, and I and @jhenin get credited anyway via the Fiorin, 2013 citation.  But there are other cases, especially when dealing with external codes that would normally be overlooked. E.g. I would like to add a citation to the Wells2007 paper when using GridForces in NAMD, as long as part of that code is used.

4. **_Longer term, some code eventually may be replaced altogether and the citation replaced as well_**.  As a minor example, the linear bias was originally coded by Andrew White in https://github.com/Colvars/colvars/pull/18, but since then I've rewritten it entirely (of course, the significant feature that he introduced, ALB, remains associated with the White2014 paper).  So this is not a big deal now, but it may be later on.  There is not a lot of pressure to supplant existing code, but sometimes it will happen just like new methodology takes over old methodology.

Possible current issues:
- Quite many features are associated with the Fiorin 2013 paper, so it is likely that I have overlooked a few cases where a significant part of the code was described elsewhere: I apologize in advance if that's the case, and would definitely want to correct these before merging this PR.
- There are several features for which I really couldn't find a good citation yet.  I put those at the very ~~beginning~~ end of the file, so that we can keep checking later as new papers are published.
