### PR TITLE
Only perform MTS automatic enable/disable for timeStepFactor > 1

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -293,7 +293,6 @@ int colvar::init(std::string const &conf)
     enable(f_cv_multiple_ts);
   }
 
-  // TODO use here information from the CVCs' own natural boundaries
   error_code |= init_grid_parameters(conf);
 
   // Detect if we have a single component that is an alchemical lambda

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -858,11 +858,13 @@ int colvarmodule::calc_colvars()
   // so they can activate colvars as needed
   std::vector<colvarbias *>::iterator bi;
   for (bi = biases.begin(); bi != biases.end(); bi++) {
-    int tsf = (*bi)->get_time_step_factor();
-    if (tsf > 0 && (step_absolute() % tsf == 0)) {
-      (*bi)->enable(colvardeps::f_cvb_awake);
-    } else {
-      (*bi)->disable(colvardeps::f_cvb_awake);
+    int const tsf = (*bi)->get_time_step_factor();
+    if (tsf > 1) {
+      if (step_absolute() % tsf == 0) {
+        (*bi)->enable(colvardeps::f_cvb_awake);
+      } else {
+        (*bi)->disable(colvardeps::f_cvb_awake);
+      }
     }
   }
 
@@ -873,12 +875,14 @@ int colvarmodule::calc_colvars()
   variables_active()->clear();
   variables_active()->reserve(variables()->size());
   for (cvi = variables()->begin(); cvi != variables()->end(); cvi++) {
-    // Wake up or put to sleep variables
+    // Wake up or put to sleep variables with MTS
     int tsf = (*cvi)->get_time_step_factor();
-    if (tsf > 0 && (step_absolute() % tsf == 0)) {
-      (*cvi)->enable(colvardeps::f_cv_awake);
-    } else {
-      (*cvi)->disable(colvardeps::f_cv_awake);
+    if (tsf > 1) {
+      if (step_absolute() % tsf == 0) {
+        (*cvi)->enable(colvardeps::f_cv_awake);
+      } else {
+        (*cvi)->disable(colvardeps::f_cv_awake);
+      }
     }
 
     if ((*cvi)->is_enabled()) {


### PR DESCRIPTION
The default is timeStepFactor == 1, for which no special behavior should be specified.

Also removing a TODO comment for something that was already done.