### PR TITLE
Integration with GROMACS unit tests

### DIFF
--- a/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
@@ -5,11 +5,6 @@
 #include <cstdlib>
 #include <cerrno>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
-
 #include "gromacs/mdlib/mdatoms.h"
 #include "gromacs/mdtypes/inputrec.h"
 #include "gromacs/mdtypes/forceoutput.h"

--- a/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
@@ -5,11 +5,6 @@
 #include <cstdlib>
 #include <cerrno>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
-
 #include "gromacs/mdtypes/inputrec.h"
 #include "gromacs/mdtypes/forceoutput.h"
 #include "gromacs/mdtypes/enerdata.h"


### PR DESCRIPTION
I recently activated the Actions workflow embedded in the GROMACS original repository for our fork:
https://github.com/Colvars/gromacs/actions/runs/1845970135
which raised a compilation error for Windows, as well as a trivial unit test failure for the help text of mdrun (because of the addition of the `-colvars*` arguments), run on macOS. I confirmed the latter on Linux.

The first commit removes the headers that are missing on Windows (they were leftovers from earlier versions of `colvarproxy_gromacs.cpp`. If these are needed again, here is a method that has worked so far:
https://github.com/Colvars/colvars/blob/11d74b8c2d51f93ee8b08b774e6ed0946a188d9e/src/colvarbias_meta.cpp#L16-L27

For the help string, one needs to modify `src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml` through the patch script. I can hard code it in the GROMACS work tree, but it should be taken care of by the patch script at the source (i.e. in this repo).