### PR TITLE
Use Apptainer to manage containers in CI

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -4,7 +4,7 @@
 # This workflow:
 #  - Checkout Colvars code
 #  - Checkout the MD engine
-#  - Build the MD engine with Singularity
+#  - Build the MD engine in a container
 #  - Run the Colvars regression tests written for the MD engine
 
 name: "Test a backend with Colvars"
@@ -78,11 +78,11 @@ jobs:
 
       # Using an exact key to forgo saving it in case of a match (tarring up
       # is expensive); also including a date to allow a force-update.
-      - name: Load Singularity containers cache
+      - name: Load containers cache
         uses: actions/cache@v2
         with:
-          path: ~/.singularity
-          key: Linux-x86_64-containers-build-2022-03-03
+          path: ~/.apptainer
+          key: Linux-x86_64-containers-build-2022-09-03
 
       - name: Checkout OpenMM (for Lepton library)
         uses: actions/checkout@v2
@@ -116,12 +116,11 @@ jobs:
           ref: 'master'
           path: 'devel-tools/packages'
 
-      - name: Install Singularity
+      - name: Install Apptainer
         shell: bash
-        working-directory: devel-tools/packages
         run: |
-          sudo apt-get -y install squashfs-tools containernetworking-plugins
-          sudo dpkg -i singularity_3.8.5-2_amd64.deb
+          wget https://github.com/apptainer/apptainer/releases/download/v1.0.3/apptainer_1.0.3_amd64.deb
+          sudo apt-get -y install ./apptainer_1.0.3_amd64.deb
 
       - name: Get container image of backends' dependencies
         shell: bash
@@ -129,21 +128,21 @@ jobs:
         run: |
           # Pull CentOS 7 container used to build backends
           # (contains build tools, OpenMPI, FFTW, Tcl/Tk and Charm++)
-          singularity pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
+          apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
 
       - name : Get spiff
         shell: bash
         working-directory: devel-tools
-        run: sudo cp -f $(singularity exec CentOS7-devel.sif ./get_spiff) /usr/local/bin
+        run: sudo cp -f $(apptainer exec CentOS7-devel.sif ./get_spiff) /usr/local/bin
 
       - name: Update and build ${{ inputs.backend_name }}
         shell: bash
         env:
           OPENMM_SOURCE: ${{ github.workspace }}/openmm-source
         run: |
-          singularity exec devel-tools/CentOS7-devel.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
+          apptainer exec devel-tools/CentOS7-devel.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
           CCACHE_DIR=~/ccache_CentOS7-devel \
-          singularity exec devel-tools/CentOS7-devel.sif \
+          apptainer exec devel-tools/CentOS7-devel.sif \
           bash ${{ inputs.path_compile_script }} ${{ inputs.backend_name }}-source
 
 
@@ -156,7 +155,7 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.test_lib_directory }}
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           ./run_tests.sh ${{github.workspace}}/${{ inputs.backend_name }}-source/${{ inputs.rpath_exe }} 0??_*
 
       - name: Run regression tests for ${{ inputs.backend_name }} interface code
@@ -164,5 +163,5 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.test_interface_directory }}
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           ./run_tests.sh ${{github.workspace}}/${{ inputs.backend_name }}-source/${{ inputs.rpath_exe }}

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -128,6 +128,8 @@ jobs:
         run: |
           # Pull CentOS 7 container used to build backends
           # (contains build tools, OpenMPI, FFTW, Tcl/Tk and Charm++)
+          apptainer remote add --no-login SylabsCloud cloud.sylabs.io
+          apptainer remote use SylabsCloud
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
 
       - name : Get spiff

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -83,31 +83,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Load Singularity containers cache
+      - name: Load containers cache
         uses: actions/cache@v2
         with:
-          path: ~/.singularity
-          key: Linux-x86_64-containers-build-doc-2022-03-04
+          path: ~/.apptainer
+          key: Linux-x86_64-containers-build-doc-2022-09-03
 
-      - name: Get small downloadable packages
-        uses: actions/checkout@v2
-        with:
-          repository: 'Colvars/build-tools-packages'
-          ref: 'master'
-          path: 'devel-tools/packages'
-
-      - name: Install Singularity
+      - name: Install Apptainer
         shell: bash
-        working-directory: devel-tools/packages
         run: |
-          sudo apt-get -y install squashfs-tools containernetworking-plugins
-          sudo dpkg -i singularity_3.8.5-2_amd64.deb
+          wget https://github.com/apptainer/apptainer/releases/download/v1.0.3/apptainer_1.0.3_amd64.deb
+          sudo apt-get -y install ./apptainer_1.0.3_amd64.deb
 
       - name: Get container image
         shell: bash
         working-directory: devel-tools
         run: |
-          singularity pull Fedora35-texlive.sif library://giacomofiorin/default/colvars_development:fedora35_texlive
+          apptainer pull Fedora35-texlive.sif library://giacomofiorin/default/colvars_development:fedora35_texlive
 
       - name: Checkout website repository
         uses: actions/checkout@v2
@@ -120,7 +112,7 @@ jobs:
         env:
           COLVARSDIR: ${{ github.workspace }}
           FORCE: 1  # Ignore error if branch isn't master
-        run: singularity exec ${COLVARSDIR}/devel-tools/Fedora35-texlive.sif make
+        run: apptainer exec ${COLVARSDIR}/devel-tools/Fedora35-texlive.sif make
 
 
   codeql:
@@ -175,11 +167,11 @@ jobs:
 
       # Using an exact key to forgo saving it in case of a match (tarring up
       # is expensive); also including a date to allow a force-update.
-      - name: Load Singularity containers cache
+      - name: Load containers cache
         uses: actions/cache@v2
         with:
-          path: ~/.singularity
-          key: Linux-x86_64-containers-build-2022-03-03
+          path: ~/.apptainer
+          key: Linux-x86_64-containers-build-2022-09-03
 
       - name: Get small downloadable packages
         uses: actions/checkout@v2
@@ -188,18 +180,17 @@ jobs:
           ref: 'master'
           path: 'devel-tools/packages'
 
-      - name: Install Singularity
+      - name: Install Apptainer
         shell: bash
-        working-directory: devel-tools/packages
         run: |
-          sudo apt-get -y install squashfs-tools containernetworking-plugins
-          sudo dpkg -i singularity_3.8.5-2_amd64.deb
+          wget https://github.com/apptainer/apptainer/releases/download/v1.0.3/apptainer_1.0.3_amd64.deb
+          sudo apt-get -y install ./apptainer_1.0.3_amd64.deb
 
       - name: Get container image
         shell: bash
         working-directory: devel-tools
         run: |
-          singularity pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
+          apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
 
       - name: GCC 4.8, C++11
         env:
@@ -208,7 +199,7 @@ jobs:
           CXX_VERSION: 4.8
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
       - name: GCC 8, C++17
@@ -218,7 +209,7 @@ jobs:
           CXX_VERSION: 8
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -229,7 +220,7 @@ jobs:
           CXX_VERSION: 11
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -240,7 +231,7 @@ jobs:
           CXX_VERSION: 11
           CC: clang
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
       - name: Clang 7, C++17
@@ -250,7 +241,7 @@ jobs:
           CXX_VERSION: 7
           CC: clang
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable llvm-toolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -261,7 +252,7 @@ jobs:
           CXX_VERSION: 11
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -272,7 +263,7 @@ jobs:
           CXX_VERSION: 10
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -283,7 +274,7 @@ jobs:
           CXX_VERSION: 9
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -294,7 +285,7 @@ jobs:
           CXX_VERSION: 8
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -305,7 +296,7 @@ jobs:
           CXX_VERSION: 8
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -316,7 +307,7 @@ jobs:
           CXX_VERSION: 7
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -327,7 +318,7 @@ jobs:
           CXX_VERSION: 7
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
@@ -338,7 +329,7 @@ jobs:
           CXX_VERSION: 4.8
           CC: gcc
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
 
@@ -350,11 +341,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Load Singularity containers cache
+      - name: Load containers cache
         uses: actions/cache@v2
         with:
-          path: ~/.singularity
-          key: Linux-x86_64-containers-build-2022-03-03
+          path: ~/.apptainer
+          key: Linux-x86_64-containers-build-2022-09-03
 
       - name: Checkout Sun compiler (Oracle Developer Studio)
         uses: actions/checkout@v2
@@ -371,18 +362,17 @@ jobs:
           ref: 'master'
           path: 'devel-tools/packages'
 
-      - name: Install Singularity
+      - name: Install Apptainer
         shell: bash
-        working-directory: devel-tools/packages
         run: |
-          sudo apt-get -y install squashfs-tools containernetworking-plugins
-          sudo dpkg -i singularity_3.8.5-2_amd64.deb
+          wget https://github.com/apptainer/apptainer/releases/download/v1.0.3/apptainer_1.0.3_amd64.deb
+          sudo apt-get -y install ./apptainer_1.0.3_amd64.deb
 
       - name: Get container image
         shell: bash
         working-directory: devel-tools
         run: |
-          singularity pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
+          apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
 
       - name: Build library with Sun compiler (Oracle Developer Studio)
         shell: bash
@@ -390,7 +380,7 @@ jobs:
           CC: ${{github.workspace}}/oracle/developerstudio12.6/bin/cc
           CXX: ${{github.workspace}}/oracle/developerstudio12.6/bin/CC
         run: |
-          singularity exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=11 -P devel-tools/build_test_library.cmake
 
 

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -99,6 +99,8 @@ jobs:
         shell: bash
         working-directory: devel-tools
         run: |
+          apptainer remote add --no-login SylabsCloud cloud.sylabs.io
+          apptainer remote use SylabsCloud
           apptainer pull Fedora35-texlive.sif library://giacomofiorin/default/colvars_development:fedora35_texlive
 
       - name: Checkout website repository
@@ -190,6 +192,8 @@ jobs:
         shell: bash
         working-directory: devel-tools
         run: |
+          apptainer remote add --no-login SylabsCloud cloud.sylabs.io
+          apptainer remote use SylabsCloud
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
 
       - name: GCC 4.8, C++11
@@ -372,6 +376,8 @@ jobs:
         shell: bash
         working-directory: devel-tools
         run: |
+          apptainer remote add --no-login SylabsCloud cloud.sylabs.io
+          apptainer remote use SylabsCloud
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
 
       - name: Build library with Sun compiler (Oracle Developer Studio)


### PR DESCRIPTION
The open-source Singularity project has now become [Apptainer](https://github.com/apptainer/apptainer).
    
Despite the minor nuisance of the rebranding, if offers DEB-format packages for major architectures, which is a significant step up given that GitHub Actions is a Ubuntu-based resource.

There may be some changes down the road in the (commercial) Sylabs library, but at the moment downloading public images from free storage and caching them in Actions for faster retrieval is working well.