### PR TITLE
Fix explicit gradient dependency of sub-CVs

### DIFF
--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -167,6 +167,7 @@ cvm::atom_group *colvar::cvc::parse_group(std::string const &conf,
       if (is_available(f_cvc_scalable_com)
           && is_enabled(f_cvc_com_based)
           && !is_enabled(f_cvc_debug_gradient)) {
+        disable(f_cvc_explicit_gradient);
         enable(f_cvc_scalable_com);
         enable(f_cvc_scalable);
         // The CVC makes the feature available;
@@ -254,9 +255,13 @@ int colvar::cvc::init_dependencies() {
 
     init_feature(f_cvc_scalable, "scalable_calculation", f_type_static);
     require_feature_self(f_cvc_scalable, f_cvc_scalable_com);
+    // CVC cannot compute atom-level gradients on rank 0 if colvar computation is distributed
+    exclude_feature_self(f_cvc_scalable, f_cvc_explicit_gradient);
 
     init_feature(f_cvc_scalable_com, "scalable_calculation_of_centers_of_mass", f_type_static);
     require_feature_self(f_cvc_scalable_com, f_cvc_com_based);
+    // CVC cannot compute atom-level gradients if computed on atom group COM
+    exclude_feature_self(f_cvc_scalable_com, f_cvc_explicit_gradient);
 
 
     // TODO only enable this when f_ag_scalable can be turned on for a pre-initialized group

--- a/src/colvarcomp_apath.cpp
+++ b/src/colvarcomp_apath.cpp
@@ -67,9 +67,7 @@ void colvar::aspathCV::calc_gradients() {
     computeDerivatives();
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         cv[i_cv]->calc_gradients();
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
@@ -84,10 +82,7 @@ void colvar::aspathCV::calc_gradients() {
 
 void colvar::aspathCV::apply_force(colvarvalue const &force) {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)
-        ) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                 (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
             }
@@ -156,9 +151,7 @@ void colvar::azpathCV::calc_gradients() {
     computeDerivatives();
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         cv[i_cv]->calc_gradients();
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
@@ -174,10 +167,7 @@ void colvar::azpathCV::calc_gradients() {
 
 void colvar::azpathCV::apply_force(colvarvalue const &force) {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)
-        ) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                 (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
             }

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -423,9 +423,7 @@ colvar::linearCombination::linearCombination(std::string const &conf): cvc(conf)
     x.reset();
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient) ||
-             cv[i_cv]->is_enabled(f_cvc_scalable_com) ||
-             cv[i_cv]->is_enabled(f_cvc_scalable)) {
+        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             use_explicit_gradients = false;
         }
     }
@@ -470,9 +468,7 @@ void colvar::linearCombination::calc_value() {
 void colvar::linearCombination::calc_gradients() {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         cv[i_cv]->calc_gradients();
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
@@ -489,10 +485,7 @@ void colvar::linearCombination::apply_force(colvarvalue const &force) {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         // If this CV us explicit gradients, then atomic gradients is already calculated
         // We can apply the force to atom groups directly
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)
-        ) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                 (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
             }
@@ -570,9 +563,7 @@ colvar::CVBasedPath::CVBasedPath(std::string const &conf): cvc(conf) {
     x.type(colvarvalue::type_scalar);
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient) ||
-             cv[i_cv]->is_enabled(f_cvc_scalable_com) ||
-             cv[i_cv]->is_enabled(f_cvc_scalable)) {
+        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             use_explicit_gradients = false;
         }
     }
@@ -707,9 +698,7 @@ void colvar::gspathCV::calc_gradients() {
         // No matter whether the i-th cv uses implicit gradient, compute it first.
         cv[i_cv]->calc_gradients();
         // If the gradient is not implicit, then add the gradients to its atom groups
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             // Temporary variables storing gradients
             colvarvalue tmp_cv_grad_v1(cv[i_cv]->value());
             colvarvalue tmp_cv_grad_v2(cv[i_cv]->value());
@@ -738,10 +727,7 @@ void colvar::gspathCV::apply_force(colvarvalue const &force) {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         // If this CV us explicit gradients, then atomic gradients is already calculated
         // We can apply the force to atom groups directly
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)
-        ) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                 (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
             }
@@ -844,9 +830,7 @@ void colvar::gzpathCV::calc_gradients() {
         // No matter whether the i-th cv uses implicit gradient, compute it first.
         cv[i_cv]->calc_gradients();
         // If the gradient is not implicit, then add the gradients to its atom groups
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             // Temporary variables storing gradients
             colvarvalue tmp_cv_grad_v1 = -1.0 * dzdv1[i_cv];
             colvarvalue tmp_cv_grad_v2 =  1.0 * dzdv2[i_cv];
@@ -871,14 +855,11 @@ void colvar::gzpathCV::apply_force(colvarvalue const &force) {
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
         // If this CV us explicit gradients, then atomic gradients is already calculated
         // We can apply the force to atom groups directly
-        if ( cv[i_cv]->is_enabled(f_cvc_explicit_gradient) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable) &&
-            !cv[i_cv]->is_enabled(f_cvc_scalable_com)) {
+        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
             for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                 (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
             }
-        }
-        else {
+        } else {
             colvarvalue tmp_cv_grad_v1 = -1.0 * dzdv1[i_cv];
             colvarvalue tmp_cv_grad_v2 =  1.0 * dzdv2[i_cv];
             // Temporary variables storing gradients

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -423,7 +423,9 @@ colvar::linearCombination::linearCombination(std::string const &conf): cvc(conf)
     x.reset();
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
+        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient) ||
+             cv[i_cv]->is_enabled(f_cvc_scalable_com) ||
+             cv[i_cv]->is_enabled(f_cvc_scalable)) {
             use_explicit_gradients = false;
         }
     }
@@ -568,7 +570,9 @@ colvar::CVBasedPath::CVBasedPath(std::string const &conf): cvc(conf) {
     x.type(colvarvalue::type_scalar);
     use_explicit_gradients = true;
     for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
+        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient) ||
+             cv[i_cv]->is_enabled(f_cvc_scalable_com) ||
+             cv[i_cv]->is_enabled(f_cvc_scalable)) {
             use_explicit_gradients = false;
         }
     }
@@ -652,16 +656,6 @@ colvar::gspathCV::gspathCV(std::string const &conf): CVBasedPath(conf) {
     }
     GeometricPathCV::GeometricPathBase<colvarvalue, cvm::real, GeometricPathCV::path_sz::S>::initialize(cv.size(), ref_cv[0], total_reference_frames, use_second_closest_frame, use_third_closest_frame);
     x.type(colvarvalue::type_scalar);
-    use_explicit_gradients = true;
-    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
-            use_explicit_gradients = false;
-        }
-    }
-    if (!use_explicit_gradients) {
-        cvm::log("Geometric path s(σ) will use implicit gradients.\n");
-        disable(f_cvc_explicit_gradient);
-    }
 }
 
 colvar::gspathCV::~gspathCV() {}
@@ -796,16 +790,6 @@ colvar::gzpathCV::gzpathCV(std::string const &conf): CVBasedPath(conf) {
     }
     GeometricPathCV::GeometricPathBase<colvarvalue, cvm::real, GeometricPathCV::path_sz::Z>::initialize(cv.size(), ref_cv[0], total_reference_frames, use_second_closest_frame, use_third_closest_frame, b_use_z_square);
     x.type(colvarvalue::type_scalar);
-    use_explicit_gradients = true;
-    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        if (!cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
-            use_explicit_gradients = false;
-        }
-    }
-    if (!use_explicit_gradients) {
-        cvm::log("Geometric path z(σ) will use implicit gradients.\n");
-        disable(f_cvc_explicit_gradient);
-    }
 }
 
 colvar::gzpathCV::~gzpathCV() {

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -353,7 +353,7 @@ public:
     f_cvc_upper_boundary,
     /// CVC calculates atom gradients
     f_cvc_gradient,
-    /// CVC calculates and stores explicit atom gradients
+    /// CVC calculates and stores explicit atom gradients on rank 0
     f_cvc_explicit_gradient,
     /// CVC calculates and stores inverse atom gradients (used for total force)
     f_cvc_inv_gradient,

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1294,8 +1294,7 @@ public:
 
     if (cos_omega > 0.0) {
       return 2.0*omega*grad1;
-    }
-    else {
+    } else {
       return -2.0*(PI-omega)*grad1;
     }
   }


### PR DESCRIPTION
Some CVCs, such as dihedrals, declare explicit gradients even when
they are set to `scalable on`. This is a quick workaround.

After this commit, if any sub-CVs of a parent CV are (i) not using explicit gradients, (ii) scalable or (iii) COM-based, then the parent CV declares itself to use implicit gradient, although the actual calculations depend on whether the sub-CVs are really explicit gradients or not.

I have to rely on this commit to make my forthcoming PR work properly.