### PR TITLE
Update Lepton via patching procedure

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -86,6 +86,13 @@ jobs:
           path: ~/.singularity
           key: Linux-x86_64-containers-build-2022-03-03
 
+      - name: Checkout OpenMM (for Lepton library)
+        uses: actions/checkout@v2
+        with:
+          repository: 'openmm/openmm'
+          ref: 'master'
+          path: 'openmm-source'
+
       - name: Checkout ${{ inputs.backend_name }}
         uses: actions/checkout@v2
         with:
@@ -133,6 +140,8 @@ jobs:
 
       - name: Update and build ${{ inputs.backend_name }}
         shell: bash
+        env:
+          OPENMM_SOURCE: ${{ github.workspace }}/openmm-source
         run: |
           singularity exec devel-tools/CentOS7-devel.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
           CCACHE_DIR=~/ccache_CentOS7-devel \

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -135,8 +135,13 @@ jobs:
       - name: Install build dependencies for library
         run: |
           sudo apt-get -y install tcl8.6-dev
-          # OpenMM contains the latest Lepton
-          git clone --single-branch --depth=1 https://github.com/openmm/openmm openmm-source
+
+      - name: Checkout OpenMM (for Lepton library)
+        uses: actions/checkout@v2
+        with:
+          repository: 'openmm/openmm'
+          ref: 'master'
+          path: 'openmm-source'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/lammps/lib/colvars/Makefile.common
+++ b/lammps/lib/colvars/Makefile.common
@@ -62,10 +62,13 @@ COLVARS_SRCS = \
         colvar_neuralnetworkcompute.cpp
 
 LEPTON_SRCS = \
-	lepton/src/CompiledExpression.cpp lepton/src/ExpressionTreeNode.cpp \
-	lepton/src/ParsedExpression.cpp lepton/src/ExpressionProgram.cpp    \
-	lepton/src/Operation.cpp lepton/src/Parser.cpp
-
+	lepton/src/CompiledExpression.cpp \
+	lepton/src/CompiledVectorExpression.cpp \
+	lepton/src/ExpressionProgram.cpp \
+	lepton/src/ExpressionTreeNode.cpp \
+	lepton/src/Operation.cpp \
+	lepton/src/ParsedExpression.cpp \
+	lepton/src/Parser.cpp
 
 # Allow to selectively turn off Lepton
 ifeq ($(COLVARS_LEPTON),no)
@@ -93,4 +96,13 @@ Makefile.deps: $(COLVARS_SRCS)
 	  done
 
 include Makefile.deps
-include Makefile.lepton.deps # Hand-generated
+
+Makefile.lepton.deps: $(LEPTON_SRCS)
+	@echo > $@
+	@for src in $^ ; do \
+	  obj=`basename $$src .cpp`.o ; \
+	  $(CXX) $(CXXFLAGS) -MM $(LEPTON_INCFLAGS) \
+	    -MT '$$(COLVARS_OBJ_DIR)'$$obj $$src >> $@ ; \
+	  done
+
+include Makefile.lepton.deps

--- a/lammps/lib/colvars/Makefile.lepton.deps
+++ b/lammps/lib/colvars/Makefile.lepton.deps
@@ -1,0 +1,50 @@
+
+$(COLVARS_OBJ_DIR)CompiledExpression.o: lepton/src/CompiledExpression.cpp \
+ lepton/include/lepton/CompiledExpression.h \
+ lepton/include/lepton/ExpressionTreeNode.h \
+ lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/Operation.h lepton/include/lepton/CustomFunction.h \
+ lepton/include/lepton/Exception.h \
+ lepton/include/lepton/ParsedExpression.h
+$(COLVARS_OBJ_DIR)CompiledVectorExpression.o: \
+ lepton/src/CompiledVectorExpression.cpp \
+ lepton/include/lepton/CompiledVectorExpression.h \
+ lepton/include/lepton/ExpressionTreeNode.h \
+ lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/Operation.h lepton/include/lepton/CustomFunction.h \
+ lepton/include/lepton/Exception.h \
+ lepton/include/lepton/ParsedExpression.h
+$(COLVARS_OBJ_DIR)ExpressionProgram.o: lepton/src/ExpressionProgram.cpp \
+ lepton/include/lepton/ExpressionProgram.h \
+ lepton/include/lepton/ExpressionTreeNode.h \
+ lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/Operation.h lepton/include/lepton/CustomFunction.h \
+ lepton/include/lepton/Exception.h \
+ lepton/include/lepton/ParsedExpression.h
+$(COLVARS_OBJ_DIR)ExpressionTreeNode.o: lepton/src/ExpressionTreeNode.cpp \
+ lepton/include/lepton/ExpressionTreeNode.h \
+ lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/Exception.h lepton/include/lepton/Operation.h \
+ lepton/include/lepton/CustomFunction.h lepton/include/lepton/Exception.h
+$(COLVARS_OBJ_DIR)Operation.o: lepton/src/Operation.cpp \
+ lepton/include/lepton/Operation.h \
+ lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/CustomFunction.h lepton/include/lepton/Exception.h \
+ lepton/include/lepton/ExpressionTreeNode.h lepton/src/MSVC_erfc.h
+$(COLVARS_OBJ_DIR)ParsedExpression.o: lepton/src/ParsedExpression.cpp \
+ lepton/include/lepton/ParsedExpression.h \
+ lepton/include/lepton/ExpressionTreeNode.h \
+ lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/CompiledExpression.h \
+ lepton/include/lepton/CompiledVectorExpression.h \
+ lepton/include/lepton/ExpressionProgram.h \
+ lepton/include/lepton/Operation.h lepton/include/lepton/CustomFunction.h \
+ lepton/include/lepton/Exception.h
+$(COLVARS_OBJ_DIR)Parser.o: lepton/src/Parser.cpp \
+ lepton/include/lepton/Parser.h lepton/include/lepton/windowsIncludes.h \
+ lepton/include/lepton/CustomFunction.h lepton/include/lepton/Exception.h \
+ lepton/include/lepton/ExpressionTreeNode.h \
+ lepton/include/lepton/Operation.h lepton/include/lepton/CustomFunction.h \
+ lepton/include/lepton/Exception.h \
+ lepton/include/lepton/ParsedExpression.h \
+ lepton/include/lepton/ExpressionTreeNode.h

--- a/namd/Makefile
+++ b/namd/Makefile
@@ -406,13 +406,7 @@ SBLIB = \
 
 include colvars/src/Makefile.namd
 
-LEPTONOBJS = \
-	$(DSTDIR)/CompiledExpression.o \
-	$(DSTDIR)/ExpressionProgram.o \
-	$(DSTDIR)/ExpressionTreeNode.o \
-	$(DSTDIR)/Operation.o \
-	$(DSTDIR)/ParsedExpression.o \
-	$(DSTDIR)/Parser.o 
+include lepton/Makefile.namd
 
 # definitions for Charm routines
 CHARMC = $(CHARM)/bin/charmc

--- a/namd/lepton/Make.depends
+++ b/namd/lepton/Make.depends
@@ -1,0 +1,80 @@
+obj/CompiledExpression.o: \
+	obj/.exists \
+	lepton/src/CompiledExpression.cpp \
+	lepton/include/lepton/CompiledExpression.h \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/ParsedExpression.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/CompiledExpression.o $(COPTC) lepton/src/CompiledExpression.cpp
+obj/CompiledVectorExpression.o: \
+	obj/.exists \
+	lepton/src/CompiledVectorExpression.cpp \
+	lepton/include/lepton/CompiledVectorExpression.h \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/ParsedExpression.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/CompiledVectorExpression.o $(COPTC) lepton/src/CompiledVectorExpression.cpp
+obj/ExpressionProgram.o: \
+	obj/.exists \
+	lepton/src/ExpressionProgram.cpp \
+	lepton/include/lepton/ExpressionProgram.h \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/ParsedExpression.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/ExpressionProgram.o $(COPTC) lepton/src/ExpressionProgram.cpp
+obj/ExpressionTreeNode.o: \
+	obj/.exists \
+	lepton/src/ExpressionTreeNode.cpp \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/ExpressionTreeNode.o $(COPTC) lepton/src/ExpressionTreeNode.cpp
+obj/Operation.o: \
+	obj/.exists \
+	lepton/src/Operation.cpp \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/src/MSVC_erfc.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/Operation.o $(COPTC) lepton/src/Operation.cpp
+obj/ParsedExpression.o: \
+	obj/.exists \
+	lepton/src/ParsedExpression.cpp \
+	lepton/include/lepton/ParsedExpression.h \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/CompiledExpression.h \
+	lepton/include/lepton/CompiledVectorExpression.h \
+	lepton/include/lepton/ExpressionProgram.h \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/ParsedExpression.o $(COPTC) lepton/src/ParsedExpression.cpp
+obj/Parser.o: \
+	obj/.exists \
+	lepton/src/Parser.cpp \
+	lepton/include/lepton/Parser.h \
+	lepton/include/lepton/windowsIncludes.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/ExpressionTreeNode.h \
+	lepton/include/lepton/Operation.h \
+	lepton/include/lepton/CustomFunction.h \
+	lepton/include/lepton/Exception.h \
+	lepton/include/lepton/ParsedExpression.h \
+	lepton/include/lepton/ExpressionTreeNode.h
+	$(CXX) $(LEPTONCXXFLAGS) $(COPTO)obj/Parser.o $(COPTC) lepton/src/Parser.cpp

--- a/namd/lepton/Makefile.namd
+++ b/namd/lepton/Makefile.namd
@@ -1,0 +1,8 @@
+LEPTONOBJS = \
+	$(DSTDIR)/CompiledExpression.o \
+	$(DSTDIR)/CompiledVectorExpression.o \
+	$(DSTDIR)/ExpressionProgram.o \
+	$(DSTDIR)/ExpressionTreeNode.o \
+	$(DSTDIR)/Operation.o \
+	$(DSTDIR)/ParsedExpression.o \
+	$(DSTDIR)/Parser.o 

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -350,15 +350,6 @@ then
   condcopy "${source}/namd/colvars/Make.depends" \
            "${target}/colvars/Make.depends"
 
-  # Update abf_integrate
-  for src in ${source}/colvartools/*h ${source}/colvartools/*cpp
-  do \
-    tgt=$(basename ${src})
-    condcopy "${src}" "${target}/lib/abf_integrate/${tgt}"
-  done
-  condcopy "${source}/colvartools/Makefile" \
-           "${target}/lib/abf_integrate/Makefile"
-
   # Update NAMD interface files
   for src in \
       ${source}/namd/src/colvarproxy_namd.h \
@@ -368,6 +359,15 @@ then
     tgt=$(basename ${src})
     condcopy "${src}" "${target}/src/${tgt}"
   done
+
+  # Update abf_integrate
+  for src in ${source}/colvartools/*h ${source}/colvartools/*cpp
+  do \
+    tgt=$(basename ${src})
+    condcopy "${src}" "${target}/lib/abf_integrate/${tgt}"
+  done
+  condcopy "${source}/colvartools/Makefile" \
+           "${target}/lib/abf_integrate/Makefile"
 
   # Is this a devel branch of NAMD 3?
   if echo $NAMD_VERSION | grep -q '3.0a'

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -272,7 +272,7 @@ then
   done
 
   # Update makefiles for library
-  for src in ${source}/lammps/lib/colvars/Makefile.{common,deps}
+  for src in ${source}/lammps/lib/colvars/Makefile.{common,deps,lepton.deps}
   do \
     tgt=$(basename ${src})
     condcopy "${src}" "${target}/lib/colvars/${tgt}"
@@ -335,6 +335,14 @@ then
   NAMD_VERSION=$(grep ^NAMD_VERSION ${target}/Makefile | cut -d' ' -f3)
 
   copy_lepton ${target}/ || exit 1
+  condcopy "${source}/namd/lepton/Make.depends" \
+           "${target}/lepton/Make.depends"
+  condcopy "${source}/namd/lepton/Makefile.namd" \
+           "${target}/lepton/Makefile.namd"
+
+  if ! grep -q lepton/Makefile.namd "${target}/lepton/Makefile.namd" ; then
+    condcopy "${source}/namd/Makefile" "${target}/Makefile"
+  fi
 
   # Copy library files to the "colvars" folder
   for src in ${source}/src/*.h ${source}/src/*.cpp

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -496,11 +496,6 @@ then
 
   target_folder=${target}/src/external/colvars
   patch_opts="-p1 --forward -s"
-  if [ ${GMX_VERSION} \< '2020.x' ] ; then
-    # Legacy path, we now target src/external
-    target_folder=${target}/src/gromacs/colvars
-    patch_opts="-p0 --forward -s"
-  fi
 
   echo ""
   if [ -d ${target_folder} ]


### PR DESCRIPTION
The Lepton copies in the LAMMPS and NAMD repositories have lagged behind a bit. This PR makes it easier to keep those copies in sync by reusing the automatic download of Lepton (introduced for GROMACS in #461).

I'm not sure what to do for VMD, so I left it untouched for the moment.