### PR TITLE
Better management of repository secrets

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -93,6 +93,7 @@ jobs:
           sudo dpkg -i singularity_3.8.5-2_amd64.deb
 
       - name: Get container image of backends' dependencies
+        if: ${{ inputs.backend_name == "NAMD" && env.PULL_NAMD_KEY != "" }} || ${{ inputs.backend_name == "VMD" && env.PULL_VMD_KEY != "" }} || ${{ inputs.backend_name != "NAMD" && inputs.backend_name != "VMD" }}
         shell: bash
         working-directory: devel-tools
         run: |
@@ -107,6 +108,8 @@ jobs:
 
       - name: Checkout ${{ inputs.backend_name }}
         uses: actions/checkout@v2
+        # NAMD and VMD have restrictive licenses
+        if: ${{ inputs.backend_name == "NAMD" && env.PULL_NAMD_KEY != "" }} || ${{ inputs.backend_name == "VMD" && env.PULL_VMD_KEY != "" }} || ${{ inputs.backend_name != "NAMD" && inputs.backend_name != "VMD" }}
         with:
           repository: ${{ inputs.backend_repo }}
           ref: ${{ inputs.backend_repo_ref }}
@@ -115,7 +118,7 @@ jobs:
 
       # Only used for VMD test case
       - name: Checkout VMD plugins
-        if: ${{ inputs.vmd_plugins_repo }}
+        if: ${{ inputs.backend_name == "VMD" && env.PULL_VMD_KEY != "" }}
         uses: actions/checkout@v2
         with:
           repository: ${{ inputs.vmd_plugins_repo }}
@@ -124,6 +127,7 @@ jobs:
           ssh-key: ${{ secrets.private_key_vmd_plugins }}
 
       - name: Update and build ${{ inputs.backend_name }}
+        if: ${{ inputs.backend_name == "NAMD" && env.PULL_NAMD_KEY != "" }} || ${{ inputs.backend_name == "VMD" && env.PULL_VMD_KEY != "" }} || ${{ inputs.backend_name != "NAMD" && inputs.backend_name != "VMD" }}
         shell: bash
         run: |
           singularity exec devel-tools/CentOS7-devel.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
@@ -137,7 +141,7 @@ jobs:
       # Note to be run, test_lib_directory or test_interface_directory must be set by the caller workflow
 
       - name: Run regression tests for library code with ${{ inputs.backend_name }}
-        if: ${{ inputs.test_lib_directory }}
+        if: ${{ inputs.test_lib_directory }} && (${{ inputs.backend_name == "NAMD" && env.PULL_NAMD_KEY != "" }} || ${{ inputs.backend_name == "VMD" && env.PULL_VMD_KEY != "" }} || ${{ inputs.backend_name != "NAMD" && inputs.backend_name != "VMD" }})
         shell: bash
         working-directory: ${{ inputs.test_lib_directory }}
         run: |
@@ -145,7 +149,7 @@ jobs:
           ./run_tests.sh ${{github.workspace}}/${{ inputs.backend_name }}-source/${{ inputs.rpath_exe }} 0??_*
 
       - name: Run regression tests for ${{ inputs.backend_name }} interface code
-        if: ${{ inputs.test_interface_directory }}
+        if: ${{ inputs.test_interface_directory }} && (${{ inputs.backend_name == "NAMD" && env.PULL_NAMD_KEY != "" }} || ${{ inputs.backend_name == "VMD" && env.PULL_VMD_KEY != "" }} || ${{ inputs.backend_name != "NAMD" && inputs.backend_name != "VMD" }})
         shell: bash
         working-directory: ${{ inputs.test_interface_directory }}
         run: |

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -2,7 +2,6 @@ name: "Backends"
 
 on: [pull_request]
 
-
 # The jobs call a template workflow `backend-template.yml` which performs
 # all the necessary steps to run the regression tests of the backend.
 # Variables need to be filled accordingly. See `backend-template.yml`
@@ -11,7 +10,6 @@ jobs:
   lammps:
     name: LAMMPS
     uses: Colvars/colvars/.github/workflows/backend-template.yml@master
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     with:
       backend_name: LAMMPS
       backend_repo: lammps/lammps
@@ -23,8 +21,6 @@ jobs:
   namd:
     name: NAMD
     uses: Colvars/colvars/.github/workflows/backend-template.yml@master
-    # Prevent running this job on fork repos due to the secrets variable
-    if: ${{ github.repository_owner == 'Colvars' }} && ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
     with:
       backend_name: NAMD
       backend_repo: Colvars/namd
@@ -34,14 +30,12 @@ jobs:
       test_interface_directory: namd/tests/interface
       rpath_exe: Linux-x86_64-g++.multicore/namd2
     secrets:
-      # Per-repository secret (sharing a secret from the org with all
-      # repositories turned out to be too complex)
+      # Choice of license by UIUC prevents sharing the code, hence the secret
       private_key: ${{ secrets.PULL_NAMD_KEY }}
 
   vmd:
     name: VMD
     uses: Colvars/colvars/.github/workflows/backend-template.yml@master
-    if: ${{ github.repository_owner == 'Colvars' }} && ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
     with:
       backend_name: VMD
       backend_repo: Colvars/vmd
@@ -60,7 +54,6 @@ jobs:
   gromacs-2020:
     name: GROMACS 2020
     uses: Colvars/colvars/.github/workflows/backend-template.yml@master
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     with:
       backend_name: GROMACS-2020
       backend_repo: gromacs/gromacs

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -1,6 +1,6 @@
 name: "Backends"
 
-on: [pull_request_target]
+on: [pull_request]
 
 
 # The jobs call a template workflow `backend-template.yml` which performs

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -1,6 +1,6 @@
 name: "Library"
 
-on: [pull_request_target]
+on: [push, pull_request]
 
 
 jobs:


### PR DESCRIPTION
This PR attempts to simplify the management of the private repositories for NAMD and VMD in automated tests. These repositories are private due to the restrictive licenses of the two packages: however, people who have accepted their license terms, are welcome to use the private repositories listed under this org using ad-hoc SSH keys.

Using these keys, it is no longer necessary that the Actions workflows are run within this repository. Therefore, I modified the tests to stop using the `pull_request_target` trigger, and use `pull_request` instead. I hope it works, 'coz I haven't read the GitHub doc in detail. (I normally do, but not when the only purpose is to comply to a restrictive license: just poking around seems enough effort for that).
