### PR TITLE
Embedded tcl

### DIFF
--- a/C_fortran/colvarproxy_C.cpp
+++ b/C_fortran/colvarproxy_C.cpp
@@ -12,7 +12,6 @@ colvarproxy_C::colvarproxy_C()
     std::cerr << "This is the colvarproxy_C constructor at address " << this << std::endl;
     colvars = new colvarmodule(this);
     colvars->log("This is the Module speaking.");
-    script = new colvarscript(this);
 }
 
 colvarproxy_C::~colvarproxy_C()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -13,6 +13,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(WARNINGS_ARE_ERRORS "Treats warnings as errors" OFF)
 
+# message(STATUS "Enabling sanitize-address")
+# add_compile_options(-fsanitize=address)
+# add_link_options(-fsanitize=address)
+
 if(NOT DEFINED LEPTON_DIR)
   set(LEPTON_DIR ${COLVARS_SOURCE_DIR}/lepton)
 endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -17,6 +17,9 @@ option(ADDRESS_SANITIZER "Build with Address Sanitizer for memory debugging" OFF
 if(ADDRESS_SANITIZER)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
+  if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+    message(WARNING "-DADDRESS_SANITIZER flag not tested yet for this compiler.")
+  endif()
 endif()
 
 if(NOT DEFINED LEPTON_DIR)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -13,9 +13,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(WARNINGS_ARE_ERRORS "Treats warnings as errors" OFF)
 
-# message(STATUS "Enabling sanitize-address")
-# add_compile_options(-fsanitize=address)
-# add_link_options(-fsanitize=address)
+option(ADDRESS_SANITIZER "Build with Address Sanitizer for memory debugging" OFF)
+if(ADDRESS_SANITIZER)
+  add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
+endif()
 
 if(NOT DEFINED LEPTON_DIR)
   set(LEPTON_DIR ${COLVARS_SOURCE_DIR}/lepton)

--- a/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
@@ -43,7 +43,6 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
   restart_frequency_s = 0;
 
   // User-scripted forces are not available in GROMACS
-  force_script_defined = false;
   have_scripts = false;
 
   angstrom_value = 0.1;

--- a/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
@@ -42,7 +42,6 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
   restart_frequency_s = 0;
 
   // User-scripted forces are not available in GROMACS
-  force_script_defined = false;
   have_scripts = false;
 
   angstrom_value = 0.1;

--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -46,10 +46,6 @@ colvarproxy_lammps::colvarproxy_lammps(LAMMPS_NS::LAMMPS *lmp,
   t_target=temp;
   do_exit=false;
 
-  // User-scripted forces are not available in LAMMPS
-  force_script_defined = false;
-  have_scripts = false;
-
   // set input restart name and strip the extension, if present
   input_prefix_str = std::string(inp_name ? inp_name : "");
   if (input_prefix_str.rfind(".colvars.state") != std::string::npos)

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -127,17 +127,8 @@ colvarproxy_namd::colvarproxy_namd()
   Node::Object()->colvars = colvars;
 
 #ifdef NAMD_TCL
-
   have_scripts = true;
-  // See is user-scripted forces are defined
-  if (Tcl_FindCommand(reinterpret_cast<Tcl_Interp *>(tcl_interp_),
-                      "calc_colvar_forces", NULL, 0) == NULL) {
-    force_script_defined = false;
-  } else {
-    force_script_defined = true;
-  }
 #else
-  force_script_defined = false;
   have_scripts = false;
 #endif
 

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -546,7 +546,7 @@ void colvarproxy_namd::init_tcl_pointers()
 {
 #ifdef NAMD_TCL
   // Store pointer to NAMD's Tcl interpreter
-  tcl_interp_ = reinterpret_cast<void *>(Node::Object()->getScript()->interp);
+  set_tcl_interp(Node::Object()->getScript()->interp);
 #else
   colvarproxy::init_tcl_pointers(); // Create dedicated interpreter
 #endif

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -59,9 +59,9 @@ protected:
   cvm::real amd_weight_factor;
   void update_accelMD_info();
 
-  void init_tcl_pointers();
-
 public:
+
+  virtual void init_tcl_pointers();
 
   friend class cvm::atom;
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -61,7 +61,7 @@ protected:
 
 public:
 
-  virtual void init_tcl_pointers();
+  void init_tcl_pointers() override;
 
   friend class cvm::atom;
 
@@ -122,7 +122,7 @@ public:
     return simparams->dt;
   }
 
-  virtual cvm::real get_accelMD_factor() const {
+  cvm::real get_accelMD_factor() const override {
     return amd_weight_factor;
   }
 
@@ -184,12 +184,12 @@ public:
 
 #endif // #if CMK_SMP && USE_CKLOOP
 
-  virtual int replica_enabled();
-  virtual int replica_index();
-  virtual int num_replicas();
-  virtual void replica_comm_barrier();
-  virtual int replica_comm_recv(char* msg_data, int buf_len, int src_rep);
-  virtual int replica_comm_send(char* msg_data, int msg_len, int dest_rep);
+  int replica_enabled() override;
+  int replica_index() override;
+  int num_replicas() override;
+  void replica_comm_barrier() override;
+  int replica_comm_recv(char* msg_data, int buf_len, int src_rep) override;
+  int replica_comm_send(char* msg_data, int msg_len, int dest_rep) override;
 
   int init_atom(int atom_number);
   int check_atom_id(int atom_number);
@@ -228,24 +228,24 @@ public:
 
 #if NAMD_VERSION_NUMBER >= 34471681
 
-  virtual int init_volmap_by_id(int volmap_id);
+  int init_volmap_by_id(int volmap_id) override;
 
-  virtual int init_volmap_by_name(const char *volmap_name);
+  int init_volmap_by_name(const char *volmap_name) override;
 
-  virtual int check_volmap_by_id(int volmap_id);
+  int check_volmap_by_id(int volmap_id) override;
 
-  virtual int check_volmap_by_name(char const *volmap_name);
+  int check_volmap_by_name(char const *volmap_name) override;
 
-  virtual int get_volmap_id_from_name(char const *volmap_name);
+  int get_volmap_id_from_name(char const *volmap_name) override;
 
-  virtual void clear_volmap(int index);
+  void clear_volmap(int index) override;
 
-  virtual int compute_volmap(int flags,
+  int compute_volmap(int flags,
                              int volmap_id,
                              cvm::atom_iter atom_begin,
                              cvm::atom_iter atom_end,
                              cvm::real *value,
-                             cvm::real *atom_field);
+                             cvm::real *atom_field) override;
 
   /// Abstraction of the two types of NAMD volumetric maps
   template<class T>

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -194,7 +194,7 @@ public:
 
   /// Enable a feature and recursively solve its dependencies.
   /// For accurate reference counting, do not add spurious calls to enable()
-  /// \param dry_run Recursively test if a feature is available, without enabling it
+  /// \param dry_run Recursively test whether a feature is available, without enabling it
   /// \param toplevel False if this is called as part of a chain of dependency resolution.
   /// This is used to diagnose failed dependencies by displaying the full stack:
   /// only the toplevel dependency will throw a fatal error.
@@ -289,7 +289,7 @@ public:
     f_cv_extended_Lagrangian,
     /// \brief An extended variable that sets an external variable in the
     /// back-end (eg. an alchemical coupling parameter for lambda-dynamics)
-    /// Can have only one component
+    /// Can have a single component
     f_cv_external,
     /// \brief The extended system coordinate undergoes Langevin dynamics
     f_cv_Langevin,

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -302,8 +302,8 @@ int colvarmodule::parse_config(std::string &conf)
   // Update any necessary proxy data
   proxy->setup();
 
-  if (run_script() != COLVARS_OK) {
-    return get_error();
+  if (source_Tcl_script.size() > 0) {
+    run_script(source_Tcl_script);
   }
 
   return get_error();
@@ -403,14 +403,12 @@ int colvarmodule::parse_global_params(std::string const &conf)
 }
 
 
-int colvarmodule::run_script() {
+int colvarmodule::run_script(std::string const &filename) {
 
   int result = COLVARS_OK;
 
 #if defined(COLVARS_TCL)
-    if (source_Tcl_script.size() > 0) {
-      result = proxy->tcl_run_file(source_Tcl_script);
-    }
+  result = proxy->tcl_run_file(filename);
 #endif
 
   return result;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -302,6 +302,10 @@ int colvarmodule::parse_config(std::string &conf)
   // Update any necessary proxy data
   proxy->setup();
 
+  if (run_script() != COLVARS_OK) {
+    return get_error();
+  }
+
   return get_error();
 }
 
@@ -392,24 +396,24 @@ int colvarmodule::parse_global_params(std::string const &conf)
                     scripting_after_biases, scripting_after_biases);
 
 #if defined(COLVARS_TCL)
-  std::string source_Tcl_script;
-  if (parse->get_keyval(conf, "sourceTclFile", source_Tcl_script)) {
-    proxy->tcl_run_file(source_Tcl_script);
-  }
+  parse->get_keyval(conf, "sourceTclFile", source_Tcl_script);
 #endif
 
-  if (use_scripted_forces && !proxy->force_script_defined) {
-    if (proxy->simulation_running()) {
-      // TODO test here
-      // return cvm::error("User script for scripted colvar forces not found.",
-      //                   INPUT_ERROR);
-    } else {
-      // Not necessary if we are not applying biases in a real simulation (eg. VMD)
-      cvm::log("Warning: User script for scripted colvar forces not found.");
-    }
-  }
-
   return cvm::get_error();
+}
+
+
+int colvarmodule::run_script() {
+
+  int result = COLVARS_OK;
+
+#if defined(COLVARS_TCL)
+    if (source_Tcl_script.size() > 0) {
+      result = proxy->tcl_run_file(source_Tcl_script);
+    }
+#endif
+
+  return result;
 }
 
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -303,7 +303,7 @@ int colvarmodule::parse_config(std::string &conf)
   proxy->setup();
 
   if (source_Tcl_script.size() > 0) {
-    run_script(source_Tcl_script);
+    run_tcl_script(source_Tcl_script);
   }
 
   return get_error();
@@ -403,7 +403,7 @@ int colvarmodule::parse_global_params(std::string const &conf)
 }
 
 
-int colvarmodule::run_script(std::string const &filename) {
+int colvarmodule::run_tcl_script(std::string const &filename) {
 
   int result = COLVARS_OK;
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -10,6 +10,10 @@
 #ifndef COLVARMODULE_H
 #define COLVARMODULE_H
 
+#if defined(NAMD_TCL) || defined(VMDTCL)
+#define COLVARS_TCL
+#endif
+
 #include <cmath>
 
 #include "colvars_version.h"

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -378,8 +378,8 @@ public:
   /// Parse and initialize collective variables
   int parse_colvars(std::string const &conf);
 
-  /// Run provided script
-  int run_script(std::string const &filename);
+  /// Run provided Tcl script
+  int run_tcl_script(std::string const &filename);
 
   /// Parse and initialize collective variable biases
   int parse_biases(std::string const &conf);

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -10,10 +10,6 @@
 #ifndef COLVARMODULE_H
 #define COLVARMODULE_H
 
-#if defined(NAMD_TCL) || defined(VMDTCL)
-#define COLVARS_TCL
-#endif
-
 #include <cmath>
 
 #include "colvars_version.h"
@@ -413,10 +409,8 @@ private:
   /// on error, delete new bias
   bool check_new_bias(std::string &conf, char const *key);
 
-#ifdef COLVARS_TCL
   /// Initialization Tcl script, user-provided
   std::string source_Tcl_script;
-#endif
 
 public:
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -378,6 +378,9 @@ public:
   /// Parse and initialize collective variables
   int parse_colvars(std::string const &conf);
 
+  /// Run provided startup script
+  int run_script();
+
   /// Parse and initialize collective variable biases
   int parse_biases(std::string const &conf);
 
@@ -405,6 +408,11 @@ private:
   /// Test error condition and keyword parsing
   /// on error, delete new bias
   bool check_new_bias(std::string &conf, char const *key);
+
+#ifdef COLVARS_TCL
+  /// Initialization Tcl script, user-provided
+  std::string source_Tcl_script;
+#endif
 
 public:
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -378,8 +378,8 @@ public:
   /// Parse and initialize collective variables
   int parse_colvars(std::string const &conf);
 
-  /// Run provided startup script
-  int run_script();
+  /// Run provided script
+  int run_script(std::string const &filename);
 
   /// Parse and initialize collective variable biases
   int parse_biases(std::string const &conf);

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -615,7 +615,6 @@ int colvarproxy_smp::smp_unlock()
 colvarproxy_script::colvarproxy_script()
 {
   script = NULL;
-  force_script_defined = false;
   have_scripts = false;
 }
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -680,9 +680,6 @@ public:
   /// (does not need to be allocated in a new interface)
   colvarscript *script;
 
-  /// is a user force script defined?
-  bool force_script_defined;
-
   /// Do we have a scripting interface?
   bool have_scripts;
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -807,7 +807,6 @@ protected:
 /// \brief Interface between the collective variables module and
 /// the simulation or analysis program (NAMD, VMD, LAMMPS...).
 /// This is the base class: each interfaced program is supported by a derived class.
-/// Only pure virtual functions ("= 0") must be reimplemented to ensure baseline functionality.
 class colvarproxy
   : public colvarproxy_system,
     public colvarproxy_atoms,

--- a/src/colvarproxy_tcl.cpp
+++ b/src/colvarproxy_tcl.cpp
@@ -61,7 +61,7 @@ char const *colvarproxy_tcl::tcl_get_str(void *obj)
 }
 
 
-int colvarproxy_tcl::tcl_run_script(std::string script)
+int colvarproxy_tcl::tcl_run_script(std::string const &script)
 {
 #if defined(COLVARS_TCL)
   Tcl_Interp *const interp = get_tcl_interp();
@@ -78,7 +78,7 @@ int colvarproxy_tcl::tcl_run_script(std::string script)
 }
 
 
-int colvarproxy_tcl::tcl_run_file(std::string fileName)
+int colvarproxy_tcl::tcl_run_file(std::string const &fileName)
 {
 #if defined(COLVARS_TCL)
   Tcl_Interp *const interp = get_tcl_interp();

--- a/src/colvarproxy_tcl.h
+++ b/src/colvarproxy_tcl.h
@@ -25,10 +25,20 @@ public:
   virtual ~colvarproxy_tcl();
 
   /// Is Tcl available? (trigger initialization if needed)
-  int tcl_available();
+  inline bool tcl_available() {
+#if defined(COLVARS_TCL)
+    return true;
+#else
+    return false;
+#endif
+  }
 
   /// Get a string representation of the Tcl object pointed to by obj
   char const *tcl_get_str(void *obj);
+
+  int tcl_run_script(std::string script);
+
+  int tcl_run_file(std::string fileName);
 
   /// Tcl implementation of run_force_callback()
   int tcl_run_force_callback();
@@ -57,13 +67,13 @@ public:
     tcl_interp_ = interp;
   }
 
+  /// Set Tcl pointers
+  virtual void init_tcl_pointers();
+
 protected:
 
   /// Pointer to Tcl interpreter object
   void *tcl_interp_;
-
-  /// Set Tcl pointers
-  virtual void init_tcl_pointers();
 };
 
 

--- a/src/colvarproxy_tcl.h
+++ b/src/colvarproxy_tcl.h
@@ -10,6 +10,14 @@
 #ifndef COLVARPROXY_TCL_H
 #define COLVARPROXY_TCL_H
 
+#if defined(NAMD_TCL) || defined(VMDTCL)
+#define COLVARS_TCL
+#endif
+
+#ifdef COLVARS_TCL
+#include <tcl.h>
+#endif
+
 #include <vector>
 
 
@@ -55,26 +63,29 @@ public:
               std::vector<const colvarvalue *> const &cvcs,
               std::vector<cvm::matrix2d<cvm::real> > &gradient);
 
+#ifdef COLVARS_TCL
   /// Get a pointer to the Tcl interpreter
-  inline void *get_tcl_interp()
+  inline Tcl_Interp *get_tcl_interp()
   {
     return tcl_interp_;
   }
 
   /// Set the pointer to the Tcl interpreter
-  inline void set_tcl_interp(void *interp)
+  inline void set_tcl_interp(Tcl_Interp *interp)
   {
     tcl_interp_ = interp;
   }
+#endif
 
   /// Set Tcl pointers
   virtual void init_tcl_pointers();
 
 protected:
 
+#ifdef COLVARS_TCL
   /// Pointer to Tcl interpreter object
-  void *tcl_interp_;
+  Tcl_Interp *tcl_interp_;
+#endif
 };
-
 
 #endif

--- a/src/colvarproxy_tcl.h
+++ b/src/colvarproxy_tcl.h
@@ -16,6 +16,9 @@
 
 #ifdef COLVARS_TCL
 #include <tcl.h>
+#else
+// Allow for placeholders Tcl_Interp* variables
+typedef void Tcl_Interp;
 #endif
 
 #include <vector>
@@ -44,9 +47,9 @@ public:
   /// Get a string representation of the Tcl object pointed to by obj
   char const *tcl_get_str(void *obj);
 
-  int tcl_run_script(std::string script);
+  int tcl_run_script(std::string const &script);
 
-  int tcl_run_file(std::string fileName);
+  int tcl_run_file(std::string const &fileName);
 
   /// Tcl implementation of run_force_callback()
   int tcl_run_force_callback();
@@ -63,7 +66,6 @@ public:
               std::vector<const colvarvalue *> const &cvcs,
               std::vector<cvm::matrix2d<cvm::real> > &gradient);
 
-#ifdef COLVARS_TCL
   /// Get a pointer to the Tcl interpreter
   inline Tcl_Interp *get_tcl_interp()
   {
@@ -75,17 +77,13 @@ public:
   {
     tcl_interp_ = interp;
   }
-#endif
 
   /// Set Tcl pointers
   virtual void init_tcl_pointers();
 
 protected:
-
-#ifdef COLVARS_TCL
   /// Pointer to Tcl interpreter object
   Tcl_Interp *tcl_interp_;
-#endif
 };
 
 #endif

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -11,13 +11,6 @@
 #include <cstring>
 #include <sstream>
 
-#if defined(NAMD_TCL) || defined(VMDTCL)
-#define COLVARS_TCL
-#endif
-#ifdef COLVARS_TCL
-#include <tcl.h>
-#endif
-
 #include "colvarproxy.h"
 #include "colvardeps.h"
 #include "colvarscript.h"

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -47,9 +47,9 @@ colvarscript::colvarscript(colvarproxy *p, colvarmodule *m)
   init_commands();
 #ifdef COLVARS_TCL
   // must be called after constructing derived proxy class to allow for overloading
-  cvm::proxy->init_tcl_pointers();
+  proxy()->init_tcl_pointers();
   // TODO put this in backend functions so we don't have to delete
-  Tcl_Interp *interp = reinterpret_cast<Tcl_Interp *>(proxy_->get_tcl_interp());
+  Tcl_Interp *const interp = proxy()->get_tcl_interp();
   if (interp == NULL) {
     cvm::error("Error: trying to construct colvarscript without a Tcl interpreter.\n");
     return;
@@ -649,11 +649,12 @@ int tcl_colvars_vmd_init(Tcl_Interp *interp, int molid);
 #endif
 
 #if !defined(VMDTCL) && !defined(NAMD_TCL)
+// Initialize Colvars when loaded as a shared library into Tcl interpreter
 extern "C" {
   int Colvars_Init(Tcl_Interp *interp) {
     colvarproxy *proxy = new colvarproxy();
     colvarmodule *colvars = new colvarmodule(proxy);
-    proxy->set_tcl_interp(reinterpret_cast<void *>(interp));
+    proxy->set_tcl_interp(interp);
     proxy->colvars = colvars;
     Tcl_CreateObjCommand(interp, "cv", tcl_run_colvarscript_command,
                          (ClientData *) NULL, (Tcl_CmdDeleteProc *) NULL);
@@ -719,8 +720,7 @@ extern "C" int tcl_run_colvarscript_command(ClientData /* clientData */,
   }
 
   colvarproxy *proxy = colvars->proxy;
-  Tcl_Interp *interp = my_interp ? my_interp :
-    reinterpret_cast<Tcl_Interp *>(proxy->get_tcl_interp());
+  Tcl_Interp *interp = my_interp ? my_interp : proxy->get_tcl_interp();
   colvarscript *script = colvarscript_obj();
   if (!script) {
     char const *errstr = "Called tcl_run_colvarscript_command "

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -38,7 +38,7 @@ public:
 
   friend class colvarproxy;
 
-  colvarscript(colvarproxy *p);
+  colvarscript(colvarproxy *p, colvarmodule *m);
 
   ~colvarscript();
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,11 +1,14 @@
 add_executable(colvarvalue_unit3vector colvarvalue_unit3vector.cpp)
 target_link_libraries(colvarvalue_unit3vector PRIVATE colvars)
 target_include_directories(colvarvalue_unit3vector PRIVATE ${COLVARS_SOURCE_DIR}/src)
-
 add_test(NAME colvarvalue_unit3vector COMMAND colvarvalue_unit3vector)
 
 add_executable(file_io file_io.cpp)
 target_link_libraries(file_io PRIVATE colvars)
 target_include_directories(file_io PRIVATE ${COLVARS_SOURCE_DIR}/src)
-
 add_test(NAME file_io COMMAND file_io)
+
+add_executable(embedded_tcl embedded_tcl.cpp)
+target_link_libraries(embedded_tcl PRIVATE colvars)
+target_include_directories(embedded_tcl PRIVATE ${COLVARS_SOURCE_DIR}/src)
+add_test(NAME embedded_tcl COMMAND embedded_tcl)

--- a/tests/unittests/embedded_tcl.cpp
+++ b/tests/unittests/embedded_tcl.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "colvarmodule.h"
+#include "colvarproxy.h"
+#include "colvarscript.h"
+
+
+extern "C" int main(int argc, char *argv[]) {
+
+  colvarproxy *proxy = new colvarproxy();
+  proxy->colvars = new colvarmodule(proxy);
+
+  proxy->tcl_run_script("puts \"\n(Tcl) Tcl script running successfully using embedded interpreter.\"");
+  proxy->tcl_run_script("puts \"(Tcl) Currently defined variables:\n(Tcl) [info vars]\"");
+  proxy->tcl_run_script("puts \"(Tcl) Currently defined procedures:\n(Tcl) [info procs]\"");
+
+  return 0;
+}

--- a/tests/unittests/embedded_tcl.cpp
+++ b/tests/unittests/embedded_tcl.cpp
@@ -10,7 +10,15 @@ extern "C" int main(int argc, char *argv[]) {
   colvarproxy *proxy = new colvarproxy();
   proxy->colvars = new colvarmodule(proxy);
 
-  proxy->tcl_run_script("puts \"\n(Tcl) Tcl script running successfully using embedded interpreter.\"");
+  int res = proxy->tcl_run_script("puts \"\n(Tcl) Tcl script running successfully using embedded interpreter.\"");
+
+  if (res != COLVARS_OK) {
+    std::cout << "Error running Tcl script.\n";
+    if (res == COLVARS_NOT_IMPLEMENTED)
+      std::cout << "Tcl scripts are not enabled in this build of the Colvars library.\n";
+    return 1;
+  }
+
   proxy->tcl_run_script("puts \"(Tcl) Currently defined variables:\n(Tcl) [info vars]\"");
   proxy->tcl_run_script("puts \"(Tcl) Currently defined procedures:\n(Tcl) [info procs]\"");
 

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -17,10 +17,6 @@
 #include "Inform.h"
 #include "utilities.h"
 
-#if !defined(COLVARS_TCL)
-#define COLVARS_TCL
-#endif
-
 #include "colvarmodule.h"
 #include "colvarscript.h"
 #include "colvaratoms.h"
@@ -38,6 +34,7 @@ namespace {
 
 // Copy of declaration from colvarscript.cpp (this alone doesn't warrant a
 // new header file)
+// COLVARS_TCL is defined when relevant in colvarproxy_tcl.h, included via colvarproxy.h
 #ifdef COLVARS_TCL
 extern "C" int tcl_run_colvarscript_command(ClientData clientData,
                                             Tcl_Interp *interp_in,

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -92,15 +92,7 @@ colvarproxy_vmd::colvarproxy_vmd(Tcl_Interp *interp, VMDApp *v, int molid)
 #if defined(VMDTCL)
   have_scripts = true;
   // Need to set this before constructing colvarmodule, which creates colvarscript object
-  tcl_interp_ = reinterpret_cast<void *>(interp);
-
-  // User-scripted forces are not really useful in VMD, but we accept them
-  // for compatibility with NAMD scripts
-  if (Tcl_FindCommand(interp, "calc_colvar_forces", NULL, 0) == NULL) {
-    force_script_defined = false;
-  } else {
-    force_script_defined = true;
-  }
+  set_tcl_interp(interp);
 #else
   have_scripts = false;
 #endif
@@ -406,12 +398,7 @@ void colvarproxy_vmd::init_tcl_pointers()
 
 int colvarproxy_vmd::run_force_callback()
 {
-  if (force_script_defined) {
-    return colvarproxy::tcl_run_force_callback();
-  } else {
-    // Ignore if script is undefined in VMD
-    return COLVARS_OK;
-  }
+  return colvarproxy::tcl_run_force_callback();
 }
 
 int colvarproxy_vmd::run_colvar_callback(


### PR DESCRIPTION
This is a fairly simple way to allow the use of Tcl scripts for all back-ends, or without a back-end at all. One major benefit is allowing for unit tests using Tcl scripts. Also helps #388

Needs some coordination with other efforts, in particular #462.

Fixes segfault when building library with Tcl enabled and running file_io unit test.