### PR TITLE
More complete documentation for index file format (NDX)

### DIFF
--- a/colvartools/write_index_group.tcl
+++ b/colvartools/write_index_group.tcl
@@ -1,0 +1,45 @@
+# Write a VMD selection into a GROMACS index file.
+
+# 1st argument is either a Tcl file channel or a file name: in the latter
+# case, content will be appended to that file.
+# 2nd argument is an atom selection proc, as returned by the atomselect
+# command.
+# 3rd argument is the name of the group.
+
+proc write_index_group { ndxfile sel name } {
+    # Check that the name does not contain spaces or tabs
+    if { ([string first " " "${name}"] >= 0) ||
+         ([string first "	" "${name}"] >= 0) } {
+        puts stderr "Error: group name may not contain spaces or tabs."
+        return
+    }
+
+    if { [catch [list tell "${ndxfile}"]] } {
+        # ${ndxfile} is the filename
+        set output [open "${ndxfile}" "a"]
+    } else {
+        # ${ndxfile} is the channel
+        set output ${ndxfile}
+    }
+
+    puts ${output} [format "\[ %s \]" ${name}]
+    set line_buf 0
+    set atom_count 0
+    foreach num [${sel} get serial] {
+        incr atom_count
+        puts -nonewline ${output} [format " %9d" ${num}]
+        set line_buf [expr ${line_buf} + 10]
+        if { ${line_buf} > 70 } {
+            set line_buf 0
+            puts -nonewline ${output} "\n"
+        }
+    }
+    if { ${line_buf} > 0 } {
+        puts -nonewline ${output} "\n"
+    }
+    puts -nonewline ${output} "\n"
+
+    if { "${output}" != "${ndxfile}" } {
+        close ${output}
+    }
+}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -897,15 +897,35 @@ All such files' names also begin with the prefix \outputName.
 
 \cvsubsubsec{Configuration and state files.}{sec:colvars_text_format}
 
-Configuration files are text files that are generally read as input by \MDENGINE{}\cvscriptonly{, and may be optionally inlined in a \MDENGINE{} script (see \ref{sec:cv_command_init})}.
-Starting from versions 2017-02-01, changes in newline encodings are handled transparently, i.e.{} it is possible to typeset a configuration file in Windows (CR-LF newlines) and then use it with Linux or macOS (LF-only newlines).
+\emph{Configuration files} are text files that are generally read as input by \MDENGINE{}\cvscriptonly{, and may be optionally inlined in a \MDENGINE{} script (see \ref{sec:cv_command_init})}.
+Starting from version 2017-02-01, changes in newline encodings are handled transparently, i.e.\ it is possible to typeset a configuration file in Windows (CR-LF newlines) and then use it with Linux or macOS (LF-only newlines).
 
-State files, although not written manually, follow otherwise the same format as configuration files.
+\emph{State files}, although not written manually, follow otherwise the same text format as configuration files.
+
 
 \cvsubsubsec{Index (NDX) files}{sec:colvars_ndx_format}
 
-For atom selections that cannot be specified only with Colvars keywords, external index files may be used following the \href{http://manual.gromacs.org/documentation/current/reference-manual/file-formats.html\#ndx}{NDX format} used in GROMACS.
-\cvlammpsonly{In LAMMPS, such files may also be produced via the \texttt{group2ndx} command.}
+For atom selections that cannot be specified only by using internal Colvars keywords, external \emph{index files} may also be used following the \href{http://manual.gromacs.org/documentation/current/reference-manual/file-formats.html\#ndx}{NDX format} used in GROMACS:
+\begin{datafileexample}
+\-[~group\_1\_name~]\\
+\-~~i1~~i2~~i3~~i4~~...\\
+\-~~...~~~~~~~~~~~~~...~~iN\\
+\-[~group\_2\_name~]\\
+\-~~...
+\end{datafileexample}
+\noindent{}where \emph{i1} through \emph{iN} are 1-based indices.  Each group name may not contain spaces or tabs: otherwise, a parsing error will be raised.
+
+Multiple index files may be provided to Colvars, each using the keyword \refkey{indexFile}{Colvars-global|indexFile}.  Two index files may contain groups with the same names, however these must also represent identical atom selections, i.e.\ the same sequence of indices including order.
+
+\cvgromasonly{\emph{Note that although GROMACS reads index files natively, \refkey{indexFile}{Colvars-global|indexFile} uses a Colvars internal function.  Thus, index files loaded into GROMACS and Colvars do not need to coincide, but it is recommended that they do for simplicity.}}
+
+Other than with GROMACS, an index group may also be generated from the VMD command-line interface, using the helper function \texttt{write\_index\_group} provided in the `colvartools`:
+\begin{mdexampleinput}
+\-source~colvartools/write\_index\_group.tcl\\
+\-set~sel~[atomselect~top~"resname~XXX~and~not~hydrogen"]\\
+\-write\_index\_group~indexfile.ndx~\${sel}~"Ligand"
+\end{mdexampleinput}
+\cvlammpsonly{In LAMMPS, NDX files may also be generated from internal groups via the \texttt{group2ndx} command.}
 
 
 \cvsubsubsec{XYZ coordinate files}{sec:colvars_xyz_format}
@@ -921,7 +941,7 @@ $E_{N}$ & $x_{N}$ & $y_{N}$ & $z_{N}$ \\
 \end{tabular}
 
 \noindent{}where $N$ is the number of atomic coordinates in the file and $E_i$ is the chemical element of the $i$-th atom.
-Because $E_i$ is not used in Colvars, any string is acceptable.
+Because $E_i$ is not used in Colvars, any string that does not contain tabs or spaces is acceptable.
 
 An XYZ file may contain either one of the following scenarios:
 \begin{enumerate}

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -53,6 +53,17 @@
   \end{mdframed}
 }
 
+\definecolor{datafileexample-border-color}{rgb}{0.05,0.2,0.0}
+\definecolor{datafileexample-background-color}{rgb}{0.95,1.0,0.8}
+\newenvironment{datafileexample}{%
+  \begin{mdframed}[%
+      linecolor=datafileexample-border-color,linewidth=2pt,%
+      backgroundcolor=datafileexample-background-color]
+  \ifdefined\HCode\HCode{<pre>}\else\begin{ttfamily}\fi}{%
+  \ifdefined\HCode\HCode{</pre>}\else\end{ttfamily}\fi
+  \end{mdframed}
+}
+
 \newcommand{\cvscriptexampleinputcv}[2]{%
 \def\cvscriptargsep{~}
 \begin{mdexampleinput}{\ifdefined\cvscriptpyapi\textbf{With the ``\texttt{\cvscriptcmd{}}'' command:}\\\fi}%


### PR DESCRIPTION
The GROMACS forum thread at:
https://gromacs.bioexcel.eu/t/error-compiling-gromacs-2020-5-patched-with-colvar-module/3048
raised an interesting issue about the NDX file format (disregard the GCC 11 compilation issues, which affect GROMACS files, not Colvars: hopefully the GROMACS devs will fix those in their repository).

When a group name contains spaces it cannot be parsed correctly by Colvars. This is reasonable behavior, but wasn't explicitly documented yet.

What's most striking is that the GROMACS parser formally allows spaces, but then uses only the first word, e.g. if one has an index file that contains the two groups labeled `[ Protein C-alpha ]` and `[ Protein backbone ]`, they would end up with two distinct groups both named `Protein`.  So while the GROMACS doc doesn't say it, it doesn't support spaces either and doesn't warn the user about it.

To simplify things I pulled out the Tcl function from #374 and put it in a script in the `colvartools` folder, with an example in the doc.  Given that this is just enough Tcl to not upset most people, I would be inclined to merge this PR and abandon #374.

Most importantly, the function warns the user about setting a group name that contains spaces or tabs.