### PR TITLE
Use map of output streams, and return references to its elements

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -61,13 +61,13 @@ jobs:
 
     steps:
       - name: Checkout Colvars
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Load compiler cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ccache
@@ -79,20 +79,20 @@ jobs:
       # Using an exact key to forgo saving it in case of a match (tarring up
       # is expensive); also including a date to allow a force-update.
       - name: Load containers cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.apptainer
           key: Linux-x86_64-containers-build-2022-10-11
 
       - name: Checkout OpenMM (for Lepton library)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'openmm/openmm'
           ref: 'master'
           path: 'openmm-source'
 
       - name: Checkout ${{ inputs.backend_name }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ inputs.backend_repo }}
           ref: ${{ inputs.backend_repo_ref }}
@@ -102,7 +102,7 @@ jobs:
       # Only used for VMD test case
       - name: Checkout VMD plugins
         if: ${{ inputs.backend_name == 'VMD' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ inputs.vmd_plugins_repo }}
           ref: master
@@ -110,7 +110,7 @@ jobs:
           ssh-key: ${{ secrets.private_key_vmd_plugins }}
 
       - name: Get small downloadable packages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/build-tools-packages'
           ref: 'master'

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout Colvars
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Load compiler cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-build-basic-${{ github.sha }}
           restore-keys: ${{ runner.os }}-build-basic-
 
       - name: Get small downloadable packages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/build-tools-packages'
           ref: 'master'
@@ -82,10 +82,10 @@ jobs:
     needs: basicchecks
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load containers cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.apptainer
           key: Linux-x86_64-containers-build-doc-2022-09-03
@@ -105,7 +105,7 @@ jobs:
           apptainer pull Fedora35-texlive.sif library://giacomofiorin/default/colvars_development:fedora35_texlive
 
       - name: Checkout website repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/colvars.github.io'
           path: 'website'
@@ -125,14 +125,14 @@ jobs:
     if: ${{ ! github.event.repository.private }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install build dependencies for library
         run: |
           sudo apt-get -y install tcl8.6-dev
 
       - name: Checkout OpenMM (for Lepton library)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'openmm/openmm'
           ref: 'master'
@@ -159,10 +159,10 @@ jobs:
       CCACHE: ccache
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load compiler ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-build-multiple-${{ github.sha }}
@@ -171,13 +171,13 @@ jobs:
       # Using an exact key to forgo saving it in case of a match (tarring up
       # is expensive); also including a date to allow a force-update.
       - name: Load containers cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.apptainer
           key: Linux-x86_64-containers-build-2022-10-11
 
       - name: Get small downloadable packages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/build-tools-packages'
           ref: 'master'
@@ -356,16 +356,16 @@ jobs:
     needs: basicchecks
     if: needs.basicchecks.outputs.hassecrets == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Load containers cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.apptainer
           key: Linux-x86_64-containers-build-2022-10-11
 
       - name: Checkout Sun compiler (Oracle Developer Studio)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/oracle'
           ssh-key: ${{ secrets.PULL_ORACLE_DEVELOPER_STUDIO }}
@@ -373,7 +373,7 @@ jobs:
           path: ${{github.workspace}}/oracle
 
       - name: Get small downloadable packages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/build-tools-packages'
           ref: 'master'
@@ -411,10 +411,10 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get small downloadable packages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/build-tools-packages'
           ref: 'master'
@@ -433,10 +433,10 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get small downloadable packages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'Colvars/build-tools-packages'
           ref: 'master'

--- a/colvartools/poisson_integrator.cpp
+++ b/colvartools/poisson_integrator.cpp
@@ -26,10 +26,7 @@ int main (int argc, char *argv[]) {
   potential.integrate(itmax, tol, err);
   potential.set_zero_minimum();
 
-  std::cout << "Writing integrated potential to " + gradfile + ".int\n";
-  std::ofstream os(std::string(gradfile + ".int").c_str());
-  potential.write_multicol(os);
-  os.close();
-
+  potential.write_multicol(std::string(gradfile + ".int"),
+                           "integrated potential");
   return 0;
 }

--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -227,8 +227,10 @@ double colvarproxy_lammps::compute()
     cvm::log("atoms_new_colvar_forces = "+cvm::to_str(atoms_new_colvar_forces)+"\n");
   }
 
-  // call the collective variable module
-  colvars->calc();
+  // Call the collective variable module
+  if (colvars->calc() != COLVARS_OK) {
+    cvm::error("Error in the collective variables module.\n", COLVARS_ERROR);
+  }
 
   if (cvm::debug()) {
     cvm::log("atoms_ids = "+cvm::to_str(atoms_ids)+"\n");

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1021,12 +1021,6 @@ std::ostream & colvarproxy_namd::output_stream(std::string const &output_name,
 }
 
 
-bool colvarproxy_namd::output_stream_exists(std::string const &output_name)
-{
-  return (output_streams_.count(output_name) > 0);
-}
-
-
 int colvarproxy_namd::flush_output_stream(std::string const &output_name)
 {
   if (!io_available()) {

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -266,11 +266,20 @@ public:
 
 #endif
 
-  std::ostream * output_stream(std::string const &output_name,
-                               std::ios_base::openmode mode);
-  int flush_output_stream(std::ostream *os);
-  int close_output_stream(std::string const &output_name);
-  int backup_file(char const *filename);
+  std::ostream &output_stream(std::string const &output_name,
+                              std::string const description = "file/channel") override;
+
+  bool output_stream_exists(std::string const &output_name);
+
+  int flush_output_stream(std::string const &output_name) override;
+
+  int flush_output_streams() override;
+
+  int close_output_stream(std::string const &output_name) override;
+
+  int close_output_streams() override;
+
+  int backup_file(char const *filename) override;
 
 };
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -269,8 +269,6 @@ public:
   std::ostream &output_stream(std::string const &output_name,
                               std::string const description = "file/channel") override;
 
-  bool output_stream_exists(std::string const &output_name) override;
-
   int flush_output_stream(std::string const &output_name) override;
 
   int flush_output_streams() override;

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -269,7 +269,7 @@ public:
   std::ostream &output_stream(std::string const &output_name,
                               std::string const description = "file/channel") override;
 
-  bool output_stream_exists(std::string const &output_name);
+  bool output_stream_exists(std::string const &output_name) override;
 
   int flush_output_stream(std::string const &output_name) override;
 

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -2411,9 +2411,7 @@ std::ostream & colvar::write_state(std::ostream &os) {
   os << "}\n\n";
 
   if (runave_outfile.size() > 0) {
-    if (cvm::main()->proxy->output_stream_exists(runave_outfile)) {
-      cvm::main()->proxy->flush_output_stream(runave_outfile);
-    }
+    cvm::main()->proxy->flush_output_stream(runave_outfile);
   }
 
   return os;

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -551,8 +551,6 @@ protected:
   size_t         runave_stride;
   /// Name of the file to write the running average
   std::string    runave_outfile;
-  /// File to write the running average
-  std::ostream  *runave_os;
   /// Current value of the running average
   colvarvalue    runave;
   /// Current value of the square deviation from the running average

--- a/src/colvar_UIestimator.h
+++ b/src/colvar_UIestimator.h
@@ -515,15 +515,16 @@ namespace UIestimator {
             // only for colvars module!
             if (written_1D) cvm::backup_file(pmf_filename.c_str());
 
-            std::ostream* ofile_pmf = cvm::proxy->output_stream(pmf_filename.c_str());
+            std::ostream &ofile_pmf = cvm::proxy->output_stream(pmf_filename,
+                                                                "PMF file");
 
             std::vector<double> position(1, 0);
             for (double i = lowerboundary[0]; i < upperboundary[0] + EPSILON; i += width[0]) {
-                *ofile_pmf << i << " ";
+                ofile_pmf << i << " ";
                 position[0] = i + EPSILON;
-                *ofile_pmf << oneD_pmf.get_value(position) << std::endl;
+                ofile_pmf << oneD_pmf.get_value(position) << std::endl;
             }
-            cvm::proxy->close_output_stream(pmf_filename.c_str());
+            cvm::proxy->close_output_stream(pmf_filename);
 
             written_1D = true;
         }
@@ -541,7 +542,8 @@ namespace UIestimator {
         void write_interal_data() {
             std::string internal_filename = output_filename + ".UI.internal";
 
-            std::ostream* ofile_internal = cvm::proxy->output_stream(internal_filename.c_str());
+            std::ostream &ofile_internal = cvm::proxy->output_stream(internal_filename,
+                                                                     "UI internal file");
 
             std::vector<double> loop_flag(dimension, 0);
             for (int i = 0; i < dimension; i++) {
@@ -551,11 +553,11 @@ namespace UIestimator {
             int n = 0;
             while (n >= 0) {
                 for (int j = 0; j < dimension; j++) {
-                    *ofile_internal << loop_flag[j] + 0.5 * width[j] << " ";
+                    ofile_internal << loop_flag[j] + 0.5 * width[j] << " ";
                 }
 
                 for (int k = 0; k < dimension; k++) {
-                    *ofile_internal << grad.get_value(loop_flag)[k] << " ";
+                    ofile_internal << grad.get_value(loop_flag)[k] << " ";
                 }
 
                 std::vector<double> ii(dimension,0);
@@ -563,10 +565,10 @@ namespace UIestimator {
                     for (double j = loop_flag[1] - 10; j< loop_flag[1] + 10 + EPSILON; j+=width[1]) {
                         ii[0] = i;
                         ii[1] = j;
-                        *ofile_internal << i <<" "<<j<<" "<< distribution_x_y.get_value(loop_flag,ii)<< " ";
+                        ofile_internal << i <<" "<<j<<" "<< distribution_x_y.get_value(loop_flag,ii)<< " ";
                     }
                 }
-                *ofile_internal << std::endl;
+                ofile_internal << std::endl;
 
                 // iterate over any dimensions
                 n = dimension - 1;
@@ -596,13 +598,16 @@ namespace UIestimator {
             //if (written) cvm::backup_file(hist_filename.c_str());
             if (written) cvm::backup_file(count_filename.c_str());
 
-            std::ostream* ofile = cvm::proxy->output_stream(grad_filename.c_str());
-            std::ostream* ofile_hist = cvm::proxy->output_stream(hist_filename.c_str(), std::ios::app);
-            std::ostream* ofile_count = cvm::proxy->output_stream(count_filename.c_str());
+            std::ostream &ofile = cvm::proxy->output_stream(grad_filename,
+                                                            "gradient file");
+            std::ostream &ofile_hist = cvm::proxy->output_stream(hist_filename,
+                                                                 "gradient history file");
+            std::ostream &ofile_count = cvm::proxy->output_stream(count_filename,
+                                                                  "count file");
 
-            writehead(*ofile);
-            writehead(*ofile_hist);
-            writehead(*ofile_count);
+            writehead(ofile);
+            writehead(ofile_hist);
+            writehead(ofile_count);
 
             if (dimension == 1) {
                 calc_1D_pmf();
@@ -617,19 +622,19 @@ namespace UIestimator {
             i = 0;
             while (i >= 0) {
                 for (j = 0; j < dimension; j++) {
-                    *ofile << loop_flag[j] + 0.5 * width[j] << " ";
-                    *ofile_hist << loop_flag[j] + 0.5 * width[j] << " ";
-                    *ofile_count << loop_flag[j] + 0.5 * width[j] << " ";
+                    ofile << loop_flag[j] + 0.5 * width[j] << " ";
+                    ofile_hist << loop_flag[j] + 0.5 * width[j] << " ";
+                    ofile_count << loop_flag[j] + 0.5 * width[j] << " ";
                 }
 
                 if (restart == false) {
                     for (j = 0; j < dimension; j++) {
-                        *ofile << grad.get_value(loop_flag)[j] << " ";
-                        *ofile_hist << grad.get_value(loop_flag)[j] << " ";
+                        ofile << grad.get_value(loop_flag)[j] << " ";
+                        ofile_hist << grad.get_value(loop_flag)[j] << " ";
                     }
-                    *ofile << std::endl;
-                    *ofile_hist << std::endl;
-                    *ofile_count << count.get_value(loop_flag) << " " <<std::endl;
+                    ofile << std::endl;
+                    ofile_hist << std::endl;
+                    ofile_count << count.get_value(loop_flag) << " " <<std::endl;
                 }
                 else {
                     double final_grad = 0;
@@ -639,12 +644,12 @@ namespace UIestimator {
                             final_grad = grad.get_value(loop_flag)[j];
                         else
                             final_grad = ((grad.get_value(loop_flag)[j] * count.get_value(loop_flag) + input_grad.get_value(loop_flag)[j] * input_count.get_value(loop_flag)) / total_count_temp);
-                        *ofile << final_grad << " ";
-                        *ofile_hist << final_grad << " ";
+                        ofile << final_grad << " ";
+                        ofile_hist << final_grad << " ";
                     }
-                    *ofile << std::endl;
-                    *ofile_hist << std::endl;
-                    *ofile_count << (count.get_value(loop_flag) + input_count.get_value(loop_flag)) << " " <<std::endl;
+                    ofile << std::endl;
+                    ofile_hist << std::endl;
+                    ofile_count << (count.get_value(loop_flag) + input_count.get_value(loop_flag)) << " " <<std::endl;
                 }
 
                 // iterate over any dimensions
@@ -654,16 +659,16 @@ namespace UIestimator {
                     if (loop_flag[i] > upperboundary[i] - width[i] + EPSILON) {
                         loop_flag[i] = lowerboundary[i];
                         i--;
-                        *ofile << std::endl;
-                        *ofile_hist << std::endl;
-                        *ofile_count << std::endl;
+                        ofile << std::endl;
+                        ofile_hist << std::endl;
+                        ofile_count << std::endl;
                     }
                     else
                         break;
                 }
             }
             cvm::proxy->close_output_stream(grad_filename.c_str());
-            cvm::proxy->close_output_stream(hist_filename.c_str());
+            // cvm::proxy->close_output_stream(hist_filename.c_str());
             cvm::proxy->close_output_stream(count_filename.c_str());
 
             written = true;

--- a/src/colvarbias_abf.cpp
+++ b/src/colvarbias_abf.cpp
@@ -601,17 +601,17 @@ int colvarbias_abf::replica_share() {
 template <class T> int colvarbias_abf::write_grid_to_file(T const *grid,
                                                           std::string const &filename,
                                                           bool close) {
-  std::ostream *os = cvm::proxy->output_stream(filename);
+  std::ostream &os = cvm::proxy->output_stream(filename);
   if (!os) {
     return cvm::error("Error opening file " + filename + " for writing.\n", COLVARS_ERROR | COLVARS_FILE_ERROR);
   }
-  grid->write_multicol(*os);
+  grid->write_multicol(os);
   if (close) {
     cvm::proxy->close_output_stream(filename);
   } else {
     // Insert empty line between frames in history files
-    *os << std::endl;
-    cvm::proxy->flush_output_stream(os);
+    os << std::endl;
+    cvm::proxy->flush_output_stream(filename);
   }
 
   // In dimension higher than 2, dx is easier to handle and visualize
@@ -619,11 +619,11 @@ template <class T> int colvarbias_abf::write_grid_to_file(T const *grid,
   // (could be implemented as multiple dx files)
   if (num_variables() > 2 && close) {
     std::string  dx = filename + ".dx";
-    std::ostream *dx_os = cvm::proxy->output_stream(dx);
+    std::ostream &dx_os = cvm::proxy->output_stream(dx);
     if (!dx_os)  {
       return cvm::error("Error opening file " + dx + " for writing.\n", COLVARS_ERROR | COLVARS_FILE_ERROR);
     }
-    grid->write_opendx(*dx_os);
+    grid->write_opendx(dx_os);
     // if (close) {
       cvm::proxy->close_output_stream(dx);
     // }

--- a/src/colvarbias_histogram.cpp
+++ b/src/colvarbias_histogram.cpp
@@ -179,31 +179,19 @@ int colvarbias_histogram::write_output_files()
     return COLVARS_OK;
   }
 
+  int error_code = COLVARS_OK;
+
   if (out_name.size() && out_name != "none") {
     cvm::log("Writing the histogram file \""+out_name+"\".\n");
-    cvm::backup_file(out_name.c_str());
-    std::ostream *grid_os = cvm::proxy->output_stream(out_name);
-    if (!grid_os) {
-      return cvm::error("Error opening histogram file "+out_name+
-                        " for writing.\n", COLVARS_FILE_ERROR);
-    }
-    grid->write_multicol(*grid_os);
-    cvm::proxy->close_output_stream(out_name);
+    error_code |= grid->write_multicol(out_name, "histogram output file");
   }
 
   if (out_name_dx.size() && out_name_dx != "none") {
     cvm::log("Writing the histogram file \""+out_name_dx+"\".\n");
-    cvm::backup_file(out_name_dx.c_str());
-    std::ostream *grid_os = cvm::proxy->output_stream(out_name_dx);
-    if (!grid_os) {
-      return cvm::error("Error opening histogram file "+out_name_dx+
-                        " for writing.\n", COLVARS_FILE_ERROR);
-    }
-    grid->write_opendx(*grid_os);
-    cvm::proxy->close_output_stream(out_name_dx);
+    error_code |= grid->write_opendx(out_name_dx, "histogram DX output file");
   }
 
-  return COLVARS_OK;
+  return error_code;
 }
 
 

--- a/src/colvarbias_histogram_reweight_amd.h
+++ b/src/colvarbias_histogram_reweight_amd.h
@@ -51,21 +51,21 @@ public:
 
   /// @brief output the PMF by the exponential average estimator
   /// @param[in] p_output_prefix the prefix of the output file
-  /// @param[in] append append the output to a .hist file if true
+  /// @param[in] keep_open Allow writing the history of the PMF
   virtual int write_exponential_reweighted_pmf(
-    const std::string& p_output_prefix, bool append = false);
+    const std::string& p_output_prefix, bool keep_open = false);
 
   /// @brief output the PMF by the cumulant expansion estimator
   /// @param[in] p_output_prefix the prefix of the output file
-  /// @param[in] append append the output to a .hist file if true
+  /// @param[in] keep_open Allow writing the history of the expansion
   virtual int write_cumulant_expansion_pmf(
-    const std::string& p_output_prefix, bool append = false);
+    const std::string& p_output_prefix, bool keep_open = false);
 
   /// @brief output the biased sampling
   /// @param[in] p_output_prefix the prefix of the output file
-  /// @param[in] append append the output to a .hist file if true
+  /// @param[in] keep_open Allow writing the history of the samples
   virtual int write_count(
-    const std::string& p_output_prefix, bool append = false);
+    const std::string& p_output_prefix, bool keep_open = false);
 protected:
   /// Current accelMD factor is the from previous frame
   std::vector<int> previous_bin;

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -334,13 +334,9 @@ colvarbias_meta::~colvarbias_meta()
   colvarbias_meta::clear_state_data();
   colvarproxy *proxy = cvm::proxy;
 
-  if (proxy->output_stream_exists(replica_hills_file)) {
-    proxy->close_output_stream(replica_hills_file);
-  }
+  proxy->close_output_stream(replica_hills_file);
 
-  if (proxy->output_stream_exists(hills_traj_file_name())) {
-    proxy->close_output_stream(hills_traj_file_name());
-  }
+  proxy->close_output_stream(hills_traj_file_name());
 
   if (target_dist) {
     delete target_dist;

--- a/src/colvarbias_meta.h
+++ b/src/colvarbias_meta.h
@@ -83,9 +83,7 @@ protected:
   size_t     new_hill_freq;
 
   /// Write the hill logfile
-  bool           b_hills_traj;
-  /// Logfile of hill management (creation and deletion)
-  std::ostream  *hills_traj_os;
+  bool b_hills_traj;
 
   /// Name of the hill logfile
   std::string const hills_traj_file_name() const;
@@ -213,10 +211,10 @@ protected:
   std::string            replica_file_name;
 
   /// \brief Read the existing replicas on registry
-  virtual void update_replicas_registry();
+  virtual int update_replicas_registry();
 
   /// \brief Read new data from replicas' files
-  virtual void read_replica_files();
+  virtual int read_replica_files();
 
   /// Write full state information to be read by other replicas
   virtual int write_replica_state_file();

--- a/src/colvarbias_restraint.cpp
+++ b/src/colvarbias_restraint.cpp
@@ -1539,27 +1539,29 @@ int colvarbias_restraint_histogram::update()
 int colvarbias_restraint_histogram::write_output_files()
 {
   if (b_write_histogram) {
+    colvarproxy *proxy = cvm::main()->proxy;
     std::string file_name(cvm::output_prefix()+"."+this->name+".hist.dat");
-    std::ostream *os = cvm::proxy->output_stream(file_name);
-    *os << "# " << cvm::wrap_string(variables(0)->name, cvm::cv_width)
-        << "  " << "p(" << cvm::wrap_string(variables(0)->name, cvm::cv_width-3)
-        << ")\n";
+    std::ostream &os = proxy->output_stream(file_name,
+                                            "histogram output file");
+    os << "# " << cvm::wrap_string(variables(0)->name, cvm::cv_width)
+       << "  " << "p(" << cvm::wrap_string(variables(0)->name, cvm::cv_width-3)
+       << ")\n";
 
-    os->setf(std::ios::fixed, std::ios::floatfield);
+    os.setf(std::ios::fixed, std::ios::floatfield);
 
     size_t igrid;
     for (igrid = 0; igrid < p.size(); igrid++) {
       cvm::real const x_grid = (lower_boundary + (igrid+1)*width);
-      *os << "  "
-          << std::setprecision(cvm::cv_prec)
-          << std::setw(cvm::cv_width)
-          << x_grid
-          << "  "
-          << std::setprecision(cvm::cv_prec)
-          << std::setw(cvm::cv_width)
-          << p[igrid] << "\n";
+      os << "  "
+         << std::setprecision(cvm::cv_prec)
+         << std::setw(cvm::cv_width)
+         << x_grid
+         << "  "
+         << std::setprecision(cvm::cv_prec)
+         << std::setw(cvm::cv_width)
+         << p[igrid] << "\n";
     }
-    cvm::proxy->close_output_stream(file_name);
+    proxy->close_output_stream(file_name);
   }
   return COLVARS_OK;
 }

--- a/src/colvargrid.cpp
+++ b/src/colvargrid.cpp
@@ -49,6 +49,29 @@ int colvar_grid_count::read_multicol(std::string const &filename,
   return colvar_grid<size_t>::read_multicol(filename, description, add);
 }
 
+std::ostream & colvar_grid_count::write_multicol(std::ostream &os) const
+{
+  return colvar_grid<size_t>::write_multicol(os);
+}
+
+int colvar_grid_count::write_multicol(std::string const &filename,
+                                      std::string description) const
+{
+  return colvar_grid<size_t>::write_multicol(filename, description);
+}
+
+std::ostream & colvar_grid_count::write_opendx(std::ostream &os) const
+{
+  return colvar_grid<size_t>::write_opendx(os);
+}
+
+int colvar_grid_count::write_opendx(std::string const &filename,
+                                    std::string description) const
+{
+  return colvar_grid<size_t>::write_opendx(filename, description);
+}
+
+
 
 colvar_grid_scalar::colvar_grid_scalar()
   : colvar_grid<cvm::real>(), samples(NULL)
@@ -84,6 +107,29 @@ int colvar_grid_scalar::read_multicol(std::string const &filename,
 {
   return colvar_grid<cvm::real>::read_multicol(filename, description, add);
 }
+
+std::ostream & colvar_grid_scalar::write_multicol(std::ostream &os) const
+{
+  return colvar_grid<cvm::real>::write_multicol(os);
+}
+
+int colvar_grid_scalar::write_multicol(std::string const &filename,
+                                       std::string description) const
+{
+  return colvar_grid<cvm::real>::write_multicol(filename, description);
+}
+
+std::ostream & colvar_grid_scalar::write_opendx(std::ostream &os) const
+{
+  return colvar_grid<cvm::real>::write_opendx(os);
+}
+
+int colvar_grid_scalar::write_opendx(std::string const &filename,
+                                     std::string description) const
+{
+  return colvar_grid<cvm::real>::write_opendx(filename, description);
+}
+
 
 cvm::real colvar_grid_scalar::maximum_value() const
 {
@@ -246,6 +292,29 @@ int colvar_grid_gradient::read_multicol(std::string const &filename,
 {
   return colvar_grid<cvm::real>::read_multicol(filename, description, add);
 }
+
+std::ostream & colvar_grid_gradient::write_multicol(std::ostream &os) const
+{
+  return colvar_grid<cvm::real>::write_multicol(os);
+}
+
+int colvar_grid_gradient::write_multicol(std::string const &filename,
+                                         std::string description) const
+{
+  return colvar_grid<cvm::real>::write_multicol(filename, description);
+}
+
+std::ostream & colvar_grid_gradient::write_opendx(std::ostream &os) const
+{
+  return colvar_grid<cvm::real>::write_opendx(os);
+}
+
+int colvar_grid_gradient::write_opendx(std::string const &filename,
+                                       std::string description) const
+{
+  return colvar_grid<cvm::real>::write_opendx(filename, description);
+}
+
 
 void colvar_grid_gradient::write_1D_integral(std::ostream &os)
 {

--- a/src/colvargrid.h
+++ b/src/colvargrid.h
@@ -1110,9 +1110,7 @@ public:
   int write_opendx(std::string const &filename,
                    std::string description = "grid file") const;
 
-  /// \brief Get the value from a formatted output and transform it
-  /// into the internal representation (it may have been rescaled or
-  /// manipulated)
+  /// Enter or add a value, but also handle parent grid
   virtual void value_input(std::vector<int> const &ix,
                            size_t const &t,
                            size_t const &imult = 0,
@@ -1400,9 +1398,7 @@ public:
     }
   }
 
-  /// \brief Get the value from a formatted output and transform it
-  /// into the internal representation (it may have been rescaled or
-  /// manipulated)
+  /// Enter or add value but also deal with count grid
   virtual void value_input(std::vector<int> const &ix,
                            cvm::real const &new_value,
                            size_t const &imult = 0,

--- a/src/colvargrid.h
+++ b/src/colvargrid.h
@@ -732,8 +732,8 @@ public:
 
   /// \brief Return the value suitable for output purposes (so that it
   /// may be rescaled or manipulated without changing it permanently)
-  virtual inline T value_output(std::vector<int> const &ix,
-                                size_t const &imult = 0) const
+  virtual T value_output(std::vector<int> const &ix,
+                         size_t const &imult = 0) const
   {
     return value(ix, imult);
   }
@@ -741,10 +741,10 @@ public:
   /// \brief Get the value from a formatted output and transform it
   /// into the internal representation (the two may be different,
   /// e.g. when using colvar_grid_count)
-  virtual inline void value_input(std::vector<int> const &ix,
-                                  T const &t,
-                                  size_t const &imult = 0,
-                                  bool add = false)
+  virtual void value_input(std::vector<int> const &ix,
+                           T const &t,
+                           size_t const &imult = 0,
+                           bool add = false)
   {
     if ( add )
       data[address(ix) + imult] += t;
@@ -803,7 +803,7 @@ public:
     }
   }
 
-  /// \brief Write the grid parameters (number of colvars, boundaries, width and number of points)
+  /// Write the grid parameters (number of colvars, boundaries, width and number of points)
   std::ostream & write_params(std::ostream &os)
   {
     size_t i;
@@ -1028,100 +1028,27 @@ public:
     return is;
   }
 
-  /// \brief Write the grid in a format which is both human readable
-  /// and suitable for visualization e.g. with gnuplot
-  void write_multicol(std::ostream &os) const
-  {
-    // Save the output formats
-    std::ios_base::fmtflags prev_flags(os.flags());
-    // Data in the header: nColvars, then for each
-    // xiMin, dXi, nPoints, periodic
-
-    os << std::setw(2) << "# " << nd << "\n";
-    // Write the floating numbers in full precision
-    os.setf(std::ios::scientific, std::ios::floatfield);
-    for (size_t i = 0; i < nd; i++) {
-      os << "# "
-         << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec) << lower_boundaries[i] << " "
-         << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec) << widths[i] << " "
-         << std::setw(10) << nx[i] << "  "
-         << periodic[i] << "\n";
-    }
-
-
-    for (std::vector<int> ix = new_index(); index_ok(ix); incr(ix) ) {
-
-      if (ix.back() == 0) {
-        // if the last index is 0, add a new line to mark the new record
-        os << "\n";
-      }
-
-      for (size_t i = 0; i < nd; i++) {
-        os << " "
-           << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec)
-           << bin_to_value_scalar(ix[i], i);
-      }
-      os << " ";
-      for (size_t imult = 0; imult < mult; imult++) {
-        os << " "
-           << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec)
-           << value_output(ix, imult);
-      }
-      os << "\n";
-    }
-    // Restore the output formats
-    os.flags(prev_flags);
-  }
-
-  /// Read a grid written by write_multicol(), incrementin if data is true
+  /// Read a grid written by write_multicol(), incrementing if add is true
   std::istream & read_multicol(std::istream &is, bool add = false);
 
-  /// Read a grid written by write_multicol(), incrementin if data is true
+  /// Read a grid written by write_multicol(), incrementing if add is true
   int read_multicol(std::string const &filename,
                     std::string description = "grid file",
                     bool add = false);
 
-  /// \brief Write the grid data without labels, as they are
-  /// represented in memory
-  std::ostream & write_opendx(std::ostream &os) const
-  {
-    // write the header
-    os << "object 1 class gridpositions counts";
-    size_t icv;
-    for (icv = 0; icv < num_variables(); icv++) {
-      os << " " << number_of_points(icv);
-    }
-    os << "\n";
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  std::ostream & write_multicol(std::ostream &os) const;
 
-    os << "origin";
-    for (icv = 0; icv < num_variables(); icv++) {
-      os << " " << (lower_boundaries[icv].real_value + 0.5 * widths[icv]);
-    }
-    os << "\n";
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  int write_multicol(std::string const &filename,
+                     std::string description = "grid file") const;
 
-    for (icv = 0; icv < num_variables(); icv++) {
-      os << "delta";
-      for (size_t icv2 = 0; icv2 < num_variables(); icv2++) {
-        if (icv == icv2) os << " " << widths[icv];
-        else os << " " << 0.0;
-      }
-      os << "\n";
-    }
+  /// Write the grid data without labels, as they are represented in memory
+  std::ostream & write_opendx(std::ostream &os) const;
 
-    os << "object 2 class gridconnections counts";
-    for (icv = 0; icv < num_variables(); icv++) {
-      os << " " << number_of_points(icv);
-    }
-    os << "\n";
-
-    os << "object 3 class array type double rank 0 items "
-       << number_of_points() << " data follows\n";
-
-    write_raw(os);
-
-    os << "object \"collective variables scalar field\" class field\n";
-    return os;
-  }
+  /// Write the grid data without labels, as they are represented in memory
+  int write_opendx(std::string const &filename,
+                   std::string description = "grid file") const;
 };
 
 
@@ -1136,7 +1063,7 @@ public:
   colvar_grid_count();
 
   /// Destructor
-  virtual inline ~colvar_grid_count()
+  virtual ~colvar_grid_count()
   {}
 
   /// Constructor
@@ -1166,16 +1093,30 @@ public:
 
   /// Read a grid written by write_multicol(), incrementin if data is true
   int read_multicol(std::string const &filename,
-                    std::string description = "grid file",
-                    bool add = false);
+                            std::string description = "grid file",
+                            bool add = false);
+
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  std::ostream & write_multicol(std::ostream &os) const;
+
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  int write_multicol(std::string const &filename,
+                     std::string description = "grid file") const;
+
+  /// Write the grid data without labels, as they are represented in memory
+  std::ostream & write_opendx(std::ostream &os) const;
+
+  /// Write the grid data without labels, as they are represented in memory
+  int write_opendx(std::string const &filename,
+                   std::string description = "grid file") const;
 
   /// \brief Get the value from a formatted output and transform it
   /// into the internal representation (it may have been rescaled or
   /// manipulated)
-  virtual inline void value_input(std::vector<int> const &ix,
-                                  size_t const &t,
-                                  size_t const &imult = 0,
-                                  bool add = false)
+  virtual void value_input(std::vector<int> const &ix,
+                           size_t const &t,
+                           size_t const &imult = 0,
+                           bool add = false)
   {
     (void) imult;
     if (add) {
@@ -1242,7 +1183,7 @@ public:
   /// \brief Return the gradient of discrete count from finite differences
   /// on the *same* grid for dimension n
   inline cvm::real gradient_finite_diff(const std::vector<int> &ix0,
-                                            int n = 0)
+                                        int n = 0)
   {
     cvm::real A0, A1, A2;
     std::vector<int> ix = ix0;
@@ -1300,7 +1241,7 @@ public:
   colvar_grid_scalar(colvar_grid_scalar const &g);
 
   /// Destructor
-  ~colvar_grid_scalar();
+  virtual ~colvar_grid_scalar();
 
   /// Constructor from specific sizes arrays
   colvar_grid_scalar(std::vector<int> const &nx_i);
@@ -1329,6 +1270,20 @@ public:
   int read_multicol(std::string const &filename,
                     std::string description = "grid file",
                     bool add = false);
+
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  std::ostream & write_multicol(std::ostream &os) const;
+
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  int write_multicol(std::string const &filename,
+                     std::string description = "grid file") const;
+
+  /// Write the grid data without labels, as they are represented in memory
+  std::ostream & write_opendx(std::ostream &os) const;
+
+  /// Write the grid data without labels, as they are represented in memory
+  int write_opendx(std::string const &filename,
+                   std::string description = "grid file") const;
 
   /// \brief Return the gradient of the scalar field from finite differences
   /// Input coordinates are those of gradient grid, shifted wrt scalar grid
@@ -1386,7 +1341,7 @@ public:
   /// \brief Return the gradient of discrete count from finite differences
   /// on the *same* grid for dimension n
   inline cvm::real gradient_finite_diff(const std::vector<int> &ix0,
-                                            int n = 0)
+                                        int n = 0)
   {
     cvm::real A0, A1, A2;
     std::vector<int> ix = ix0;
@@ -1508,7 +1463,7 @@ public:
   colvar_grid_gradient();
 
   /// Destructor
-  virtual inline ~colvar_grid_gradient()
+  virtual ~colvar_grid_gradient()
   {}
 
   /// Constructor from specific sizes arrays
@@ -1521,12 +1476,26 @@ public:
   colvar_grid_gradient(std::string &filename);
 
   /// Read a grid written by write_multicol(), incrementin if data is true
-  std::istream & read_multicol(std::istream &is, bool add = false);
+  virtual std::istream & read_multicol(std::istream &is, bool add = false);
 
   /// Read a grid written by write_multicol(), incrementin if data is true
-  int read_multicol(std::string const &filename,
-                    std::string description = "grid file",
-                    bool add = false);
+  virtual int read_multicol(std::string const &filename,
+                            std::string description = "grid file",
+                            bool add = false);
+
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  virtual std::ostream & write_multicol(std::ostream &os) const;
+
+  /// Write grid in a format which is both human-readable and gnuplot-friendly
+  virtual int write_multicol(std::string const &filename,
+                             std::string description = "grid file") const;
+
+  /// Write the grid data without labels, as they are represented in memory
+  virtual std::ostream & write_opendx(std::ostream &os) const;
+
+  /// Write the grid data without labels, as they are represented in memory
+  virtual int write_opendx(std::string const &filename,
+                           std::string description = "grid file") const;
 
   /// \brief Get a vector with the binned value(s) indexed by ix, normalized if applicable
   inline void vector_value(std::vector<int> const &ix, std::vector<cvm::real> &v) const
@@ -1583,8 +1552,8 @@ public:
 
   /// \brief Return the value of the function at ix divided by its
   /// number of samples (if the count grid is defined)
-  virtual inline cvm::real value_output(std::vector<int> const &ix,
-                                        size_t const &imult = 0) const
+  virtual cvm::real value_output(std::vector<int> const &ix,
+                                 size_t const &imult = 0) const
   {
     if (samples)
       return (samples->value(ix) > 0) ?
@@ -1597,10 +1566,10 @@ public:
   /// \brief Get the value from a formatted output and transform it
   /// into the internal representation (it may have been rescaled or
   /// manipulated)
-  virtual inline void value_input(std::vector<int> const &ix,
-                                  cvm::real const &new_value,
-                                  size_t const &imult = 0,
-                                  bool add = false)
+  virtual void value_input(std::vector<int> const &ix,
+                           cvm::real const &new_value,
+                           size_t const &imult = 0,
+                           bool add = false)
   {
     if (add) {
       if (samples)

--- a/src/colvargrid_def.h
+++ b/src/colvargrid_def.h
@@ -140,21 +140,22 @@ int colvar_grid<T>::read_multicol(std::string const &filename,
 template <class T>
 std::ostream & colvar_grid<T>::write_multicol(std::ostream &os) const
 {
-  std::streamsize const w = os.width();
-  std::streamsize const p = os.precision();
+  // Save the output formats
+  std::ios_base::fmtflags prev_flags(os.flags());
 
   // Data in the header: nColvars, then for each
   // xiMin, dXi, nPoints, periodic
 
   os << std::setw(2) << "# " << nd << "\n";
+  // Write the floating numbers in full precision
+  os.setf(std::ios::scientific, std::ios::floatfield);
   for (size_t i = 0; i < nd; i++) {
     os << "# "
-       << std::setw(10) << lower_boundaries[i]
-       << std::setw(10) << widths[i]
+       << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec) << lower_boundaries[i] << " "
+       << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec) << widths[i] << " "
        << std::setw(10) << nx[i] << "  "
        << periodic[i] << "\n";
   }
-
 
   for (std::vector<int> ix = new_index(); index_ok(ix); incr(ix) ) {
 
@@ -165,17 +166,21 @@ std::ostream & colvar_grid<T>::write_multicol(std::ostream &os) const
 
     for (size_t i = 0; i < nd; i++) {
       os << " "
-         << std::setw(w) << std::setprecision(p)
+         << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec)
          << bin_to_value_scalar(ix[i], i);
     }
     os << " ";
     for (size_t imult = 0; imult < mult; imult++) {
       os << " "
-         << std::setw(w) << std::setprecision(p)
+         << std::setw(cvm::cv_width) << std::setprecision(cvm::cv_prec)
          << value_output(ix, imult);
     }
     os << "\n";
   }
+
+  // Restore the output formats
+  os.flags(prev_flags);
+
   return os;
 }
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1089,10 +1089,7 @@ int colvarmodule::write_restart_file(std::string const &out_name)
   }
   proxy->close_output_stream(out_name);
 
-  if (proxy->output_stream_exists(cv_traj_name)) {
-    // Take the opportunity to flush colvars.traj
-    proxy->flush_output_stream(cv_traj_name);
-  }
+  // Take the opportunity to flush colvars.traj
 
   return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);
 }

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -770,12 +770,6 @@ protected:
   /// Name of the trajectory file
   std::string cv_traj_name;
 
-  /// Collective variables output trajectory file
-  std::ostream *cv_traj_os;
-
-  /// Appending to the existing trajectory file?
-  bool cv_traj_append;
-
   /// Write labels at the next iteration
   bool cv_traj_write_labels;
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -652,7 +652,7 @@ colvarproxy::colvarproxy()
 
 colvarproxy::~colvarproxy()
 {
-  close_files();
+  close_output_streams();
   if (colvars != NULL) {
     delete colvars;
     colvars = NULL;
@@ -664,24 +664,6 @@ bool colvarproxy::io_available()
 {
   return (smp_enabled() == COLVARS_OK && smp_thread_id() == 0) ||
     (smp_enabled() != COLVARS_OK);
-}
-
-
-int colvarproxy::close_files()
-{
-  if (! io_available()) {
-    // Nothing to do on threads other than the main one
-    return COLVARS_OK;
-  }
-  std::list<std::string>::iterator    osni = output_stream_names.begin();
-  std::list<std::ostream *>::iterator osi  = output_files.begin();
-  for ( ; osi != output_files.end(); osi++, osni++) {
-    ((std::ofstream *) (*osi))->close();
-    delete *osi;
-  }
-  output_files.clear();
-  output_stream_names.clear();
-  return COLVARS_OK;
 }
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -737,9 +737,6 @@ public:
   /// \brief Reset proxy state, e.g. requested atoms
   virtual int reset();
 
-  /// Close any open files to prevent data loss
-  int close_files();
-
   /// (Re)initialize required member data after construction
   virtual int setup();
 

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -256,8 +256,7 @@ int colvarproxy_io::flush_output_stream(std::string const &output_name)
     return COLVARS_OK;
   }
 
-  return cvm::error("Error: trying to flush an output file/channel "
-                    "that wasn't open.\n", COLVARS_BUG_ERROR);
+  return COLVARS_OK;
 }
 
 

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -161,7 +161,7 @@ std::istream &colvarproxy_io::input_stream(std::string const &input_name,
     return *input_stream_error_;
   }
 
-  if (input_streams_.count(input_name) > 0) {
+  if (colvarproxy_io::input_stream_exists(input_name)) {
     return *(input_streams_[input_name]);
   }
 
@@ -179,9 +179,15 @@ std::istream &colvarproxy_io::input_stream(std::string const &input_name,
 }
 
 
+bool colvarproxy_io::input_stream_exists(std::string const &input_name)
+{
+  return (input_streams_.count(input_name) > 0);
+}
+
+
 int colvarproxy_io::close_input_stream(std::string const &input_name)
 {
-  if (input_streams_.count(input_name) > 0) {
+  if (colvarproxy_io::input_stream_exists(input_name)) {
     delete input_streams_[input_name];
     input_streams_.erase(input_name);
     return COLVARS_OK;
@@ -216,7 +222,7 @@ std::ostream & colvarproxy_io::output_stream(std::string const &output_name,
     return *output_stream_error_;
   }
 
-  if (output_streams_.count(output_name) > 0) {
+  if (colvarproxy_io::output_stream_exists(output_name)) {
     return *(output_streams_[output_name]);
   }
 
@@ -245,7 +251,7 @@ int colvarproxy_io::flush_output_stream(std::string const &output_name)
     return COLVARS_OK;
   }
 
-  if (output_streams_.count(output_name) > 0) {
+  if (colvarproxy_io::output_stream_exists(output_name)) {
     (reinterpret_cast<std::ofstream *>(output_streams_[output_name]))->flush();
     return COLVARS_OK;
   }
@@ -278,7 +284,7 @@ int colvarproxy_io::close_output_stream(std::string const &output_name)
                       "from the wrong thread.\n", COLVARS_BUG_ERROR);
   }
 
-  if (output_streams_.count(output_name) > 0) {
+  if (colvarproxy_io::output_stream_exists(output_name)) {
     (reinterpret_cast<std::ofstream *>(output_streams_[output_name]))->close();
     delete output_streams_[output_name];
     output_streams_.erase(output_name);

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -252,7 +252,7 @@ int colvarproxy_io::flush_output_stream(std::string const &output_name)
   }
 
   if (colvarproxy_io::output_stream_exists(output_name)) {
-    (reinterpret_cast<std::ofstream *>(output_streams_[output_name]))->flush();
+    (dynamic_cast<std::ofstream *>(output_streams_[output_name]))->flush();
     return COLVARS_OK;
   }
 
@@ -269,7 +269,7 @@ int colvarproxy_io::flush_output_streams()
   for (std::map<std::string, std::ostream *>::iterator osi = output_streams_.begin();
        osi != output_streams_.end();
        osi++) {
-    (reinterpret_cast<std::ofstream *>(osi->second))->flush();
+    (dynamic_cast<std::ofstream *>(osi->second))->flush();
   }
 
   return COLVARS_OK;
@@ -284,7 +284,7 @@ int colvarproxy_io::close_output_stream(std::string const &output_name)
   }
 
   if (colvarproxy_io::output_stream_exists(output_name)) {
-    (reinterpret_cast<std::ofstream *>(output_streams_[output_name]))->close();
+    (dynamic_cast<std::ofstream *>(output_streams_[output_name]))->close();
     delete output_streams_[output_name];
     output_streams_.erase(output_name);
   }
@@ -302,7 +302,7 @@ int colvarproxy_io::close_output_streams()
   for (std::map<std::string, std::ostream *>::iterator osi = output_streams_.begin();
        osi != output_streams_.end();
        osi++) {
-    (reinterpret_cast<std::ofstream *>(osi->second))->close();
+    (dynamic_cast<std::ofstream *>(osi->second))->close();
   }
   output_streams_.clear();
 

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -103,6 +103,9 @@ public:
                                      std::string const description = "file/channel",
                                      bool error_on_fail = true);
 
+  /// Check if the file/channel is open (without opening it if not)
+  virtual bool input_stream_exists(std::string const &input_name);
+
   /// Closes the given input stream
   virtual int close_input_stream(std::string const &input_name);
 

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -109,23 +109,26 @@ public:
   /// Closes all input streams
   virtual int close_input_streams();
 
-  /// \brief Returns a reference to the given output channel;
-  /// if this is not open already, then open it
-  virtual std::ostream *output_stream(std::string const &output_name,
-                                      std::ios_base::openmode mode =
-                                      std::ios_base::out);
+  /// Returns a reference to the named output file/channel (open it if needed)
+  /// \param output_name File name or identifier
+  /// \param description Purpose of the file
+  virtual std::ostream &output_stream(std::string const &output_name,
+                                      std::string const description = "file/channel");
 
-  /// Returns a reference to output_name if it exists, NULL otherwise
-  virtual std::ostream *get_output_stream(std::string const &output_name);
+  /// Check if the file/channel is open (without opening it if not)
+  virtual bool output_stream_exists(std::string const &output_name);
 
-  /// \brief Flushes the given output channel
-  virtual int flush_output_stream(std::ostream *os);
+  /// Flushes the given output file/channel
+  virtual int flush_output_stream(std::string const &output_name);
 
-  /// \brief Flushes all output channels
+  /// Flushes all output files/channels
   virtual int flush_output_streams();
 
-  /// \brief Closes the given output channel
+  /// Closes the given output file/channel
   virtual int close_output_stream(std::string const &output_name);
+
+  /// Close all open files/channels to prevent data loss
+  virtual int close_output_streams();
 
 protected:
 
@@ -141,17 +144,17 @@ protected:
   /// How often the simulation engine will write its own restart
   int restart_frequency_engine;
 
-  /// \brief Currently opened output files: by default, these are ofstream objects.
-  /// Allows redefinition to implement different output mechanisms
-  std::list<std::ostream *> output_files;
-  /// \brief Identifiers for output_stream objects: by default, these are the names of the files
-  std::list<std::string>    output_stream_names;
-
   /// Container of input files/channels indexed by path name
   std::map<std::string, std::istream *> input_streams_;
 
   /// Object whose reference is returned when read errors occur
   std::istream *input_stream_error_;
+
+  /// Currently open output files/channels
+  std::map<std::string, std::ostream *> output_streams_;
+
+  /// Object whose reference is returned when write errors occur
+  std::ostream *output_stream_error_;
 
   /// Buffer from which the input state information may be read
   char const *input_buffer_;


### PR DESCRIPTION
As mentioned in the conversation for #481, update the registry of output files to use a `std::map` rather than two paired lists, which are no longer worth using any more.