### PR TITLE
Safer detection of Windows with recent Microsoft Visual Studio versions

### DIFF
--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 
 // used to set the absolute path of a replica file
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <direct.h>
 #define CHDIR ::_chdir
 #define GETCWD ::_getcwd

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -8,10 +8,10 @@
 // Colvars repository at GitHub.
 
 // Using access() to check if a file exists (until we can assume C++14/17)
-#if !defined(WIN32) || defined(__CYGWIN__)
+#if !defined(_WIN32) || defined(__CYGWIN__)
 #include <unistd.h>
 #endif
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <io.h>
 #endif
 
@@ -66,7 +66,7 @@ int colvarproxy_io::backup_file(char const *filename)
   // Simplified version of NAMD_file_exists()
   int exit_code;
   do {
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     // We could use _access_s here, but it is probably too new
     exit_code = _access(filename, 00);
 #else
@@ -96,7 +96,7 @@ int colvarproxy_io::backup_file(char const *filename)
 int colvarproxy_io::remove_file(char const *filename)
 {
   int error_code = COLVARS_OK;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
   // Because the file may be open by other processes, rename it to filename.old
   std::string const renamed_file(std::string(filename)+".old");
   // It may still be there from an interrupted run, so remove it to be safe
@@ -129,7 +129,7 @@ int colvarproxy_io::remove_file(char const *filename)
 int colvarproxy_io::rename_file(char const *filename, char const *newfilename)
 {
   int error_code = COLVARS_OK;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
   // On straight Windows, must remove the destination before renaming it
   error_code |= remove_file(newfilename);
 #endif


### PR DESCRIPTION
Compiling colvars in LAMMPS fails to compile on Windows with Visual Studio 2022 Community Edition 17.4 / MSVC++ v19.34 because the WIN32 define is not present (anymore?).

Using _WIN32 instead of WIN32 as predefined preprocessor macro to detect Windows works and is what is documented.
https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170

Update: I think I have figured out why `#if defined(WIN32)` worked before: CMake sets this. I had a corrupted CMakeCache.txt file and all the predefined compiler switches were lost. That cause the failure to compile, but with this change it doesn't matter whether CMake sets the define because _WIN32 is set by the compiler.