### PR TITLE
Integrate functional version of backup_file() into base proxy class

### DIFF
--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -27,35 +27,6 @@
 
 #define HASH_FAIL  -1
 
-////////////////////////////////////////////////////////////////////////
-// local helper functions
-
-// safely move filename to filename.extension
-static int my_backup_file(const char *filename, const char *extension)
-{
-  struct stat sbuf;
-  if (stat(filename, &sbuf) == 0) {
-    if (!extension) extension = ".BAK";
-    char *backup = new char[strlen(filename)+strlen(extension)+1];
-    strcpy(backup, filename);
-    strcat(backup, extension);
-#if defined(_WIN32) && !defined(__CYGWIN__)
-    remove(backup);
-#endif
-    if (rename(filename,backup)) {
-      char *sys_err_msg = strerror(errno);
-      if (!sys_err_msg)  sys_err_msg = (char *) "(unknown error)";
-      fprintf(stderr,"Error renaming file %s to %s: %s\n",
-              filename, backup, sys_err_msg);
-      delete [] backup;
-      return COLVARS_ERROR;
-    }
-    delete [] backup;
-  }
-  return COLVARS_OK;
-}
-
-////////////////////////////////////////////////////////////////////////
 
 colvarproxy_lammps::colvarproxy_lammps(LAMMPS_NS::LAMMPS *lmp,
                                        const char *inp_name,
@@ -339,17 +310,6 @@ int colvarproxy_lammps::set_unit_system(std::string const &units_in, bool /*chec
     return COLVARS_ERROR;
   }
   return COLVARS_OK;
-}
-
-
-int colvarproxy_lammps::backup_file(char const *filename)
-{
-  if (std::string(filename).rfind(std::string(".colvars.state"))
-      != std::string::npos) {
-    return my_backup_file(filename, ".old");
-  } else {
-    return my_backup_file(filename, ".BAK");
-  }
 }
 
 

--- a/lammps/src/COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/COLVARS/colvarproxy_lammps.h
@@ -103,8 +103,6 @@ class colvarproxy_lammps : public colvarproxy {
 
   cvm::rvector position_distance(cvm::atom_pos const &pos1, cvm::atom_pos const &pos2) const;
 
-  int backup_file(char const *filename);
-
   cvm::real rand_gaussian(void) { return _random->gaussian(); };
 
   int init_atom(int atom_number);

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -713,7 +713,7 @@ public:
   }
 
   /// Remove the given file (on Windows only, rename to filename.old)
-  int remove_file(char const *filename);
+  virtual int remove_file(char const *filename);
 
   /// Remove the given file (on Windows only, rename to filename.old)
   inline int remove_file(std::string const &filename)
@@ -722,7 +722,7 @@ public:
   }
 
   /// Rename the given file
-  int rename_file(char const *filename, char const *newfilename);
+  virtual int rename_file(char const *filename, char const *newfilename);
 
   /// Rename the given file
   inline int rename_file(std::string const &filename,

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(colvarvalue_unit3vector colvarvalue_unit3vector.cpp)
 target_link_libraries(colvarvalue_unit3vector PRIVATE colvars)
 target_include_directories(colvarvalue_unit3vector PRIVATE ${COLVARS_SOURCE_DIR}/src)
+
+add_executable(file_io file_io.cpp)
+target_link_libraries(file_io PRIVATE colvars)
+target_include_directories(file_io PRIVATE ${COLVARS_SOURCE_DIR}/src)

--- a/tests/unittests/file_io.cpp
+++ b/tests/unittests/file_io.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+
+#include "colvarmodule.h"
+#include "colvarproxy.h"
+#include "colvarscript.h"
+
+
+extern "C" int main(int argc, char *argv[]) {
+
+  colvarproxy *proxy = new colvarproxy();
+  proxy->colvars = new colvarmodule(proxy);
+  proxy->script = new colvarscript(proxy);
+
+  proxy->backup_file("nonexistent.txt");
+
+  proxy->remove_file("nonexistent.txt");
+
+  // Produce an (almost) empty state file, twice (uses proxy->backup_file())
+  proxy->colvars->write_restart_file("test.colvars.state");
+  proxy->colvars->write_restart_file("test.colvars.state");
+
+  proxy->backup_file("test.colvars.state.old");
+
+  proxy->remove_file("test.colvars.state");
+  proxy->remove_file("test.colvars.state.old");
+  proxy->remove_file("test.colvars.state.old.old");
+
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #422 by delegating the renaming task to rename_file(); this is likely
to silence the overzealous CodeQL warning:
https://github.com/lammps/lammps/security/code-scanning/448
where rename_file() was ignored.