### PR TITLE
Return type of bias from scripting interface

### DIFF
--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -554,6 +554,15 @@
 \texttt{-------}
 \\
 \texttt{state : string - String representation of the bias features}
+\item \texttt{cv bias name type}
+\\
+\texttt{Print the type of this bias object}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{type : string - Type of this bias object (e.g. metadynamics)}
 \item \texttt{cv bias name update}
 \\
 \texttt{Recompute this bias and return its up-to-date energy}

--- a/src/colvarscript_commands_bias.h
+++ b/src/colvarscript_commands_bias.h
@@ -172,6 +172,15 @@ CVSCRIPT(bias_state,
          return COLVARS_OK;
          )
 
+CVSCRIPT(bias_type,
+         "Print the type of this bias object\n"
+         "type : string - Type of this bias object (e.g. metadynamics)",
+         0, 0,
+         "",
+         script->set_result_str(this_bias->bias_type);
+         return COLVARS_OK;
+         )
+
 CVSCRIPT(bias_update,
          "Recompute this bias and return its up-to-date energy\n"
          "E : float - Energy value",


### PR DESCRIPTION
Allow detecting which type of bias a particular object represents from the scripting interface.

With additional changes in the Dashboard, this would allow the latter to handle configuration strings for biases, and facilitate their preparation. (Feature discussed previously a few times and also raised by a reviewer of the Dashboard paper).

This change is minimal, but a PR is used to track its purpose and mostly to exercise the new CI workflow.