### PR TITLE
Accept multiple config files from NAMD (preliminary work)

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -113,9 +113,9 @@ colvarproxy_namd::colvarproxy_namd()
            cvm::to_str(COLVARPROXY_VERSION)+".\n");
   colvars->cite_feature("NAMD engine");
   colvars->cite_feature("Colvars-NAMD interface");
-    // Construct instance of colvars scripting interface
+
   errno = 0;
-  if (config) {
+  for ( ; config; config = config->next ) {
     colvars->read_config_file(config->data);
   }
 


### PR DESCRIPTION
Together with an equally tiny patch in NAMD (below), this makes it possible to parse multiple config files in NAMD. With current NAMD, this doesn't change the behavior.

```diff
diff --git a/src/SimParameters.C b/src/SimParameters.C
index f9e89889..8df00654 100644
--- a/src/SimParameters.C
+++ b/src/SimParameters.C
@@ -1874,7 +1874,7 @@ void SimParameters::config_parser_constraints(ParseOptions &opts) {
     opts.optionalB("main", "colvars", "Is the colvars module enabled?",
       &colvarsOn, FALSE);
     opts.optional("colvars", "colvarsConfig",
-      "configuration for the collective variables", PARSE_STRING);
+      "configuration for the collective variables", PARSE_MULTIPLES);
     opts.optional("colvars", "colvarsInput",
       "input restart file for the collective variables", PARSE_STRING);
```
 
