### PR TITLE
Prevent double-free in linearCombination

### DIFF
--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -446,6 +446,9 @@ colvar::linearCombination::~linearCombination() {
     for (auto it = cv.begin(); it != cv.end(); ++it) {
         delete (*it);
     }
+    // the atom groups should be freed by the sub-CVCs,
+    // so we clear the container to avoid double-free.
+    atom_groups.clear();
 }
 
 void colvar::linearCombination::calc_value() {


### PR DESCRIPTION
The `linearCombination` component registers the atom groups of its sub-CVCs as its own atom groups. The atom groups are deleted by the sub-CVCs, leaving dangling pointers, which are then freed again since `linearCombination` is also a subclass from `colvar::cvc`. This commit solves the problem by clearing the container of the pointers to atom groups.