### PR TITLE
Handle biases in VMD Colvars Dashboard

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -246,10 +246,8 @@ If variables are modified, added or deleted by an external script, hit ``Refresh
 Starting the Dashboard also enables trajectory animation using the left/right arrow keys within VMD's graphical window.
 Atomic coordinates can be modified using VMD's ``Mouse/Move'' functions, and the Colvars module can then be updated by pressing F5 directly from the graphical window.
 
-A dropdown list allows for changing the current unit system if no variables are defined.
-If some variables are already defined, it is recommended to edit the configuration for all of
-them at once (eg. pressing Ctrl-a, then Ctrl-e), checking that all quantities are expressed in the desired set of units, and adding the
-\texttt{units} keyword to the general parameters, outside of \texttt{colvar \{\}} blocks (\ref{sec:units}).
+A dropdown list allows for changing the current unit system if no variables are defined (see section~\ref{sec:units}).
+When changing units, it is strongly recommended to check the configuration for all colvars to ensure that all quantities are expressed in the desired set of units.
 
 The Colvars Module interacts with one VMD Molecule at a time.
 At the bottom of the \textit{Actions} tab, a  dropdown lets the user change which VMD molecule is associated with the Colvars module.
@@ -260,9 +258,9 @@ Auto-updating selections (see below) can be used to adapt the colvar definitions
 
 \cvsubsec{Loading / Saving configuration files}{sec:dashboard_load_save}
 
-This saves the configuration of all defined collective variables to a file.
-Neither biases, nor general parameters of the Colvars module (except the units) are saved: editing them is beyond the scope of the Dashboard.
-We recommend keeping them in separate configuration files, and reading them separately in biased MD simulations.
+This saves the current configuration of the colvars Module to a file.
+This includes comments found in the input, general parameters of the Colvars Module, the collective variables themselves, and collective variable biases.
+The resulting configuration file can be read by Colvars, either back in VMD, or within a supported MD engine.
 
 \cvsubsec{The configuration editor}{sec:dashboard_config_editor}
 
@@ -327,6 +325,19 @@ The Dashboard offers visualizations for specific types of variables:
 \end{itemize}
 Parameters for fine-tuning these visualizations can be set in the \textit{Settings} tab.
 
+
+\cvsubsec{Monitoring colvar biases in the Dashboard}{sec:dashboard_biases}
+
+The main Dashboard window features a "Biases" tab that contains a list of currently defined biases, their current energy, and the colvars that they depend upon.
+A button enables creating a Timeline plot with the energies of currently selected biases, similar to the colvar Timeline plot.
+Only one plot can be active at a time.
+
+Note that the energy of history-dependent biases such as ABF or metadynamics may not be meaningfully computed in VMD.
+Nevertheless, the bias list can be used to check the presence of specific biases in a given configuration.
+Hitting the Save button will save the configuration of any bias listed in this tab, except the harmonic wall biases that are created automatically from a colvar for which the lower or upper wall options are specified.
+
+The Dashboard does not currently include a bias configuration editor, as there is less opportunity for interactive refinement of biases than colvars.
+Therefore, bias configurations should be created separately in a text editor.
 
 \cvsubsec{Plotting custom time-dependent quantities as colvars}{sec:dashboard_custom_vars}
 
@@ -711,7 +722,7 @@ See \ref{sec:cvscript_tcl_cv} for a complete list of scripting commands used to 
 \cvsubsubsec{Analyzing a trajectory in VMD}{sec:cv_command_vmd_traj}
 
 One of the typical uses of Colvars in VMD is computing the values of one or more variables along an existing trajectory.
-A complete example input for this frequent use case is shown here.
+This is most easily done using the Dashboard (section~\ref{sec:dashboard}), but can also be done by a script, as in the example below:
 
 \begin{mdexampleinput}
 \-{\bfseries\#~Activate~the~module~on~the~current~VMD~molecule}\\

--- a/vmd/cv_dashboard/cv_dashboard_editor.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_editor.tcl
@@ -86,7 +86,7 @@ proc ::cv_dashboard::edit { {add false} {cvs ""} } {
       dict set ::cv_dashboard::templates_$d [regsub -all {_} [file rootname [file tail $f]] " "] $f
     }
     tk::label $templates.template_label_$d -text "$d templates:"
-    ttk::combobox $templates.pick_template_$d -justify left -state readonly
+    ttk::combobox $templates.pick_template_$d -justify left -state readonly -exportselection no
     $templates.pick_template_$d configure -values [dict keys [set ::cv_dashboard::templates_$d]]
     bind $templates.pick_template_$d <<keyb_enter>> \
       "::cv_dashboard::insert_template $templates.pick_template_$d [list [set ::cv_dashboard::templates_$d]]"
@@ -123,7 +123,7 @@ proc ::cv_dashboard::edit { {add false} {cvs ""} } {
 
   ############# Atoms from representation ################################
   tk::label $helpers.rep_label -text "Atoms from representation:"
-  ttk::combobox $helpers.reps -justify left -state readonly
+  ttk::combobox $helpers.reps -justify left -state readonly -exportselection no
   ttk::button $helpers.refresh_reps -text "Refresh list" -command ::cv_dashboard::refresh_reps
   bind $helpers.reps <<ComboboxSelected>> "::cv_dashboard::atoms_from_sel reps"
 
@@ -138,7 +138,7 @@ proc ::cv_dashboard::edit { {add false} {cvs ""} } {
   ############# Atoms from atom, bond, angle, dihedral labels ####################
   ttk::button $helpers.labeled_atoms -text "Insert labeled atoms" -command {::cv_dashboard::insert_labels Atoms}
   ttk::button $helpers.labeled_var -text "Insert labeled..." -command {::cv_dashboard::insert_labels combo}
-  ttk::combobox $helpers.labels -justify left -state readonly
+  ttk::combobox $helpers.labels -justify left -state readonly -exportselection no
   $helpers.labels configure -values [list Bonds Angles Dihedrals]
   $helpers.labels set Bonds
 
@@ -221,17 +221,18 @@ proc ::cv_dashboard::tab_pressed { {shift false} } {
       $t insert insert $indent
       return -code break
     } else {
+      # Shift-tab without selection will unindent current line
       # Select line of cursor
       set s [list "insert linestart" "insert lineend"]
     }
   } else {
-    # Extend selection to whole lines
+    # Extend selection to whole lines to (un)indent
     set s [list "sel.first linestart" "sel.last lineend"]
   }
 
   set current_sel [$t get {*}$s]
   if { $shift } {
-    regsub -all -lineanchor "^${indent}" $current_sel "" new_sel
+    regsub -all -lineanchor "^${indent}" $current_sel {} new_sel
   } else {
     regsub -all -lineanchor "^" $current_sel $indent new_sel
   }

--- a/vmd/cv_dashboard/cv_dashboard_editor.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_editor.tcl
@@ -43,7 +43,7 @@ proc ::cv_dashboard::edit { {add false} {cvs ""} } {
       set cvs $::cv_dashboard::cvs
     }
     foreach c $cvs {
-      append cfg "colvar {[get_config $c]}\n\n"
+      append cfg "colvar {[get_cv_config $c]}\n\n"
     }
     set ::cv_dashboard::backup_cfg $cfg
   }

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -30,10 +30,13 @@ proc ::cv_dashboard::createWindow {} {
     -row $gridrow -column 2 -pady 2 -padx 2 -sticky nsew
 
   # Table of colvars
-  ttk::treeview $w.cvtable -selectmode extended -show tree
+  ttk::treeview $w.cvtable -selectmode extended -show {headings tree}
   $w.cvtable configure -column val
   $w.cvtable column #0 -width 50 -stretch 1 -anchor w
   $w.cvtable column val -width 150 -stretch 1 -anchor w
+
+  $w.cvtable heading #0 -text "colvar name"
+  $w.cvtable heading val -text "value"
 
   bind $w.cvtable <Button-3> {::cv_dashboard::cvContextMenu %x %y %X %Y}
   bind $w.cvtable <Button-1> {::cv_dashboard::cvTableClicked %x %y}
@@ -51,7 +54,7 @@ proc ::cv_dashboard::createWindow {} {
   }
 
   incr gridrow
-  grid $w.cvtable -row $gridrow -column 0 -sticky news -columnspan 3
+  grid $w.cvtable -row $gridrow -column 0 -sticky news -columnspan 3 -pady 10
   # The colvar table expands and shrinks with the window height
   grid rowconfigure $w $gridrow -weight 1 -minsize 20
 
@@ -190,10 +193,15 @@ proc ::cv_dashboard::createBiasesTab {} {
   set gridrow 0
 
   # Table of biases
-  ttk::treeview $biases.bias_table -selectmode extended -show tree
-  $biases.bias_table configure -column val
-  $biases.bias_table column #0 -width 50 -stretch 1 -anchor w
-  $biases.bias_table column val -width 150 -stretch 1 -anchor w
+  ttk::treeview $biases.bias_table -selectmode extended -show {headings tree}
+  $biases.bias_table configure -columns { val colvars }
+  $biases.bias_table column #0 -width 40 -stretch 1 -anchor w
+  $biases.bias_table column val -width 20 -stretch 1 -anchor w
+  $biases.bias_table column colvars -width 60 -stretch 1 -anchor w
+
+  $biases.bias_table heading #0 -text "bias name"
+  $biases.bias_table heading val -text "energy"
+  $biases.bias_table heading colvars -text "colvars"
 
  # bind $biases.bias_table <Button-3> {::cv_dashboard::cvContextMenu %x %y %X %Y}
  # bind $biases.bias_table <Button-1> {::cv_dashboard::bias_tableClicked %x %y}
@@ -487,6 +495,10 @@ proc ::cv_dashboard::refresh_bias_table {} {
 
     set val [run_cv bias $bias update]
     $biases.bias_table set $bias val [format_value $val]
+    set cfg [run_cv bias $bias getconfig]
+    set cvs ""
+    regexp -line -nocase {^\s*colvars\s+(.*)} $cfg match cvs
+    $biases.bias_table set $bias colvars $cvs
   }
 }
 

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -39,7 +39,7 @@ proc ::cv_dashboard::createWindow {} {
   $w.cvtable heading val -text "value"
 
   bind $w.cvtable <Button-3> {::cv_dashboard::cvContextMenu %x %y %X %Y}
-  bind $w.cvtable <Button-1> {::cv_dashboard::cvTableClicked %x %y}
+  bind $w.cvtable <Button-1> {::cv_dashboard::tableClicked cvtable %x %y}
 
   bind $w.cvtable <Control-e> ::cv_dashboard::edit
   bind $w.cvtable <Control-a> { .cv_dashboard_window.cvtable selection set $::cv_dashboard::cvs }
@@ -204,6 +204,7 @@ proc ::cv_dashboard::createBiasesTab {} {
   $biases.bias_table heading colvars -text "colvars"
 
   bind $biases <Control-a> { .cv_dashboard_window.tabs.biases.bias_table selection set $::cv_dashboard::biases }
+  bind $biases.bias_table <Button-1> {::cv_dashboard::tableClicked tabs.biases.bias_table %x %y}
 
   event add <<keyb_enter>> <Return>   ;# Combine Return and keypad-Enter into a single virtual event
   event add <<keyb_enter>> <KP_Enter>
@@ -219,7 +220,10 @@ proc ::cv_dashboard::createBiasesTab {} {
 
   incr gridrow
 
-  grid [ttk::button $biases.refresh -text "Refresh list \[F5\]" -command ::cv_dashboard::refresh_bias_table -padding "2 0 2 0"] -row $gridrow -column 0 -columnspan 2 -pady 2 -padx 2 -sticky nsew
+  grid [ttk::button $biases.plot -text "Energy timeline" -command ::cv_dashboard::plot_bias_energy -padding "2 0 2 0"] \
+    -row $gridrow -column 0 -pady 2 -padx 2 -sticky nsew
+  grid [ttk::button $biases.refresh -text "Refresh list \[F5\]" -command ::cv_dashboard::refresh_bias_table -padding "2 0 2 0"] \
+    -row $gridrow -column 1 -pady 2 -padx 2 -sticky nsew
   grid [ttk::button $biases.del -text "Delete bias" -command ::cv_dashboard::del_bias -padding "2 0 2 0"] \
     -row $gridrow -column 2 -pady 2 -padx 2 -sticky nsew
 
@@ -353,16 +357,15 @@ proc ::cv_dashboard::cvContextMenu { x y wX wY } {
 
 
 # Takes coordinates within widget
-proc ::cv_dashboard::cvTableClicked { x y } {
-  set w .cv_dashboard_window
-  set menu $w.cvMenu
+proc ::cv_dashboard::tableClicked { table x y } {
+  set t .cv_dashboard_window.$table
 
-  # colvar under mouse
-  set cv [$w.cvtable identify row $x $y]
+  # colvar / bias under mouse
+  set item [$t identify row $x $y]
 
   # Deselect all if clicked on nothing
-  if { [llength $cv] == 0 } {
-    $w.cvtable selection set [list]
+  if { [llength $item] == 0 } {
+    $t selection set [list]
   }
 }
 

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -225,7 +225,7 @@ proc ::cv_dashboard::createBiasesTab {} {
   incr gridrow
 
   grid [ttk::button $biases.refresh -text "Refresh list \[F5\]" -command ::cv_dashboard::refresh_bias_table -padding "2 0 2 0"] -row $gridrow -column 0 -columnspan 2 -pady 2 -padx 2 -sticky nsew
-  grid [ttk::button $biases.del -text "Delete" -command ::cv_dashboard::del_bias -padding "2 0 2 0"] \
+  grid [ttk::button $biases.del -text "Delete bias" -command ::cv_dashboard::del_bias -padding "2 0 2 0"] \
     -row $gridrow -column 2 -pady 2 -padx 2 -sticky nsew
 
   grid columnconfigure $biases 0 -weight 1
@@ -504,7 +504,7 @@ proc ::cv_dashboard::refresh_bias_table {} {
 
 
 proc ::cv_dashboard::refresh_energy_forces {} {
-  set ::cv_dashboard::colvar_energy [run_cv getenergy]
+  set ::cv_dashboard::colvar_energy [catch {cv getenergy}]
 
   if { [string compare [run_cv version] "2021-03-02"] >= 0 } {
     set ::cv_dashboard::atom_forces_rms [run_cv getatomappliedforcesrms]
@@ -817,7 +817,7 @@ proc ::cv_dashboard::show_volmaps { colvars } {
     if { [info exists ::cv_dashboard::volmap_rep($cv)]} {
       hide_volmaps $cv
     }
-    set cv_volmaps [run_cv colvar $cv getvolmapids]
+    set cv_volmaps [catch {cv colvar $cv getvolmapids}]
     set repnames {}
     foreach volid $cv_volmaps {
       if { $volid >= 0 } {

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -38,9 +38,9 @@ proc ::cv_dashboard::createWindow {} {
   bind $w.cvtable <Button-3> {::cv_dashboard::cvContextMenu %x %y %X %Y}
   bind $w.cvtable <Button-1> {::cv_dashboard::cvTableClicked %x %y}
 
-  bind $w <Control-e> ::cv_dashboard::edit
-  bind $w <Control-a> { .cv_dashboard_window.cvtable selection set $::cv_dashboard::cvs }
-  bind $w <Control-n> ::cv_dashboard::add
+  bind $w.cvtable <Control-e> ::cv_dashboard::edit
+  bind $w.cvtable <Control-a> { .cv_dashboard_window.cvtable selection set $::cv_dashboard::cvs }
+  bind $w.cvtable <Control-n> ::cv_dashboard::add
 
   event add <<keyb_enter>> <Return>   ;# Combine Return and keypad-Enter into a single virtual event
   event add <<keyb_enter>> <KP_Enter>
@@ -199,7 +199,7 @@ proc ::cv_dashboard::createBiasesTab {} {
  # bind $biases.bias_table <Button-1> {::cv_dashboard::bias_tableClicked %x %y}
 
   # bind $biases <Control-e> ::cv_dashboard::edit
-  bind $biases <Control-a> { .cv_dashboard_window.bias_table selection set $::cv_dashboard::biases }
+  bind $biases <Control-a> { .cv_dashboard_window.tabs.biases.bias_table selection set $::cv_dashboard::biases }
   # bind $biases <Control-n> ::cv_dashboard::add
 
   event add <<keyb_enter>> <Return>   ;# Combine Return and keypad-Enter into a single virtual event
@@ -215,27 +215,10 @@ proc ::cv_dashboard::createBiasesTab {} {
   #grid rowconfigure $biases $gridrow -weight 1 -minsize 20
 
   incr gridrow
-  grid [label $biases.actions_text -text "Bias list actions"] -row $gridrow -column 0 -columnspan 3 -pady 2 -padx 2 -sticky nsew
 
-  incr gridrow
-  grid [ttk::button $biases.edit -text "Edit \[Ctrl-e\]" -command ::cv_dashboard::edit -padding "2 0 2 0"] \
-    -row $gridrow -column 0 -pady 2 -padx 2 -sticky nsew
-  grid [ttk::button $biases.add -text "New \[Ctrl-n\]" -command ::cv_dashboard::add -padding "2 0 2 0"] \
-    -row $gridrow -column 1 -pady 2 -padx 2 -sticky nsew
-  grid [ttk::button $biases.del -text "Delete" -command ::cv_dashboard::del -padding "2 0 2 0"] \
+  grid [ttk::button $biases.refresh -text "Refresh list \[F5\]" -command ::cv_dashboard::refresh_bias_table -padding "2 0 2 0"] -row $gridrow -column 0 -columnspan 2 -pady 2 -padx 2 -sticky nsew
+  grid [ttk::button $biases.del -text "Delete" -command ::cv_dashboard::del_bias -padding "2 0 2 0"] \
     -row $gridrow -column 2 -pady 2 -padx 2 -sticky nsew
-  incr gridrow
-  grid [ttk::button $biases.refresh -text "Refresh list \[F5\]" -command ::cv_dashboard::refresh_table -padding "2 0 2 0"] -row $gridrow -column 0 -columnspan 3 -pady 2 -padx 2 -sticky nsew
-
-  incr gridrow
-  grid [ttk::separator $biases.sep_plots -orient horizontal] -row $gridrow -column 0 -columnspan 3 -pady 5 -sticky ew
-  incr gridrow
-  grid [label $biases.viz_text -text "Plots and real-time visualizations"] -row $gridrow -column 0 -columnspan 3 -pady 2 -padx 2 -sticky nsew
-
-  # Plots
-  incr gridrow
-  grid [ttk::button $biases.plot -text "Timeline plot" -command ::cv_dashboard::plot -padding "2 0 2 0"] -row $gridrow -column 0 -pady 2 -padx 2 -sticky nsew
-  grid [ttk::button $biases.plot2cv -text "Pairwise plot" -command {::cv_dashboard::plot 2cv} -padding "2 0 2 0"] -row $gridrow -column 1 -pady 2 -padx 2 -sticky nsew
 
   grid columnconfigure $biases 0 -weight 1
   grid columnconfigure $biases 1 -weight 1
@@ -685,6 +668,28 @@ proc ::cv_dashboard::reset {} {
   set ::cv_dashboard::global_comments ""
   refresh_table
   refresh_units
+}
+
+
+# Return list of selected biases in the table
+proc ::cv_dashboard::selected_biases {} {
+
+  set biases .cv_dashboard_window.tabs.biases
+
+  return [$biases.bias_table selection]
+}
+
+
+# Delete currently selected biases
+proc ::cv_dashboard::del_bias { {biases "" } } {
+  if { [llength $biases] < 1 } {
+    set biases [selected_biases]
+  }
+
+  foreach bias $biases {
+    run_cv bias $bias delete
+  }
+  refresh_bias_table
 }
 
 

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -203,12 +203,7 @@ proc ::cv_dashboard::createBiasesTab {} {
   $biases.bias_table heading val -text "energy"
   $biases.bias_table heading colvars -text "colvars"
 
- # bind $biases.bias_table <Button-3> {::cv_dashboard::cvContextMenu %x %y %X %Y}
- # bind $biases.bias_table <Button-1> {::cv_dashboard::bias_tableClicked %x %y}
-
-  # bind $biases <Control-e> ::cv_dashboard::edit
   bind $biases <Control-a> { .cv_dashboard_window.tabs.biases.bias_table selection set $::cv_dashboard::biases }
-  # bind $biases <Control-n> ::cv_dashboard::add
 
   event add <<keyb_enter>> <Return>   ;# Combine Return and keypad-Enter into a single virtual event
   event add <<keyb_enter>> <KP_Enter>

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -219,7 +219,9 @@ proc ::cv_dashboard::createBiasesTab {} {
   #grid rowconfigure $biases $gridrow -weight 1 -minsize 20
 
   incr gridrow
+  grid [label $biases.actions_text -text "Bias list actions"] -row $gridrow -column 0 -columnspan 3 -pady 2 -padx 2 -sticky nsew
 
+  incr gridrow
   grid [ttk::button $biases.plot -text "Energy timeline" -command ::cv_dashboard::plot_bias_energy -padding "2 0 2 0"] \
     -row $gridrow -column 0 -pady 2 -padx 2 -sticky nsew
   grid [ttk::button $biases.refresh -text "Refresh list \[F5\]" -command ::cv_dashboard::refresh_bias_table -padding "2 0 2 0"] \
@@ -598,10 +600,10 @@ proc ::cv_dashboard::change_track_frame {} {
 # Load config from file
 proc ::cv_dashboard::load {} {
   if { [info exists ::cv_dashboard::config_dir] } {
-    set path [tk_getOpenFile -filetypes {{"Colvars cfg" .in} {"Colvars cfg" .colvars} {"Gromacs Colvars cfg" .dat} {"All files" *}} \
+    set path [tk_getOpenFile -filetypes {{"Colvars cfg" .colvars} {"Colvars cfg" .in} {"Gromacs Colvars cfg" .dat} {"All files" *}} \
         -initialdir $::cv_dashboard::config_dir]
   } else {
-    set path [tk_getOpenFile -filetypes {{"Colvars cfg" .in} {"Colvars cfg" .colvars} {"Gromacs Colvars cfg" .dat} {"All files" *}} \
+    set path [tk_getOpenFile -filetypes {{"Colvars cfg" .colvars} {"Colvars cfg" .in} {"Gromacs Colvars cfg" .dat} {"All files" *}} \
         -initialdir [pwd]]
   }
   if [string compare $path ""] {
@@ -622,7 +624,7 @@ proc ::cv_dashboard::save {} {
   } else {
     set initialdir [pwd]
   }
-  set path [tk_getSaveFile -filetypes {{"Colvars cfg" .in} {"Colvars cfg" .colvars} {"Gromacs Colvars cfg" .dat} {"All files" *}} \
+  set path [tk_getSaveFile -filetypes {{"Colvars cfg" .colvars} {"Colvars cfg" .in} {"Gromacs Colvars cfg" .dat} {"All files" *}} \
         -initialdir $initialdir]
 
   if [string compare $path ""] { ;# Empty if the dialog is closed without confirmation

--- a/vmd/cv_dashboard/cv_dashboard_settings.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_settings.tcl
@@ -153,6 +153,9 @@ check any parameters with the dimension of a length or a force constant."
   }
   cv units $new
 
+  # Remember in global config
+  dict set ::cv_dashboard::global_config units $new
+
   # Refresh Combo box
   refresh_units
   refresh_values

--- a/vmd/cv_dashboard/cv_dashboard_settings.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_settings.tcl
@@ -144,19 +144,15 @@ proc ::cv_dashboard::change_units {} {
   # Get up-to-date current setting
   refresh_units
   if {$new != $::cv_dashboard::units} {
-    if {[run_cv list] == {}} {
-      cv units $new
-    } else {
-      tk_messageBox -icon error -title "Colvars Dashboard Error"\
-        -message "Cannot change units while colvars are defined.
-You can either:
-1) delete all colvars, or
-2) edit their configuration (<Ctrl-a> <e>), checking all parameters \
-for consistency with desired units, and add the following line:
-units $new"
-      return
+    if {[run_cv list] != {}} {
+      tk_messageBox -icon error -title "Colvars Dashboard Warning"\
+        -message "Warning: Changing units while colvars are defined.
+Make sure the configuration of all variables is compatible with the new unit system. In particular, \
+check any parameters with the dimension of a length or a force constant."
     }
   }
+  cv units $new
+
   # Refresh Combo box
   refresh_units
   refresh_values

--- a/vmd/cv_dashboard/pkgIndex.tcl
+++ b/vmd/cv_dashboard/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded cv_dashboard 1.3  "set env(CV_DASHBOARD_DIR) [list $dir]; [list source [file join $dir cv_dashboard.tcl]]"
+package ifneeded cv_dashboard 1.4 "set env(CV_DASHBOARD_DIR) [list $dir]; [list source [file join $dir cv_dashboard.tcl]]"


### PR DESCRIPTION
I'm not completely happy with the interface as it is. I considered several options, such as putting the list of biases directly below the list of colvars and not in a tab, but then I'm unsure how to distribute the respective Action buttons.

I think the biases will remain secondary in VMD. The main feature I'm looking for here is to be able to open a config file, edit the colvars, and save everything without losing any information. In that sense the list of biases is mostly for information purposes.


- [x] expose table of biases
- [x] implement energy timeline (and other actions?)
- [x] deal with (in)compatible versions of the library throughout
- [x] document
- [x] do not write unit keyword twice if specified in input
- [x] do not write auto-generated harmonicWalls (will require parsing colvar cfg for wall options - piece of cake)