### PR TITLE
Set GMX_VERSION_STRING_OF_FORK while patching when it is available

### DIFF
--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -101,6 +101,12 @@ else
   fi
 fi
 
+
+source $(dirname $0)/devel-tools/version_functions.sh
+
+COLVARS_VERSION=$(get_colvarmodule_version)
+
+
 get_gromacs_major_version_cmake() {
   cat $1 | grep 'set(GMX_VERSION_MAJOR' | \
     sed -e 's/set(GMX_VERSION_MAJOR //' -e 's/)//'
@@ -144,6 +150,10 @@ then
     fi
     ;;
   esac
+
+  if grep -q 'set(GMX_VERSION_STRING_OF_FORK ""' ${GMX_VERSION_INFO} ; then
+    sed -i "s/set(GMX_VERSION_STRING_OF_FORK \"\"/set(GMX_VERSION_STRING_OF_FORK \"Colvars-${COLVARS_VERSION}\"/" ${GMX_VERSION_INFO}
+  fi
 
 fi
 echo -n "Updating ..."


### PR DESCRIPTION
Adapt the Colvars patching script so that a descriptive label (e.g. `Colvars-2021-09-13` at the moment) is added to the Gromacs version string. The relevant CMake variable was introduced in the 2020 release series, so the script checks for it first before patching.

Having adapted the patching script affects the pre-patched releases at https://github.com/Colvars/gromacs, but also the use case of somebody patching a Gromacs source tree on their own. 

See: https://github.com/Colvars/gromacs/pull/2