### PR TITLE
Add a script in colvartools for extracting the weights and biases from

### DIFF
--- a/colvartools/README.md
+++ b/colvartools/README.md
@@ -10,7 +10,7 @@ This directory contains both standalone tools and Colvars scripts.
 | **plot_colvars_traj.py** | Select variables from a Colvars trajectory file and optionally plot them as a 1D graph as a function of time or of one of the variables.|
 | **quaternion2rmatrix.tcl** | As the name says.|
 | **test_scripted_gradients.tcl** | When implementing [colvars as scripted functions of components](http://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:colvar_scripted), use this to test numerically the correctness of the analytical gradient. |
-| **extract_weights_biases.py** | Script to read the weights and biases from a trained dense neural network model, and output them to plain text files suitable for the [NeuralNetwork CV](http://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:neuralnetwork). |
+| **extract_weights_biases.py** | Script to read the weights and biases from a trained dense neural network model, and output them to plain text files suitable for the [NeuralNetwork CV](http://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:neuralnetwork). Examples of how to train those models and save them on-the-fly can be found in the Supporting Information of [this paper](https://pubs.acs.org/doi/abs/10.1021/acs.jcim.1c01010) |
 ## Colvars scripts
 
 | File name | Summary |

--- a/colvartools/README.md
+++ b/colvartools/README.md
@@ -10,6 +10,7 @@ This directory contains both standalone tools and Colvars scripts.
 | **plot_colvars_traj.py** | Select variables from a Colvars trajectory file and optionally plot them as a 1D graph as a function of time or of one of the variables.|
 | **quaternion2rmatrix.tcl** | As the name says.|
 | **test_scripted_gradients.tcl** | When implementing [colvars as scripted functions of components](http://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:colvar_scripted), use this to test numerically the correctness of the analytical gradient. |
+| **extract_weights_biases.py** | Script to read the weights and biases from a trained dense neural network model, and output them to plain text files suitable for the [NeuralNetwork CV](http://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:neuralnetwork). |
 ## Colvars scripts
 
 | File name | Summary |

--- a/colvartools/extract_weights_biases.py
+++ b/colvartools/extract_weights_biases.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import numpy as np
+from tensorflow.keras.models import model_from_json
+import argparse
+
+
+def load_model(model_filename, weights_filename):
+    '''load tensorflow model from saved files'''
+    with open(model_filename, 'r') as json_file:
+        model = model_from_json(json_file.read())
+        model.load_weights(weights_filename)
+        return model
+
+
+def dump_dense_weights_biases(model):
+    for index, layer in enumerate(model.layers):
+        name = layer.name
+        data = layer.get_weights()
+        if len(data) == 0:
+            continue
+        if name.startswith('dense'):
+            # print(name)
+            weights = data[0]
+            biases = data[1]
+            np.savetxt(f'dense_{index}_weights.txt', weights.transpose())
+            np.savetxt(f'dense_{index}_biases.txt', biases)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('model_file', type=str, help='model file of the tensorflow trained model (JSON format)')
+    parser.add_argument('weights_file', type=str, help='weight file of the tensorflow trained model (HDF5 format)')
+    args = parser.parse_args()
+    model = load_model(args.model_file, args.weights_file)
+    dump_dense_weights_biases(model)


### PR DESCRIPTION
The extract_weights_biases.py script reads the weights and biases from
a trained dense neural network model, and outputs them to plain text
files suitable for the NeuralNetwork CV.

I add this script as requested by @jhenin in #453 