### PR TITLE
Speed up plot_colvars_traj and add conversion to pandas dataframe

### DIFF
--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -138,7 +138,7 @@ class Colvars_traj(object):
     @property
     def variables(self):
         """Names of variables defined"""
-        return self._keys[1:] # The first entry is "step"
+        return list(self._colvars.keys())
 
     def _parse_comment_line(self, line):
         """

--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -236,9 +236,14 @@ class Colvars_traj(object):
         tmp_dict = dict()
         if keys is None:
             keys = self.variables
+        series = list()
         for key in keys:
-            tmp_dict[key] = self.__getitem__(key).values.tolist()
-        return pd.DataFrame(data=tmp_dict)
+            series.append(pd.Series(data=self.__getitem__(key).values.tolist(),
+                                    index=self.__getitem__(key).steps,
+                                    name=key))
+        df = pd.concat(series, axis=1).reset_index()
+        df.rename(columns={'index': 'step'}, inplace=True)
+        return df
 
 
 if (__name__ == '__main__'):

--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -11,7 +11,6 @@ import os
 import sys
 
 import numpy as np
-import re
 
 
 class Colvar_traj(object):
@@ -152,11 +151,15 @@ class Colvars_traj(object):
         self._keys = new_keys
         # Find the boundaries of each column
         for i in range(1, len(self._keys)):
-            prog = re.compile(f' {self._keys[i]}\\S?')
-            match_result = prog.search(line)
-            self._start[self._keys[i]] = match_result.start()
-            self._end[self._keys[i-1]] = match_result.start()
+            if i == 1:
+                pos = line.find(' '+self._keys[i]+' ')
+            else:
+                pos = line.find(' '+self._keys[i],
+                                self._start[self._keys[i-1]]+len(self._keys[i-1]))
+            self._start[self._keys[i]] = pos
+            self._end[self._keys[i-1]] = pos
         self._end[self._keys[-1]] = -1
+
 
     def _parse_line(self, line, dict_buffer):
         """

--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -168,16 +168,16 @@ class Colvars_traj(object):
 
         step = np.int64(line[0:self._end['step']])
         for v in self._keys[1:]:
-            text = line[self._start[v]:self._end[v]]
+            text = line[self._start[v]:self._end[v]].strip()
             if (v not in dict_buffer):
                 dict_buffer[v] = {'cv_step': list(), 'cv_values': list()}
-            v_v = np.fromstring(text.lstrip(' (').rstrip(') '), sep=',')
-            if len(v_v) > 1:
-                dict_buffer[v]['cv_values'].append(v_v)
+            if text.startswith('('):
+                v_v = np.fromstring(text[1:-1], sep=',')
                 dict_buffer[v]['dimension'] = len(v_v)
             else:
-                dict_buffer[v]['cv_values'].append(v_v[0])
+                v_v = np.float64(text)
                 dict_buffer[v]['dimension'] = 1
+            dict_buffer[v]['cv_values'].append(v_v)
             dict_buffer[v]['cv_step'].append(step)
 
     def read_files(self, filenames, list_variables=False,

--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -10,11 +10,6 @@ from __future__ import print_function
 import os
 import sys
 
-if (sys.version_info[:2] < (2, 7)):
-    # Save some explanations
-    print("Python versions prior to 2.7 are no longer supported.")
-    sys.exit(1)
-
 import numpy as np
 
 


### PR DESCRIPTION
When reading a colvars.traj file, plot_colvars_traj tries to resize the according numpy array every step, which is slow. I change it to use a buffer of lists and then convert the lists to numpy arrays.
Before this patch, the time of reading a colvars.traj file of 280M is 30 seconds, and after this patch, the reading time is about 10 seconds.
I am not sure if it breaks other use cases. Maybe more tests are required.