### PR TITLE
Ensure that the PR head is checked out rather than main repo's master

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -2,10 +2,10 @@
 # It generalize the test procedure to be applied by a generic MD engine
 
 # This workflow:
-#  - checkout colvars code
-#  - checkout the MD engine
-#  - build the MD engine with Singularity
-#  - run the colvars regression tests written for the MD engine
+#  - Checkout Colvars code
+#  - Checkout the MD engine
+#  - Build the MD engine with Singularity
+#  - Run the Colvars regression tests written for the MD engine
 
 name: "Test a backend with Colvars"
 
@@ -60,7 +60,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Colvars
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure Ccache
         uses: actions/cache@v2

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -1,6 +1,6 @@
 name: "Backends"
 
-on: [push, pull_request_target]
+on: [pull_request_target]
 
 
 # The jobs call a template workflow `backend-template.yml` which performs

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -1,6 +1,6 @@
 name: "Library"
 
-on: [push, pull_request_target]
+on: [pull_request_target]
 
 
 jobs:
@@ -12,7 +12,11 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Colvars
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Test build recipes
         run: bash devel-tools/check_build_recipes


### PR DESCRIPTION
As stated in the commit title, using a PR for tracking.

In recently open PRs, namely those from @HanatoK's repository, the Checkout action picked the main repo instead of the PR's head, defeating the purpose of the CI workflow altogether. Here I'm attempting to fix this by specifying the repository and commit/branch explicitly:
```
      - name: Checkout Colvars
        uses: actions/checkout@v2
        with:
          repository: ${{ github.event.pull_request.head.repo.full_name }}
          ref: ${{ github.event.pull_request.head.sha }}
```

To avoid conflicts I temporarily disabled the `push` event target, because testing a PR is more important than testing an individual commit.