### PR TITLE
[Draft] add support for GROMACS 2022

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -118,3 +118,15 @@ jobs:
       path_compile_script: devel-tools/compile-gromacs.sh
       test_lib_directory: gromacs/tests/library
       rpath_exe: install/bin/gmx_d
+
+  gromacs-2022:
+    name: GROMACS 2022
+    if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'test-gromacs-2022')
+    uses: ./.github/workflows/backend-template.yml
+    with:
+      backend_name: GROMACS-2022
+      backend_repo: gromacs/gromacs
+      backend_repo_ref: release-2022
+      path_compile_script: devel-tools/compile-gromacs.sh
+      test_lib_directory: gromacs/tests/library
+      rpath_exe: install/bin/gmx_d

--- a/gromacs/gromacs-2022.x.patch
+++ b/gromacs/gromacs-2022.x.patch
@@ -1,0 +1,506 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cd748c9..31e3b62 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -588,6 +588,10 @@ include(gmxManageLmfit)
+
+ include(gmxManageMuparser)
+
++include(gmxManageColvars)
++
++include(gmxManageLepton)
++
+ ##################################################
+ # Process SIMD instruction settings
+ ##################################################
+diff --git a/src/gromacs/CMakeLists.txt b/src_colvars/gromacs/CMakeLists.txt
+index 99cc804..40fbe29 100644
+--- a/src/gromacs/CMakeLists.txt
++++ b/src_colvars/gromacs/CMakeLists.txt
+@@ -139,6 +139,11 @@ if (WIN32)
+ endif()
+ list(APPEND libgromacs_object_library_dependencies thread_mpi)
+
++gmx_manage_colvars()
++gmx_manage_lepton()
++list(APPEND libgromacs_object_library_dependencies colvars)
++list(APPEND libgromacs_object_library_dependencies lepton)
++
+ if(GMX_INSTALL_LEGACY_API)
+   install(FILES
+ 	  analysisdata.h
+@@ -184,6 +189,8 @@ else()
+     add_library(libgromacs ${LIBGROMACS_SOURCES})
+ endif()
+
++gmx_include_colvars_headers()
++
+ if (TARGET Heffte::Heffte)
+     target_link_libraries(libgromacs PRIVATE Heffte::Heffte)
+ endif()
+diff --git a/src/gromacs/fileio/checkpoint.cpp b/src_colvars/gromacs/fileio/checkpoint.cpp
+index f6764a1..279953d 100644
+--- a/src/gromacs/fileio/checkpoint.cpp
++++ b/src_colvars/gromacs/fileio/checkpoint.cpp
+@@ -69,6 +69,7 @@
+ #include "gromacs/mdtypes/pullhistory.h"
+ #include "gromacs/mdtypes/state.h"
+ #include "gromacs/mdtypes/swaphistory.h"
++#include "gromacs/mdtypes/colvarshistory.h"
+ #include "gromacs/modularsimulator/modularsimulator.h"
+ #include "gromacs/trajectory/trajectoryframe.h"
+ #include "gromacs/utility/arrayref.h"
+@@ -1287,6 +1293,14 @@ static void do_cpt_header(XDR* xd, gmx_bool bRead, FILE* list, CheckpointHeaderC
+     {
+         contents->isModularSimulatorCheckpoint = false;
+     }
++    if (contents->file_version >= CheckPointVersion::Colvars)
++    {
++        do_cpt_int_err(xd, "colvars atoms", &contents->ecolvars, list);
++    }
++    else
++    {
++        contents->ecolvars = 0;
++    }
+ }
+
+ static int do_cpt_footer(XDR* xd, CheckPointVersion file_version)
+@@ -2035,6 +2049,36 @@ static int do_cpt_EDstate(XDR* xd, gmx_bool bRead, int nED, edsamhistory_t* EDst
+     return 0;
+ }
+
++/* This function stores the last whole configuration of the colvars atoms in the .cpt file */
++static int do_cpt_colvars(XDR* xd, gmx_bool bRead, int ecolvars, colvarshistory_t* colvarsstate, FILE* list)
++{
++
++    if (ecolvars == 0)
++    {
++        return 0;
++    }
++
++    colvarsstate->bFromCpt = bRead;
++    colvarsstate->n_atoms  = ecolvars;
++
++    /* Write data */
++    char buf[STRLEN];
++    sprintf(buf, "Colvars atoms in reference structure : %d", ecolvars);
++    sprintf(buf, "Colvars xa_old");
++    if (bRead)
++    {
++        snew(colvarsstate->xa_old_whole, colvarsstate->n_atoms);
++        do_cpt_n_rvecs_err(xd, buf, colvarsstate->n_atoms, colvarsstate->xa_old_whole, list);
++    }
++    else
++    {
++        do_cpt_n_rvecs_err(xd, buf, colvarsstate->n_atoms, colvarsstate->xa_old_whole_p, list);
++    }
++
++    return 0;
++}
++
++
+ static int do_cpt_correlation_grid(XDR*                         xd,
+                                    gmx_bool                     bRead,
+                                    gmx_unused int               fflags,
+@@ -2432,6 +2476,7 @@ void write_checkpoint_data(t_fileio*                         fp,
+                              observablesHistory->swapHistory.get(),
+                              nullptr)
+             < 0)
++        || (do_cpt_colvars(gmx_fio_getxdr(fp), FALSE, headerContents.ecolvars, observablesHistory->colvarsHistory.get(), nullptr) < 0)
+         || (do_cpt_files(gmx_fio_getxdr(fp), FALSE, outputfiles, nullptr, headerContents.file_version) < 0))
+     {
+         gmx_file("Cannot read/write checkpoint; corrupt file, or maybe you are out of disk space?");
+@@ -2825,6 +2870,17 @@ static void read_checkpoint(const char*                    fn,
+         cp_error();
+     }
+
++    if (headerContents->ecolvars != 0 && observablesHistory->colvarsHistory == nullptr)
++    {
++        observablesHistory->colvarsHistory = std::make_unique<colvarshistory_t>(colvarshistory_t{});
++    }
++    ret = do_cpt_colvars(gmx_fio_getxdr(fp), TRUE, headerContents->ecolvars,
++                           observablesHistory->colvarsHistory.get(), nullptr);
++    if (ret)
++    {
++        cp_error();
++    }
++
+     std::vector<gmx_file_position_t> outputfiles;
+     ret = do_cpt_files(gmx_fio_getxdr(fp), TRUE, &outputfiles, nullptr, headerContents->file_version);
+     if (ret)
+@@ -3000,6 +3056,13 @@ static CheckpointHeaderContents read_checkpoint_data(t_fileio*
+         cp_error();
+     }
+
++    colvarshistory_t colvarshist = {};
++    ret = do_cpt_colvars(gmx_fio_getxdr(fp), TRUE, headerContents.ecolvars, &colvarshist, nullptr);
++    if (ret)
++    {
++        cp_error();
++    }
++
+     ret = do_cpt_files(gmx_fio_getxdr(fp), TRUE, outputfiles, nullptr, headerContents.file_version);
+
+     if (ret)
+@@ -3120,6 +3183,12 @@ void list_checkpoint(const char* fn, FILE* out)
+         ret = do_cpt_swapstate(gmx_fio_getxdr(fp), TRUE, headerContents.eSwapCoords, &swaphist, out);
+     }
+
++    if (ret == 0)
++    {
++        colvarshistory_t colvarshist = {};
++        ret = do_cpt_colvars(gmx_fio_getxdr(fp), TRUE, headerContents.ecolvars, &colvarshist, out);
++    }
++
+     if (ret == 0)
+     {
+         std::vector<gmx_file_position_t> outputfiles;
+diff --git a/src/gromacs/fileio/checkpoint.h b/src_colvars/gromacs/fileio/checkpoint.h
+index 5145e1d..3054462 100644
+--- a/src/gromacs/fileio/checkpoint.h
++++ b/src_colvars/gromacs/fileio/checkpoint.h
+@@ -220,6 +220,8 @@ enum class CheckPointVersion : int
+     MDModules,
+     //! Added checkpointing for modular simulator.
+     ModularSimulator,
++    //! Added Colvars
++    Colvars,
+     //! The total number of checkpoint versions.
+     Count,
+     //! Current version
+@@ -302,6 +304,8 @@ struct CheckpointHeaderContents
+     int nED;
+     //! Enum for coordinate swapping.
+     SwapType eSwapCoords;
++    //! Colvars
++    int ecolvars;
+     //! Whether the checkpoint was written by modular simulator.
+     bool isModularSimulatorCheckpoint = false;
+ };
+diff --git a/src/gromacs/mdlib/energyoutput.cpp b/src_colvars/gromacs/mdlib/energyoutput.cpp
+index 6c0fca5..e06e511 100644
+--- a/src/gromacs/mdlib/energyoutput.cpp
++++ b/src_colvars/gromacs/mdlib/energyoutput.cpp
+@@ -254,7 +254,7 @@ EnergyOutput::EnergyOutput(ener_file*                fp_ene,
+     bEner_[F_DISPCORR]   = (inputrec.eDispCorr != DispersionCorrectionType::No);
+     bEner_[F_DISRESVIOL] = (gmx_mtop_ftype_count(mtop, F_DISRES) > 0);
+     bEner_[F_ORIRESDEV]  = (gmx_mtop_ftype_count(mtop, F_ORIRES) > 0);
+-    bEner_[F_COM_PULL]   = ((inputrec.bPull && pull_have_potential(*pull_work)) || inputrec.bRot);
++    bEner_[F_COM_PULL]   = ((inputrec.bPull && pull_have_potential(*pull_work)) || inputrec.bRot || inputrec.bColvars);
+
+     // Check MDModules for any energy output
+     MDModulesEnergyOutputToDensityFittingRequestChecker mdModulesAddOutputToDensityFittingFieldRequest;
+diff --git a/src/gromacs/mdlib/mdoutf.cpp b/src_colvars/gromacs/mdlib/mdoutf.cpp
+index 0a8653a..b75c8b1 100644
+--- a/src/gromacs/mdlib/mdoutf.cpp
++++ b/src_colvars/gromacs/mdlib/mdoutf.cpp
+@@ -60,6 +60,7 @@
+ #include "gromacs/mdtypes/observableshistory.h"
+ #include "gromacs/mdtypes/state.h"
+ #include "gromacs/mdtypes/swaphistory.h"
++#include "gromacs/mdtypes/colvarshistory.h"
+ #include "gromacs/timing/wallcycle.h"
+ #include "gromacs/topology/topology.h"
+ #include "gromacs/utility/baseversion.h"
+@@ -353,6 +354,10 @@ static void write_checkpoint(const char*                     fn,
+     swaphistory_t* swaphist    = observablesHistory->swapHistory.get();
+     SwapType       eSwapCoords = (swaphist ? swaphist->eSwapCoords : SwapType::No);
+
++    /* COLVARS */
++    colvarshistory_t* colvarshist = observablesHistory->colvarsHistory.get();
++    int               ecolvars    = (colvarshist ? colvarshist->n_atoms : 0);
++
+     CheckpointHeaderContents headerContents = { CheckPointVersion::UnknownVersion0,
+                                                 { 0 },
+                                                 { 0 },
+@@ -381,6 +386,7 @@ static void write_checkpoint(const char*                     fn,
+                                                 0,
+                                                 nED,
+                                                 eSwapCoords,
++                                                ecolvars,
+                                                 false };
+     std::strcpy(headerContents.version, gmx_version());
+     std::strcpy(headerContents.fprog, gmx::getProgramContext().fullBinaryPath());
+diff --git a/src/gromacs/mdlib/sim_util.cpp b/src_colvars/gromacs/mdlib/sim_util.cpp
+index 5551227..a104775 100644
+--- a/src/gromacs/mdlib/sim_util.cpp
++++ b/src_colvars/gromacs/mdlib/sim_util.cpp
+@@ -122,6 +122,8 @@
+ #include "gromacs/utility/stringutil.h"
+ #include "gromacs/utility/sysinfo.h"
+
++#include "colvarproxy_gromacs.h"
++
+ #include "gpuforcereduction.h"
+
+ using gmx::ArrayRef;
+@@ -648,6 +650,16 @@ static void computeSpecialForces(FILE*                          fplog,
+      */
+     if (stepWork.computeForces)
+     {
++
++        /* COLVARS */
++        /* Colvars Module needs some updated data - just PBC & step number - before calling its ForceProvider */
++        if (inputrec.bColvars)
++        {
++            t_pbc pbc;
++            set_pbc(&pbc, inputrec.pbcType, box);
++            inputrec.colvars_proxy->update_data(cr, step, pbc, box, didNeighborSearch);
++        }
++
+         gmx::ForceProviderInput forceProviderInput(
+                 x,
+                 mdatoms->homenr,
+diff --git a/src/gromacs/mdrun/legacymdrunoptions.h b/src_colvars/gromacs/mdrun/legacymdrunoptions.h
+index 20d793e..b37d822 100644
+--- a/src/gromacs/mdrun/legacymdrunoptions.h
++++ b/src_colvars/gromacs/mdrun/legacymdrunoptions.h
+@@ -124,7 +124,9 @@ public:
+                                           { efTOP, "-mp", "membed", ffOPTRD },
+                                           { efNDX, "-mn", "membed", ffOPTRD },
+                                           { efXVG, "-if", "imdforces", ffOPTWR },
+-                                          { efXVG, "-swap", "swapions", ffOPTWR } } };
++                                          { efXVG, "-swap", "swapions", ffOPTWR },
++                                          { efDAT, "-colvars",  "colvars",   ffOPTRDMULT },     /* COLVARS */
++                                          { efDAT, "-colvars_restart", "colvars",  ffOPTRD },   /* COLVARS */}};
+
+     //! Print a warning if any force is larger than this (in kJ/mol nm).
+     real pforce = -1;
+diff --git a/src/gromacs/mdrun/replicaexchange.cpp b/src_colvars/gromacs/mdrun/replicaexchange.cpp
+index 9fa553c..9c5be82 100644
+--- a/src/gromacs/mdrun/replicaexchange.cpp
++++ b/src_colvars/gromacs/mdrun/replicaexchange.cpp
+@@ -617,6 +617,7 @@ static void exchange_state(const gmx_multisim_t* ms, int b, t_state* state)
+     exchange_doubles(ms, b, &state->baros_integral, 1);
+     exchange_rvecs(ms, b, state->x.rvec_array(), state->natoms);
+     exchange_rvecs(ms, b, state->v.rvec_array(), state->natoms);
++    exchange_rvecs(ms, b, state->xa_old_whole_colvars, state->n_colvars_atoms);
+ }
+
+ static void copy_state_serial(const t_state* src, t_state* dest)
+diff --git a/src/gromacs/mdrun/runner.cpp b/src_colvars/gromacs/mdrun/runner.cpp
+index ea7f402..d3ffd59 100644
+--- a/src/gromacs/mdrun/runner.cpp
++++ b/src_colvars/gromacs/mdrun/runner.cpp
+@@ -126,6 +126,7 @@
+ #include "gromacs/mdtypes/mdrunoptions.h"
+ #include "gromacs/mdtypes/multipletimestepping.h"
+ #include "gromacs/mdtypes/observableshistory.h"
++#include "gromacs/mdtypes/colvarshistory.h"
+ #include "gromacs/mdtypes/observablesreducer.h"
+ #include "gromacs/mdtypes/simulation_workload.h"
+ #include "gromacs/mdtypes/state.h"
+@@ -170,6 +171,8 @@
+ #include "gromacs/utility/stringutil.h"
+ #include "gromacs/utility/mpiinfo.h"
+
++#include "colvarproxy_gromacs.h"
++
+ #include "isimulator.h"
+ #include "membedholder.h"
+ #include "replicaexchange.h"
+@@ -2055,6 +2058,52 @@ int Mdrunner::mdrunner()
+                                          mdrunOptions.imdOptions,
+                                          startingBehavior);
+
++        /* COLVARS */
++        if (opt2bSet("-colvars",filenames.size(), filenames.data()))
++        {
++
++            gmx::ArrayRef<const std::string> filenames_colvars;
++            std::string filename_restart;
++            std::string prefix;
++
++            inputrec->bColvars = TRUE;
++
++            /* Retrieve filenames */
++            filenames_colvars = opt2fns("-colvars", filenames.size(), filenames.data());
++            if (opt2bSet("-colvars_restart",filenames.size(), filenames.data()))
++            {
++                filename_restart = opt2fn("-colvars_restart",filenames.size(), filenames.data());
++            }
++
++            /* Determine the prefix for the colvars output files, based on the logfile name. */
++            std::string logfile = ftp2fn(efLOG, filenames.size(), filenames.data());
++            /* 4 = ".log".length() */
++            if(logfile.length() > 4)
++            {
++                prefix = logfile.substr(0,logfile.length()-4);
++            }
++
++            inputrec->colvars_proxy =  new colvarproxy_gromacs();
++            inputrec->colvars_proxy->init(inputrec.get(),inputrec->init_step,&mtop, &observablesHistory, prefix, filenames_colvars,filename_restart, cr, MASTER(cr) ? globalState->x.rvec_array() : nullptr,
++                                          MASTER(cr) ? &globalState->xa_old_whole_colvars : nullptr, MASTER(cr) ? &globalState->n_colvars_atoms : nullptr);
++            fr->forceProviders->addForceProvider(inputrec->colvars_proxy);
++        }
++        else
++        {
++            inputrec->bColvars = FALSE;
++            if (opt2bSet("-colvars_restart",filenames.size(), filenames.data()))
++            {
++                gmx_fatal(FARGS, "-colvars_restart can only be used together with the -colvars option.");
++            }
++            if(observablesHistory.colvarsHistory) {
++                gmx_fatal(FARGS,
++                  "The checkpoint is from a run with colvars, "
++                  "but the current run did not specify the -colvars option. "
++                  "Either specify the -colvars option to mdrun, or do not use this checkpoint file.");
++            }
++        }
++
++
+         if (haveDDAtomOrdering(*cr))
+         {
+             GMX_RELEASE_ASSERT(fr, "fr was NULL while cr->duty was DUTY_PP");
+@@ -2225,6 +2274,13 @@ int Mdrunner::mdrunner()
+         releaseDevice(deviceInfo);
+     }
+
++    /* COLVARS */
++    if (inputrec->bColvars)
++    {
++        inputrec->colvars_proxy->finish(cr);
++        delete inputrec->colvars_proxy;
++    }
++
+     /* Does what it says */
+     print_date_and_time(fplog, cr->nodeid, "Finished mdrun", gmx_gettime());
+     walltime_accounting_destroy(walltime_accounting);
+diff --git a/src/gromacs/mdtypes/colvarshistory.h b/src/gromacs/mdtypes/colvarshistory.h
+new file mode 100644
+index 0000000000..6605e6fce2
+--- /dev/null
++++ b/src/gromacs/mdtypes/colvarshistory.h
+@@ -0,0 +1,20 @@
++#ifndef GMX_MDLIB_COLVARSHISTORY_H
++#define GMX_MDLIB_COLVARSHISTORY_H
++
++#include "gromacs/math/vectypes.h"
++#include "gromacs/utility/basedefinitions.h"
++
++/* Helper structure to be able to make colvars group(s) whole
++ *
++ * To also make colvars group(s) whole, we save the last whole configuration
++ * of the atoms in the checkpoint file.
++ */
++typedef struct colvarshistory_t
++{
++    gmx_bool         bFromCpt;     // Did we start from a checkpoint file?
++    int              n_atoms; // Number of colvars atoms
++    rvec*            xa_old_whole; // Last known whole positions of the colvars atoms
++    rvec*            xa_old_whole_p; // Pointer to these positions
++} colvarshistory_t;
++
++#endif
+diff --git a/src/gromacs/mdtypes/inputrec.h b/src_colvars/gromacs/mdtypes/inputrec.h
+index 922a22e..9d981ff 100644
+--- a/src/gromacs/mdtypes/inputrec.h
++++ b/src_colvars/gromacs/mdtypes/inputrec.h
+@@ -51,6 +51,8 @@ struct gmx_enfrot;
+ struct gmx_enfrotgrp;
+ struct pull_params_t;
+
++class colvarproxy_gromacs;
++
+ namespace gmx
+ {
+ class Awh;
+@@ -577,6 +579,10 @@ struct t_inputrec // NOLINT (clang-analyzer-optin.performance.Padding)
+
+     //! KVT for storing simulation parameters that are not part of the mdp file.
+     std::unique_ptr<gmx::KeyValueTreeObject> internalParameters;
++
++    /* COLVARS */
++    bool                bColvars;       /* Do we do colvars calculations ? */
++    colvarproxy_gromacs     *colvars_proxy; /* The object for the colvars calculations */
+ };
+
+ int ir_optimal_nstcalcenergy(const t_inputrec* ir);
+diff --git a/src/gromacs/mdtypes/observableshistory.cpp b/src_colvars/gromacs/mdtypes/observableshistory.cpp
+index 12230ee..13f5df1 100644
+--- a/src/gromacs/mdtypes/observableshistory.cpp
++++ b/src_colvars/gromacs/mdtypes/observableshistory.cpp
+@@ -40,6 +40,7 @@
+ #include "gromacs/mdtypes/energyhistory.h"
+ #include "gromacs/mdtypes/pullhistory.h"
+ #include "gromacs/mdtypes/swaphistory.h"
++#include "gromacs/mdtypes/colvarshistory.h"
+
+ ObservablesHistory::ObservablesHistory()  = default;
+ ObservablesHistory::~ObservablesHistory() = default;
+diff --git a/src/gromacs/mdtypes/observableshistory.h b/src_colvars/gromacs/mdtypes/observableshistory.h
+index 6ed0e3f..172ead0 100644
+--- a/src/gromacs/mdtypes/observableshistory.h
++++ b/src_colvars/gromacs/mdtypes/observableshistory.h
+@@ -58,6 +58,7 @@ class energyhistory_t;
+ class PullHistory;
+ struct edsamhistory_t;
+ struct swaphistory_t;
++struct colvarshistory_t;
+
+ /*! \libinternal \brief Observables history, for writing/reading to/from checkpoint file
+  */
+@@ -75,6 +76,9 @@ struct ObservablesHistory
+     //! Ion/water position swapping history
+     std::unique_ptr<swaphistory_t> swapHistory;
+
++    //! Colvars
++    std::unique_ptr<colvarshistory_t> colvarsHistory;
++
+     ObservablesHistory();
+
+     ~ObservablesHistory();
+diff --git a/src/gromacs/mdtypes/state.cpp b/src_colvars/gromacs/mdtypes/state.cpp
+index 99b315e..d49a386 100644
+--- a/src/gromacs/mdtypes/state.cpp
++++ b/src_colvars/gromacs/mdtypes/state.cpp
+@@ -369,7 +369,9 @@ t_state::t_state() :
+     dfhist(nullptr),
+     awhHistory(nullptr),
+     ddp_count(0),
+-    ddp_count_cg_gl(0)
++    ddp_count_cg_gl(0),
++    xa_old_whole_colvars(nullptr),
++    n_colvars_atoms(0)
+
+ {
+     // It would be nicer to initialize these with {} or {{0}} in the
+diff --git a/src/gromacs/mdtypes/state.h b/src_colvars/gromacs/mdtypes/state.h
+index 579e343..725e841 100644
+--- a/src/gromacs/mdtypes/state.h
++++ b/src_colvars/gromacs/mdtypes/state.h
+@@ -282,6 +282,9 @@ public:
+     std::vector<int> cg_gl;           //!< The global cg number of the local cgs
+
+     std::vector<double> pull_com_prev_step; //!< The COM of the previous step of each pull group
++
++    int      n_colvars_atoms; //!< number of colvars atoms
++    rvec*    xa_old_whole_colvars; //!< last whole positions of colvars atoms
+ };
+
+ #ifndef DOXYGEN
+diff --git a/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml b/src_colvars/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
+index c2973bb..cb4d1da 100644
+--- a/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
++++ b/src_colvars/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
+@@ -6,7 +6,8 @@
+ gmx [-s [&lt;.tpr&gt;]] [-cpi [&lt;.cpt&gt;]] [-table [&lt;.xvg&gt;]] [-tablep [&lt;.xvg&gt;]]
+     [-tableb [&lt;.xvg&gt; [...]]] [-rerun [&lt;.xtc/.trr/...&gt;]] [-ei [&lt;.edi&gt;]]
+     [-multidir [&lt;dir&gt; [...]]] [-awh [&lt;.xvg&gt;]] [-membed [&lt;.dat&gt;]]
+-    [-mp [&lt;.top&gt;]] [-mn [&lt;.ndx&gt;]] [-o [&lt;.trr/.cpt/...&gt;]] [-x [&lt;.xtc/.tng&gt;]]
++    [-mp [&lt;.top&gt;]] [-mn [&lt;.ndx&gt;]] [-colvars [&lt;.dat&gt; [...]]]
++    [-colvars_restart [&lt;.dat&gt;]] [-o [&lt;.trr/.cpt/...&gt;]] [-x [&lt;.xtc/.tng&gt;]]
+     [-cpo [&lt;.cpt&gt;]] [-c [&lt;.gro/.g96/...&gt;]] [-e [&lt;.edr&gt;]] [-g [&lt;.log&gt;]]
+     [-dhdl [&lt;.xvg&gt;]] [-field [&lt;.xvg&gt;]] [-tpi [&lt;.xvg&gt;]] [-tpid [&lt;.xvg&gt;]]
+     [-eo [&lt;.xvg&gt;]] [-px [&lt;.xvg&gt;]] [-pf [&lt;.xvg&gt;]] [-ro [&lt;.xvg&gt;]]
+@@ -163,6 +164,10 @@ Options to specify input files:
+            Topology file
+  -mn     [&lt;.ndx&gt;]           (membed.ndx)     (Opt.)
+            Index file
++ -colvars [&lt;.dat&gt; [...]]    (colvars.dat)    (Opt.)
++           Generic data file
++ -colvars_restart [&lt;.dat&gt;]  (colvars.dat)    (Opt.)
++           Generic data file
+
+ Options to specify output files:
+

--- a/gromacs/gromacs-2022.x.patch
+++ b/gromacs/gromacs-2022.x.patch
@@ -38,6 +38,18 @@ index 99cc804..40fbe29 100644
  if (TARGET Heffte::Heffte)
      target_link_libraries(libgromacs PRIVATE Heffte::Heffte)
  endif()
+diff --git a/src/gromacs/applied_forces/CMakeLists.txt b/src_colvars/gromacs/applied_forces/CMakeLists.txt
+index 34114cd..b469541 100644
+--- a/src/gromacs/applied_forces/CMakeLists.txt
++++ b/src_colvars/gromacs/applied_forces/CMakeLists.txt
+@@ -73,6 +73,7 @@ gmx_add_libgromacs_sources(
+ add_subdirectory(awh)
+ add_subdirectory(densityfitting)
+ add_subdirectory(qmmm)
++add_subdirectory(colvarproxy)
+
+ if (BUILD_TESTING)
+     add_subdirectory(tests)
 diff --git a/src/gromacs/fileio/checkpoint.cpp b/src_colvars/gromacs/fileio/checkpoint.cpp
 index f6764a1..279953d 100644
 --- a/src/gromacs/fileio/checkpoint.cpp
@@ -229,7 +241,7 @@ index 5551227..a104775 100644
  #include "gromacs/utility/stringutil.h"
  #include "gromacs/utility/sysinfo.h"
 
-+#include "colvarproxy_gromacs.h"
++#include "gromacs/applied_forces/colvarproxy/colvarproxy_gromacs.h"
 +
  #include "gpuforcereduction.h"
 
@@ -294,7 +306,7 @@ index ea7f402..d3ffd59 100644
  #include "gromacs/utility/stringutil.h"
  #include "gromacs/utility/mpiinfo.h"
 
-+#include "colvarproxy_gromacs.h"
++#include "gromacs/applied_forces/colvarproxy/colvarproxy_gromacs.h"
 +
  #include "isimulator.h"
  #include "membedholder.h"
@@ -329,7 +341,7 @@ index ea7f402..d3ffd59 100644
 +            }
 +
 +            inputrec->colvars_proxy =  new colvarproxy_gromacs();
-+            inputrec->colvars_proxy->init(inputrec.get(),inputrec->init_step,&mtop, &observablesHistory, prefix, filenames_colvars,filename_restart, cr, MASTER(cr) ? globalState->x.rvec_array() : nullptr,
++            inputrec->colvars_proxy->init(inputrec.get(),inputrec->init_step,mtop, &observablesHistory, prefix, filenames_colvars,filename_restart, cr, MASTER(cr) ? globalState->x.rvec_array() : nullptr,
 +                                          MASTER(cr) ? &globalState->xa_old_whole_colvars : nullptr, MASTER(cr) ? &globalState->n_colvars_atoms : nullptr);
 +            fr->forceProviders->addForceProvider(inputrec->colvars_proxy);
 +        }

--- a/gromacs/gromacs-2022.x.patch
+++ b/gromacs/gromacs-2022.x.patch
@@ -13,10 +13,10 @@ index cd748c9..31e3b62 100644
  ##################################################
  # Process SIMD instruction settings
  ##################################################
-diff --git a/src/gromacs/CMakeLists.txt b/src_colvars/gromacs/CMakeLists.txt
+diff --git a/src/gromacs/CMakeLists.txt b/src/gromacs/CMakeLists.txt
 index 99cc804..40fbe29 100644
 --- a/src/gromacs/CMakeLists.txt
-+++ b/src_colvars/gromacs/CMakeLists.txt
++++ b/src/gromacs/CMakeLists.txt
 @@ -139,6 +139,11 @@ if (WIN32)
  endif()
  list(APPEND libgromacs_object_library_dependencies thread_mpi)
@@ -38,10 +38,10 @@ index 99cc804..40fbe29 100644
  if (TARGET Heffte::Heffte)
      target_link_libraries(libgromacs PRIVATE Heffte::Heffte)
  endif()
-diff --git a/src/gromacs/applied_forces/CMakeLists.txt b/src_colvars/gromacs/applied_forces/CMakeLists.txt
+diff --git a/src/gromacs/applied_forces/CMakeLists.txt b/src/gromacs/applied_forces/CMakeLists.txt
 index 34114cd..b469541 100644
 --- a/src/gromacs/applied_forces/CMakeLists.txt
-+++ b/src_colvars/gromacs/applied_forces/CMakeLists.txt
++++ b/src/gromacs/applied_forces/CMakeLists.txt
 @@ -73,6 +73,7 @@ gmx_add_libgromacs_sources(
  add_subdirectory(awh)
  add_subdirectory(densityfitting)
@@ -50,10 +50,10 @@ index 34114cd..b469541 100644
 
  if (BUILD_TESTING)
      add_subdirectory(tests)
-diff --git a/src/gromacs/fileio/checkpoint.cpp b/src_colvars/gromacs/fileio/checkpoint.cpp
+diff --git a/src/gromacs/fileio/checkpoint.cpp b/src/gromacs/fileio/checkpoint.cpp
 index f6764a1..279953d 100644
 --- a/src/gromacs/fileio/checkpoint.cpp
-+++ b/src_colvars/gromacs/fileio/checkpoint.cpp
++++ b/src/gromacs/fileio/checkpoint.cpp
 @@ -69,6 +69,7 @@
  #include "gromacs/mdtypes/pullhistory.h"
  #include "gromacs/mdtypes/state.h"
@@ -167,10 +167,10 @@ index f6764a1..279953d 100644
      if (ret == 0)
      {
          std::vector<gmx_file_position_t> outputfiles;
-diff --git a/src/gromacs/fileio/checkpoint.h b/src_colvars/gromacs/fileio/checkpoint.h
+diff --git a/src/gromacs/fileio/checkpoint.h b/src/gromacs/fileio/checkpoint.h
 index 5145e1d..3054462 100644
 --- a/src/gromacs/fileio/checkpoint.h
-+++ b/src_colvars/gromacs/fileio/checkpoint.h
++++ b/src/gromacs/fileio/checkpoint.h
 @@ -220,6 +220,8 @@ enum class CheckPointVersion : int
      MDModules,
      //! Added checkpointing for modular simulator.
@@ -189,10 +189,10 @@ index 5145e1d..3054462 100644
      //! Whether the checkpoint was written by modular simulator.
      bool isModularSimulatorCheckpoint = false;
  };
-diff --git a/src/gromacs/mdlib/energyoutput.cpp b/src_colvars/gromacs/mdlib/energyoutput.cpp
+diff --git a/src/gromacs/mdlib/energyoutput.cpp b/src/gromacs/mdlib/energyoutput.cpp
 index 6c0fca5..e06e511 100644
 --- a/src/gromacs/mdlib/energyoutput.cpp
-+++ b/src_colvars/gromacs/mdlib/energyoutput.cpp
++++ b/src/gromacs/mdlib/energyoutput.cpp
 @@ -254,7 +254,7 @@ EnergyOutput::EnergyOutput(ener_file*                fp_ene,
      bEner_[F_DISPCORR]   = (inputrec.eDispCorr != DispersionCorrectionType::No);
      bEner_[F_DISRESVIOL] = (gmx_mtop_ftype_count(mtop, F_DISRES) > 0);
@@ -202,10 +202,10 @@ index 6c0fca5..e06e511 100644
 
      // Check MDModules for any energy output
      MDModulesEnergyOutputToDensityFittingRequestChecker mdModulesAddOutputToDensityFittingFieldRequest;
-diff --git a/src/gromacs/mdlib/mdoutf.cpp b/src_colvars/gromacs/mdlib/mdoutf.cpp
+diff --git a/src/gromacs/mdlib/mdoutf.cpp b/src/gromacs/mdlib/mdoutf.cpp
 index 0a8653a..b75c8b1 100644
 --- a/src/gromacs/mdlib/mdoutf.cpp
-+++ b/src_colvars/gromacs/mdlib/mdoutf.cpp
++++ b/src/gromacs/mdlib/mdoutf.cpp
 @@ -60,6 +60,7 @@
  #include "gromacs/mdtypes/observableshistory.h"
  #include "gromacs/mdtypes/state.h"
@@ -233,10 +233,10 @@ index 0a8653a..b75c8b1 100644
                                                  false };
      std::strcpy(headerContents.version, gmx_version());
      std::strcpy(headerContents.fprog, gmx::getProgramContext().fullBinaryPath());
-diff --git a/src/gromacs/mdlib/sim_util.cpp b/src_colvars/gromacs/mdlib/sim_util.cpp
+diff --git a/src/gromacs/mdlib/sim_util.cpp b/src/gromacs/mdlib/sim_util.cpp
 index 5551227..a104775 100644
 --- a/src/gromacs/mdlib/sim_util.cpp
-+++ b/src_colvars/gromacs/mdlib/sim_util.cpp
++++ b/src/gromacs/mdlib/sim_util.cpp
 @@ -122,6 +122,8 @@
  #include "gromacs/utility/stringutil.h"
  #include "gromacs/utility/sysinfo.h"
@@ -263,10 +263,10 @@ index 5551227..a104775 100644
          gmx::ForceProviderInput forceProviderInput(
                  x,
                  mdatoms->homenr,
-diff --git a/src/gromacs/mdrun/legacymdrunoptions.h b/src_colvars/gromacs/mdrun/legacymdrunoptions.h
+diff --git a/src/gromacs/mdrun/legacymdrunoptions.h b/src/gromacs/mdrun/legacymdrunoptions.h
 index 20d793e..b37d822 100644
 --- a/src/gromacs/mdrun/legacymdrunoptions.h
-+++ b/src_colvars/gromacs/mdrun/legacymdrunoptions.h
++++ b/src/gromacs/mdrun/legacymdrunoptions.h
 @@ -124,7 +124,9 @@ public:
                                            { efTOP, "-mp", "membed", ffOPTRD },
                                            { efNDX, "-mn", "membed", ffOPTRD },
@@ -278,10 +278,10 @@ index 20d793e..b37d822 100644
 
      //! Print a warning if any force is larger than this (in kJ/mol nm).
      real pforce = -1;
-diff --git a/src/gromacs/mdrun/replicaexchange.cpp b/src_colvars/gromacs/mdrun/replicaexchange.cpp
+diff --git a/src/gromacs/mdrun/replicaexchange.cpp b/src/gromacs/mdrun/replicaexchange.cpp
 index 9fa553c..9c5be82 100644
 --- a/src/gromacs/mdrun/replicaexchange.cpp
-+++ b/src_colvars/gromacs/mdrun/replicaexchange.cpp
++++ b/src/gromacs/mdrun/replicaexchange.cpp
 @@ -617,6 +617,7 @@ static void exchange_state(const gmx_multisim_t* ms, int b, t_state* state)
      exchange_doubles(ms, b, &state->baros_integral, 1);
      exchange_rvecs(ms, b, state->x.rvec_array(), state->natoms);
@@ -290,10 +290,10 @@ index 9fa553c..9c5be82 100644
  }
 
  static void copy_state_serial(const t_state* src, t_state* dest)
-diff --git a/src/gromacs/mdrun/runner.cpp b/src_colvars/gromacs/mdrun/runner.cpp
+diff --git a/src/gromacs/mdrun/runner.cpp b/src/gromacs/mdrun/runner.cpp
 index ea7f402..d3ffd59 100644
 --- a/src/gromacs/mdrun/runner.cpp
-+++ b/src_colvars/gromacs/mdrun/runner.cpp
++++ b/src/gromacs/mdrun/runner.cpp
 @@ -126,6 +126,7 @@
  #include "gromacs/mdtypes/mdrunoptions.h"
  #include "gromacs/mdtypes/multipletimestepping.h"
@@ -404,10 +404,10 @@ index 0000000000..6605e6fce2
 +} colvarshistory_t;
 +
 +#endif
-diff --git a/src/gromacs/mdtypes/inputrec.h b/src_colvars/gromacs/mdtypes/inputrec.h
+diff --git a/src/gromacs/mdtypes/inputrec.h b/src/gromacs/mdtypes/inputrec.h
 index 922a22e..9d981ff 100644
 --- a/src/gromacs/mdtypes/inputrec.h
-+++ b/src_colvars/gromacs/mdtypes/inputrec.h
++++ b/src/gromacs/mdtypes/inputrec.h
 @@ -51,6 +51,8 @@ struct gmx_enfrot;
  struct gmx_enfrotgrp;
  struct pull_params_t;
@@ -428,10 +428,10 @@ index 922a22e..9d981ff 100644
  };
 
  int ir_optimal_nstcalcenergy(const t_inputrec* ir);
-diff --git a/src/gromacs/mdtypes/observableshistory.cpp b/src_colvars/gromacs/mdtypes/observableshistory.cpp
+diff --git a/src/gromacs/mdtypes/observableshistory.cpp b/src/gromacs/mdtypes/observableshistory.cpp
 index 12230ee..13f5df1 100644
 --- a/src/gromacs/mdtypes/observableshistory.cpp
-+++ b/src_colvars/gromacs/mdtypes/observableshistory.cpp
++++ b/src/gromacs/mdtypes/observableshistory.cpp
 @@ -40,6 +40,7 @@
  #include "gromacs/mdtypes/energyhistory.h"
  #include "gromacs/mdtypes/pullhistory.h"
@@ -440,10 +440,10 @@ index 12230ee..13f5df1 100644
 
  ObservablesHistory::ObservablesHistory()  = default;
  ObservablesHistory::~ObservablesHistory() = default;
-diff --git a/src/gromacs/mdtypes/observableshistory.h b/src_colvars/gromacs/mdtypes/observableshistory.h
+diff --git a/src/gromacs/mdtypes/observableshistory.h b/src/gromacs/mdtypes/observableshistory.h
 index 6ed0e3f..172ead0 100644
 --- a/src/gromacs/mdtypes/observableshistory.h
-+++ b/src_colvars/gromacs/mdtypes/observableshistory.h
++++ b/src/gromacs/mdtypes/observableshistory.h
 @@ -58,6 +58,7 @@ class energyhistory_t;
  class PullHistory;
  struct edsamhistory_t;
@@ -462,10 +462,10 @@ index 6ed0e3f..172ead0 100644
      ObservablesHistory();
 
      ~ObservablesHistory();
-diff --git a/src/gromacs/mdtypes/state.cpp b/src_colvars/gromacs/mdtypes/state.cpp
+diff --git a/src/gromacs/mdtypes/state.cpp b/src/gromacs/mdtypes/state.cpp
 index 99b315e..d49a386 100644
 --- a/src/gromacs/mdtypes/state.cpp
-+++ b/src_colvars/gromacs/mdtypes/state.cpp
++++ b/src/gromacs/mdtypes/state.cpp
 @@ -369,7 +369,9 @@ t_state::t_state() :
      dfhist(nullptr),
      awhHistory(nullptr),
@@ -477,10 +477,10 @@ index 99b315e..d49a386 100644
 
  {
      // It would be nicer to initialize these with {} or {{0}} in the
-diff --git a/src/gromacs/mdtypes/state.h b/src_colvars/gromacs/mdtypes/state.h
+diff --git a/src/gromacs/mdtypes/state.h b/src/gromacs/mdtypes/state.h
 index 579e343..725e841 100644
 --- a/src/gromacs/mdtypes/state.h
-+++ b/src_colvars/gromacs/mdtypes/state.h
++++ b/src/gromacs/mdtypes/state.h
 @@ -282,6 +282,9 @@ public:
      std::vector<int> cg_gl;           //!< The global cg number of the local cgs
 
@@ -491,10 +491,10 @@ index 579e343..725e841 100644
  };
 
  #ifndef DOXYGEN
-diff --git a/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml b/src_colvars/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
+diff --git a/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml b/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
 index c2973bb..cb4d1da 100644
 --- a/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
-+++ b/src_colvars/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
++++ b/src/programs/mdrun/tests/refdata/MdrunTest_WritesHelp.xml
 @@ -6,7 +6,8 @@
  gmx [-s [&lt;.tpr&gt;]] [-cpi [&lt;.cpt&gt;]] [-table [&lt;.xvg&gt;]] [-tablep [&lt;.xvg&gt;]]
      [-tableb [&lt;.xvg&gt; [...]]] [-rerun [&lt;.xtc/.trr/...&gt;]] [-ei [&lt;.edi&gt;]]

--- a/gromacs/gromacs-2022.x.patch
+++ b/gromacs/gromacs-2022.x.patch
@@ -46,7 +46,7 @@ index 34114cd..b469541 100644
  add_subdirectory(awh)
  add_subdirectory(densityfitting)
  add_subdirectory(qmmm)
-+add_subdirectory(colvarproxy)
++add_subdirectory(colvars)
 
  if (BUILD_TESTING)
      add_subdirectory(tests)
@@ -241,7 +241,7 @@ index 5551227..a104775 100644
  #include "gromacs/utility/stringutil.h"
  #include "gromacs/utility/sysinfo.h"
 
-+#include "gromacs/applied_forces/colvarproxy/colvarproxy_gromacs.h"
++#include "gromacs/applied_forces/colvars/colvarproxy_gromacs.h"
 +
  #include "gpuforcereduction.h"
 
@@ -306,7 +306,7 @@ index ea7f402..d3ffd59 100644
  #include "gromacs/utility/stringutil.h"
  #include "gromacs/utility/mpiinfo.h"
 
-+#include "gromacs/applied_forces/colvarproxy/colvarproxy_gromacs.h"
++#include "gromacs/applied_forces/colvars/colvarproxy_gromacs.h"
 +
  #include "isimulator.h"
  #include "membedholder.h"

--- a/gromacs/gromacs-2022.x/CMakeLists.txt
+++ b/gromacs/gromacs-2022.x/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# This file is part of the GROMACS molecular simulation package.
+#
+# Copyright 2014- The GROMACS Authors
+# and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+# Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+#
+# GROMACS is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# GROMACS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with GROMACS; if not, see
+# https://www.gnu.org/licenses, or write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+#
+# If you want to redistribute modifications to GROMACS, please
+# consider that scientific software is very special. Version
+# control is crucial - bugs must be traceable. We will be happy to
+# consider code for inclusion in the official distribution, but
+# derived work must not be called official GROMACS. Details are found
+# in the README & COPYING files - if they are missing, get the
+# official version at https://www.gromacs.org.
+#
+# To help us fund GROMACS development, we humbly ask that you cite
+# the research papers on the package. Check out https://www.gromacs.org.
+
+gmx_add_libgromacs_sources(colvarproxy_gromacs.cpp)
+

--- a/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
@@ -1,0 +1,592 @@
+/// -*- c++ -*-
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cerrno>
+
+
+#include "gromacs/mdtypes/inputrec.h"
+#include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/mdtypes/enerdata.h"
+#include "gromacs/pbcutil/pbc.h"
+#include "gromacs/utility/fatalerror.h"
+#include "gromacs/utility/futil.h"
+#include "colvarproxy_gromacs.h"
+#include "gromacs/mdtypes/commrec.h"
+#include "gromacs/domdec/domdec_struct.h"
+#include "gromacs/gmxlib/network.h"
+#include "gromacs/domdec/ga2la.h"
+#include "gromacs/mdtypes/colvarshistory.h"
+#include "gromacs/topology/ifunc.h"
+#include "gromacs/topology/mtop_util.h"
+#include "gromacs/mdlib/broadcaststructs.h"
+
+//************************************************************
+// colvarproxy_gromacs
+colvarproxy_gromacs::colvarproxy_gromacs() : colvarproxy() {}
+
+// Colvars Initialization
+void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step, const gmx_mtop_t &mtop,
+                               ObservablesHistory* oh,
+                               const std::string &prefix,
+                               gmx::ArrayRef<const std::string> filenames_config,
+                               const std::string &filename_restart,
+                               const t_commrec *cr,
+                               const rvec x[],
+                               rvec **xa_old_whole_colvars_state_p,
+                               int *n_colvars_atoms_state_p) {
+
+
+  // Initialize colvars.
+  first_timestep = true;
+  restart_frequency_s = 0;
+
+  // User-scripted forces are not available in GROMACS
+  have_scripts = false;
+
+  angstrom_value = 0.1;
+
+  // Get the thermostat temperature.
+  // NOTE: Considers only the first temperature coupling group!
+  thermostat_temperature = ir->opts.ref_t[0];
+
+  // GROMACS random number generation.
+  // Seed with the mdp parameter ld_seed, the Langevin dynamics seed.
+  rng.seed(ir->ld_seed);
+
+  /// Handle input filenames and prefix/suffix for colvars files.
+  ///
+  /// filename_config is the colvars configuration file collected from "-colvars" option.
+  /// The output prefix will be the prefix of Gromacs log filename.
+  /// or "output" otherwise.
+  ///
+  /// For restart, 'filename_restart' is the colvars input file for restart,
+  /// set by the "-cv_restart" option. It will be NULL otherwise.
+  ///
+
+  if(!prefix.empty())
+  {
+    output_prefix_str = prefix;
+  }
+  else {
+    output_prefix_str = "output";
+  }
+
+  restart_output_prefix_str = prefix + ".restart";
+
+  colvars_restart = false;
+
+  if(!filename_restart.empty())
+  {
+    colvars_restart = true;
+    input_prefix_str = filename_restart;
+    input_prefix_str.erase(input_prefix_str.rfind(".dat"));
+    input_prefix_str.erase(input_prefix_str.rfind(".colvars.state"));
+  }
+
+  // Retrieve masses and charges from input file
+  updated_masses_ = updated_charges_ = true;
+
+  // GROMACS timestep
+  timestep = ir->delta_t;
+  // Retrieve the topology of all atoms
+  gmx_atoms = gmx_mtop_global_atoms(mtop);
+
+  // Read configuration file and set up the proxy only on the master node.
+  if (MASTER(cr))
+  {
+
+    // initiate module: this object will be the communication proxy
+    // colvarmodule pointer is only defined on the Master due to the static pointer to colvarproxy.
+    colvars = new colvarmodule(this);
+
+    version_int = get_version_from_string(COLVARPROXY_VERSION);
+
+    colvars->cite_feature("GROMACS engine");
+    colvars->cite_feature("Colvars-GROMACS interface");
+
+    if (cvm::debug()) {
+      log("Initializing the colvars proxy object.\n");
+    }
+
+    cvm::log("Using GROMACS interface, version "+
+      cvm::to_str(COLVARPROXY_VERSION)+".\n");
+
+    auto i = filenames_config.begin();
+    for(; i != filenames_config.end(); ++i) {
+        colvars->read_config_file(i->c_str());
+    }
+
+
+    colvars->setup();
+    colvars->setup_input();
+
+    // Citation Reporter
+    cvm::log(std::string("\n")+colvars->feature_report(0)+std::string("\n"));
+
+    colvars->setup_output();
+
+    if (step != 0) {
+      cvm::log("Initializing step number to "+cvm::to_str(step)+".\n");
+    }
+
+    colvars->it = colvars->it_restart = step;
+
+
+  } // end master
+
+
+  // MPI initialisation
+
+  // Initialise attributs for the MPI communication
+  if(MASTER(cr)) {
+    // Retrieve the number of colvar atoms
+    n_colvars_atoms = atoms_ids.size();
+    // Copy their global indices
+    ind = atoms_ids.data(); // This has to be updated if the vector is reallocated
+  }
+
+
+  if(PAR(cr)) {
+    // Let the other nodes know the number of colvar atoms.
+    block_bc(cr->mpi_comm_mygroup, n_colvars_atoms);
+
+    // Initialise atoms_new_colvar_forces on non-master nodes
+    if(!MASTER(cr)) {
+      atoms_new_colvar_forces.reserve(n_colvars_atoms);
+    }
+  }
+
+  snew(x_colvars_unwrapped,         n_colvars_atoms);
+  snew(xa_ind,       n_colvars_atoms);
+  snew(xa_shifts,    n_colvars_atoms);
+  snew(xa_eshifts,   n_colvars_atoms);
+  snew(xa_old_whole, n_colvars_atoms);
+  snew(f_colvars,    n_colvars_atoms);
+
+  // Prepare data
+
+  // Manage restart with .cpt
+  if (MASTER(cr))
+  {
+      /* colvarsHistory is the struct holding the data saved in the cpt
+
+       If we dont start with from a .cpt, prepare the colvarsHistory struct for proper .cpt writing,
+       If we did start from .cpt, we copy over the last whole structures from .cpt,
+       In any case, for subsequent checkpoint writing, we set the pointers (xa_old_whole_p) in
+       the xa_old_whole arrays, which contain the correct PBC representation of
+       colvars atoms at the last time step.
+      */
+
+      if (oh->colvarsHistory == nullptr)
+      {
+          oh->colvarsHistory = std::make_unique<colvarshistory_t>(colvarshistory_t{});
+      }
+      colvarshistory_t *colvarshist = oh->colvarsHistory.get();
+
+
+      snew(colvarshist->xa_old_whole_p, n_colvars_atoms);
+
+      /* We always need the last whole positions such that
+      * in the next time step we can make the colvars atoms whole again in PBC */
+      if (colvarshist->bFromCpt)
+      {
+          for (int i = 0; i < n_colvars_atoms; i++)
+            {
+                copy_rvec(colvarshist->xa_old_whole[i], xa_old_whole[i]);
+            }
+      }
+      else
+      {
+          colvarshist->n_atoms = n_colvars_atoms;
+          for (int i = 0; i < n_colvars_atoms; i++)
+          {
+              int ii = ind[i];
+              copy_rvec(x[ii], xa_old_whole[i]);
+          }
+      }
+
+      /* For subsequent checkpoint writing, set the pointers (xa_old_whole_p) to the xa_old_whole
+      * arrays that get updated at every NS step */
+      colvarshist->xa_old_whole_p = xa_old_whole;
+      //Initialize number of colvars atoms from the global state
+      *n_colvars_atoms_state_p = n_colvars_atoms;
+      // Point the shifts array from the  global state to the local shifts array
+      *xa_old_whole_colvars_state_p = xa_old_whole;
+  }
+
+
+  // Communicate initial coordinates and global indices to all processes
+  if (PAR(cr))
+  {
+    nblock_bc(cr->mpi_comm_mygroup, n_colvars_atoms, xa_old_whole);
+    snew_bc(MASTER(cr), ind, n_colvars_atoms);
+    nblock_bc(cr->mpi_comm_mygroup, n_colvars_atoms, ind);
+  }
+
+  // Serial Run
+  if (!PAR(cr))
+  {
+    nat_loc = n_colvars_atoms;
+    nalloc_loc = n_colvars_atoms;
+    ind_loc = ind;
+
+    // xa_ind[i] needs to be set to i for serial runs
+    for (int i = 0; i < n_colvars_atoms; i++)
+    {
+        xa_ind[i] = i;
+    }
+  }
+
+  if (MASTER(cr) && cvm::debug()) {
+    cvm::log ("atoms_ids = "+cvm::to_str (atoms_ids)+"\n");
+    cvm::log ("atoms_ncopies = "+cvm::to_str (atoms_ncopies)+"\n");
+    cvm::log ("positions = "+cvm::to_str (atoms_positions)+"\n");
+    cvm::log ("atoms_new_colvar_forces = "+cvm::to_str (atoms_new_colvar_forces)+"\n");
+    cvm::log (cvm::line_marker);
+    log("done initializing the colvars proxy object.\n");
+  }
+
+
+} // End colvars initialization.
+
+
+colvarproxy_gromacs::~colvarproxy_gromacs()
+{}
+
+void colvarproxy_gromacs::finish(const t_commrec *cr)
+{
+  if(MASTER(cr)) {
+    colvars->write_restart_file(output_prefix_str+".colvars.state");
+    colvars->write_output_files();
+  }
+}
+
+void colvarproxy_gromacs::set_temper(double temper)
+{
+  thermostat_temperature = temper;
+}
+
+// GROMACS uses nanometers and kJ/mol internally
+cvm::real colvarproxy_gromacs::backend_angstrom_value() { return 0.1; }
+
+// From Gnu units
+// $ units -ts 'k' 'kJ/mol/K/avogadro'
+// 0.0083144621
+cvm::real colvarproxy_gromacs::boltzmann() { return 0.0083144621; }
+
+// Temperature of the simulation (K)
+cvm::real colvarproxy_gromacs::temperature()
+{
+  return thermostat_temperature;
+}
+
+// Time step of the simulation (fs)
+// GROMACS uses picoseconds.
+cvm::real colvarproxy_gromacs::dt() { return 1000.0*timestep; }
+
+cvm::real colvarproxy_gromacs::rand_gaussian()
+{
+  return  normal_distribution(rng);
+}
+
+size_t colvarproxy_gromacs::restart_frequency()
+{
+  return restart_frequency_s;
+}
+
+// **************** PERIODIC BOUNDARY CONDITIONS ****************
+//  Get the PBC-aware distance vector between two positions
+cvm::rvector colvarproxy_gromacs::position_distance (cvm::atom_pos const &pos1,
+                                                     cvm::atom_pos const &pos2) const
+{
+  rvec r1, r2, dr;
+  r1[0] = pos1.x;
+  r1[1] = pos1.y;
+  r1[2] = pos1.z;
+  r2[0] = pos2.x;
+  r2[1] = pos2.y;
+  r2[2] = pos2.z;
+
+  pbc_dx(&gmx_pbc, r2, r1, dr);
+  return cvm::atom_pos( dr[0], dr[1], dr[2] );
+}
+
+
+void colvarproxy_gromacs::log (std::string const &message)
+{
+  std::istringstream is(message);
+  std::string line;
+  while (std::getline(is, line))
+    // Gromacs prints messages on the stderr FILE
+    fprintf(stderr, "colvars: %s\n", line.c_str());
+}
+
+void colvarproxy_gromacs::error (std::string const &message)
+{
+  // In GROMACS, all errors are fatal.
+  fatal_error (message);
+}
+
+void colvarproxy_gromacs::fatal_error (std::string const &message)
+{
+  log(message);
+  if (!cvm::debug())
+    log("If this error message is unclear, "
+	"try recompiling with -DCOLVARS_DEBUG.\n");
+  gmx_fatal(FARGS,"Error in collective variables module.\n");
+}
+
+void colvarproxy_gromacs::exit (std::string const gmx_unused &message)
+{
+  gmx_fatal(FARGS,"SUCCESS: %s\n", message.c_str());
+}
+
+int colvarproxy_gromacs::load_atoms (char const gmx_unused *filename, std::vector<cvm::atom> gmx_unused &atoms,
+                                     std::string const gmx_unused &pdb_field, double const gmx_unused pdb_field_value)
+{
+  cvm::error("Selecting collective variable atoms "
+		   "from a PDB file is currently not supported.\n");
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+int colvarproxy_gromacs::load_coords (char const gmx_unused *filename, std::vector<cvm::atom_pos> gmx_unused &pos,
+                                      const std::vector<int> gmx_unused &indices, std::string const gmx_unused &pdb_field_str,
+                                      double const gmx_unused pdb_field_value)
+{
+  cvm::error("Selecting collective variable atoms "
+		   "from a PDB file is currently not supported.\n");
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+int colvarproxy_gromacs::set_unit_system(std::string const &units_in, bool /*colvars_defined*/)
+{
+  if (units_in != "gromacs") {
+    cvm::error("Specified unit system \"" + units_in + "\" is unsupported in Gromacs. Supported units are \"gromacs\" (nm, kJ/mol).\n");
+    return COLVARS_ERROR;
+  }
+  return COLVARS_OK;
+}
+
+int colvarproxy_gromacs::backup_file (char const *filename)
+{
+  // Incremental gromacs backup system will be use only for those file
+  if (std::string(filename).rfind(std::string(".colvars.traj")) != std::string::npos) {
+
+    // GROMACS function
+    make_backup(filename);
+
+  // Otherwise, just keep one backup.
+  } else {
+
+    //Handle filename of the backup file
+    const char *extension = ".old";
+    char *backup = new char[strlen(filename)+strlen(extension)+1];
+    strcpy(backup, filename);
+    strcat(backup, extension);
+
+    gmx_file_copy(filename, backup, FALSE);
+
+    delete [] backup;
+
+  }
+  return COLVARS_OK;
+}
+
+
+void colvarproxy_gromacs::update_data(const t_commrec *cr, int64_t const step, t_pbc const &pbc, const matrix box, bool bNS)
+{
+
+  if (MASTER(cr)) {
+
+    if(cvm::debug()) {
+      cvm::log(cvm::line_marker);
+      cvm::log("colvarproxy_gromacs, step no. "+cvm::to_str(colvars->it)+"\n"+
+              "Updating internal data.\n");
+    }
+
+    // step update on master only due to the call of colvars pointer.
+    if (first_timestep) {
+      first_timestep = false;
+    } else {
+      // Use the time step number inherited from GROMACS
+      if ( step - previous_gmx_step == 1 )
+        colvars->it++;
+      // Other cases?
+    }
+  } // end master
+
+  gmx_pbc = pbc;
+  gmx_box = box;
+  gmx_bNS = bNS;
+
+  previous_gmx_step = step;
+
+  // Prepare data for MPI communication
+  if(PAR(cr) && bNS) {
+    dd_make_local_group_indices(cr->dd->ga2la, n_colvars_atoms, ind, &nat_loc, &ind_loc, &nalloc_loc, xa_ind);
+  }
+}
+
+
+void colvarproxy_gromacs::calculateForces(
+                    const gmx::ForceProviderInput &forceProviderInput,
+                    gmx::ForceProviderOutput      *forceProviderOutput)
+{
+
+  const t_commrec *cr           = &(forceProviderInput.cr_);
+  // Local atom coords
+  const gmx::ArrayRef<const gmx::RVec> x  = forceProviderInput.x_;
+  // Local atom coords (coerced into into old gmx type)
+  const rvec *x_pointer          = &(x.data()->as_vec());
+
+
+  // Eventually there needs to be an interface to update local data upon neighbor search
+  // We could check if by chance all atoms are in one node, and skip communication
+  communicate_group_positions(cr, x_colvars_unwrapped, xa_shifts, xa_eshifts,
+                              gmx_bNS, x_pointer, n_colvars_atoms, nat_loc,
+                              ind_loc, xa_ind, xa_old_whole, gmx_box);
+
+  // Communicate_group_positions takes care of removing shifts (unwrapping)
+  // in single node jobs, communicate_group_positions() is efficient and adds no overhead
+
+  if (MASTER(cr))
+  {
+    // On non-master nodes, jump directly to applying the forces
+
+    // Zero the forces on the atoms, so that they can be accumulated by the colvars.
+    for (size_t i = 0; i < atoms_new_colvar_forces.size(); i++) {
+      atoms_new_colvar_forces[i].x = atoms_new_colvar_forces[i].y = atoms_new_colvar_forces[i].z = 0.0;
+    }
+
+    // Get the atom positions from the Gromacs array.
+    for (size_t i = 0; i < atoms_ids.size(); i++) {
+      atoms_positions[i] = cvm::rvector(x_colvars_unwrapped[i][0], x_colvars_unwrapped[i][1], x_colvars_unwrapped[i][2]);
+    }
+
+    bias_energy = 0.0;
+    // Call the collective variable module to fill atoms_new_colvar_forces
+    if (colvars->calc() != COLVARS_OK) {
+      cvm::error("Error calling colvars->calc()\n");
+    }
+
+    // Copy the forces to C array for broadcasting
+    for (int i = 0; i < n_colvars_atoms; i++)
+    {
+      f_colvars[i][0] = atoms_new_colvar_forces[i].x;
+      f_colvars[i][1] = atoms_new_colvar_forces[i].y;
+      f_colvars[i][2] = atoms_new_colvar_forces[i].z;
+    }
+
+    forceProviderOutput->enerd_.term[F_COM_PULL] += bias_energy;
+  } // master node
+
+  //Broadcast the forces to all the nodes
+  if (PAR(cr))
+  {
+    nblock_bc(cr->mpi_comm_mygroup, n_colvars_atoms, f_colvars);
+  }
+
+  const gmx::ArrayRef<gmx::RVec> &f_out = forceProviderOutput->forceWithVirial_.force_;
+  matrix local_colvars_virial = { { 0 } };
+
+  // Pass the applied forces back to GROMACS
+  for (int i = 0; i < n_colvars_atoms; i++)
+  {
+    int i_global = ind[i];
+
+    // check if this is a local atom and find out locndx
+    if (PAR(cr)) {
+      const int *locndx = cr->dd->ga2la->findHome(i_global);
+      if (locndx) {
+        f_out[*locndx] += f_colvars[i];
+        add_virial_term(local_colvars_virial, f_colvars[i], x_colvars_unwrapped[i]);
+      }
+      // Do nothing if atom is not local
+    } else { // Non MPI-parallel
+      f_out[i_global] += f_colvars[i];
+      add_virial_term(local_colvars_virial, f_colvars[i], x_colvars_unwrapped[i]);
+    }
+  }
+
+  forceProviderOutput->forceWithVirial_.addVirialContribution(local_colvars_virial);
+  return;
+}
+
+
+void colvarproxy_gromacs::add_virial_term(matrix vir, rvec const f, gmx::RVec const x)
+{
+  for (int j = 0; j < DIM; j++) {
+    for (int m = 0; m < DIM; m++) {
+      vir[j][m] -= 0.5 * f[j] * x[m];
+    }
+  }
+}
+
+
+// Pass restraint energy value for current timestep to MD engine
+void colvarproxy_gromacs::add_energy (cvm::real energy)
+{
+  bias_energy += energy;
+}
+
+// **************** ATOMS ****************
+
+int colvarproxy_gromacs::check_atom_id(int atom_number)
+{
+  // GROMACS uses zero-based arrays.
+  int const aid = (atom_number-1);
+
+  if (cvm::debug())
+    log("Adding atom "+cvm::to_str(atom_number)+
+        " for collective variables calculation.\n");
+
+  if ( (aid < 0) || (aid >= gmx_atoms.nr) ) {
+    cvm::error("Error: invalid atom number specified, "+
+               cvm::to_str(atom_number)+"\n", COLVARS_INPUT_ERROR);
+    return COLVARS_INPUT_ERROR;
+  }
+
+  return aid;
+}
+
+
+int colvarproxy_gromacs::init_atom(int atom_number)
+{
+  // GROMACS uses zero-based arrays.
+  int aid = atom_number-1;
+
+  for (size_t i = 0; i < atoms_ids.size(); i++) {
+    if (atoms_ids[i] == aid) {
+      // this atom id was already recorded
+      atoms_ncopies[i] += 1;
+      return i;
+    }
+  }
+
+  aid = check_atom_id(atom_number);
+
+  if(aid < 0) {
+    return COLVARS_INPUT_ERROR;
+  }
+
+  int const index = add_atom_slot(aid);
+  update_atom_properties(index);
+  return index;
+}
+
+void colvarproxy_gromacs::update_atom_properties(int index)
+{
+
+  // update mass
+  double const mass = gmx_atoms.atom[atoms_ids[index]].m;
+  if (mass <= 0.001) {
+    this->log("Warning: near-zero mass for atom "+
+              cvm::to_str(atoms_ids[index]+1)+
+              "; expect unstable dynamics if you apply forces to it.\n");
+  }
+  atoms_masses[index] = mass;
+  // update charge
+  atoms_charges[index] = gmx_atoms.atom[atoms_ids[index]].q;
+}

--- a/gromacs/gromacs-2022.x/colvarproxy_gromacs.h
+++ b/gromacs/gromacs-2022.x/colvarproxy_gromacs.h
@@ -1,0 +1,151 @@
+/// -*- c++ -*-
+/* Based on Jeff Comer's old code */
+#ifndef GMX_COLVARS_COLVARPROXY_GROMACS_H
+#define GMX_COLVARS_COLVARPROXY_GROMACS_H
+
+#include "colvarmodule.h"
+#include "colvaratoms.h"
+#include "colvarproxy.h"
+#include "gromacs/random/tabulatednormaldistribution.h"
+#include "gromacs/random/threefry.h"
+#include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/mdlib/groupcoord.h"
+#include "gromacs/mdtypes/iforceprovider.h"
+#include "gromacs/mdtypes/observableshistory.h"
+#include "gromacs/topology/atoms.h"
+#include "colvarproxy_gromacs_version.h"
+
+/// \brief Communication between colvars and Gromacs (implementation of
+/// \link colvarproxy \endlink)
+class colvarproxy_gromacs : public colvarproxy, public gmx::IForceProvider {
+public:
+  // GROMACS structures.
+  //PBC struct
+  t_pbc gmx_pbc;
+  //Box
+  const real (*gmx_box)[3];
+  //
+  t_atoms gmx_atoms;
+protected:
+  cvm::real thermostat_temperature;
+  cvm::real timestep;
+  bool first_timestep;
+
+  bool colvars_restart;
+  std::string config_file;
+  size_t restart_frequency_s;
+  int previous_gmx_step;
+  double bias_energy;
+
+  bool gmx_bNS; // Is this a neighbor-search step? Eventually will become unnecessary
+
+  // GROMACS random number generation.
+  gmx::DefaultRandomEngine           rng;   // gromacs random number generator
+  gmx::TabulatedNormalDistribution<> normal_distribution;
+
+
+  // Node-local bookkepping data
+  //! Total number of Colvars atoms
+  int        n_colvars_atoms = 0;
+  //! Part of the atoms that are local.
+  int        nat_loc = 0;
+  //! Global indices of the Colvars atoms.
+  int       *ind = nullptr;
+  //! Local indices of the Colvars atoms.
+  int       *ind_loc = nullptr;
+  //! Allocation size for ind_loc.
+  int        nalloc_loc = 0;
+  //! Unwrapped positions for all Colvars atoms, communicated to all nodes.
+  rvec      *x_colvars_unwrapped = nullptr;
+  //! Shifts for all Colvars atoms, to make molecule(s) whole.
+  ivec      *xa_shifts = nullptr;
+  //! Extra shifts since last DD step.
+  ivec      *xa_eshifts = nullptr;
+  //! Old positions for all Colvars atoms on master.
+  rvec      *xa_old_whole = nullptr;
+  //! Position of each local atom in the collective array.
+  int       *xa_ind = nullptr;
+  //! Bias forces on all Colvars atoms
+  rvec      *f_colvars = nullptr;
+public:
+  friend class cvm::atom;
+  colvarproxy_gromacs();
+  ~colvarproxy_gromacs();
+
+  // Initialize colvars.
+  void init(t_inputrec *gmx_inp, int64_t step, const gmx_mtop_t &mtop, ObservablesHistory* oh,
+            const std::string &prefix, gmx::ArrayRef<const std::string> filenames_config,
+            const std::string &filename_restart, const t_commrec *cr,
+            const rvec x[], rvec **xa_old_whole_colvars_state_p, int *n_colvars_atoms_state_p);
+
+  void dd_make_local_atoms(const t_commrec *cr);
+  // Called each step before evaluating the force provider
+  // Should eventually be replaced by the MDmodule interface?
+  void update_data(const t_commrec *cr, int64_t const step, t_pbc const &pbc, const matrix box, bool bNS);
+  /*! \brief
+    * Computes forces.
+    *
+    * \param[in]    forceProviderInput    struct that collects input data for the force providers
+    * \param[in,out] forceProviderOutput   struct that collects output data of the force providers
+    */
+  virtual void calculateForces(const gmx::ForceProviderInput &forceProviderInput,
+                                gmx::ForceProviderOutput      *forceProviderOutput);
+
+  // Compute virial tensor for position r and force f, and add to matrix vir
+  void add_virial_term(matrix vir, rvec const f, gmx::RVec const r);
+
+  void add_energy (cvm::real energy);
+  void finish(const t_commrec *cr);
+
+  // **************** SYSTEM-WIDE PHYSICAL QUANTITIES ****************
+  cvm::real backend_angstrom_value();
+  cvm::real boltzmann();
+  cvm::real temperature();
+  cvm::real dt();
+  cvm::real rand_gaussian();
+  // **************** SIMULATION PARAMETERS ****************
+  void set_temper(double temper);
+  size_t restart_frequency();
+  std::string restart_output_prefix();
+  std::string output_prefix();
+  // **************** PERIODIC BOUNDARY CONDITIONS ****************
+  cvm::rvector position_distance (cvm::atom_pos const &pos1,
+                                  cvm::atom_pos const &pos2) const;
+
+  // **************** INPUT/OUTPUT ****************
+  /// Print a message to the main log
+  void log (std::string const &message);
+  /// Print a message to the main log and let the rest of the program handle the error
+  void error (std::string const &message);
+  /// Print a message to the main log and exit with error code
+  void fatal_error (std::string const &message);
+  /// Print a message to the main log and exit normally
+  void exit (std::string const &message);
+  /// Request to set the units used internally by Colvars
+  int set_unit_system(std::string const &units_in, bool colvars_defined);
+  int backup_file (char const *filename);
+  /// Read atom identifiers from a file \param filename name of
+  /// the file (usually a PDB) \param atoms array to which atoms read
+  /// from "filename" will be appended \param pdb_field (optiona) if
+  /// "filename" is a PDB file, use this field to determine which are
+  /// the atoms to be set
+  int load_atoms (char const *filename,
+                           std::vector<cvm::atom> &atoms,
+                           std::string const &pdb_field,
+                           double const pdb_field_value = 0.0);
+  /// Load the coordinates for a group of atoms from a file
+  /// (usually a PDB); if "pos" is already allocated, the number of its
+  /// elements must match the number of atoms in "filename"
+  int load_coords (char const *filename,
+                            std::vector<cvm::atom_pos> &pos,
+                            const std::vector<int> &indices,
+                            std::string const &pdb_field,
+                            double const pdb_field_value = 0.0);
+
+  int init_atom(int atom_number);
+
+  int check_atom_id(int atom_number);
+  void update_atom_properties(int index);
+};
+
+#endif

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -508,12 +508,37 @@ then
     mkdir ${target_folder}
   fi
 
-  # Copy library files and proxy files to the "src/external/colvars" folder
-  for src in ${source}/src/*.h ${source}/src/*.cpp ${source}/gromacs/src/*.h ${source}/gromacs/gromacs-${GMX_VERSION}/*{cpp,h}
-  do \
-    tgt=$(basename ${src})
-    condcopy "${src}" "${target_folder}/${tgt}"
-  done
+  if [ ${GMX_VERSION} == '2020.x' ] || [ ${GMX_VERSION} == '2021.x' ] ; then
+    # Copy library files and proxy files to the "src/external/colvars" folder
+    for src in ${source}/src/*.h ${source}/src/*.cpp ${source}/gromacs/src/*.h ${source}/gromacs/gromacs-${GMX_VERSION}/*{cpp,h}
+    do \
+      tgt=$(basename ${src})
+      condcopy "${src}" "${target_folder}/${tgt}"
+    done
+  else
+    # Starting from GROMACS 2022, colvar library is in `external` and proxy files are in `src/gromacs/applied_forces/colvarproxy`
+    # Library files
+    for src in ${source}/src/*.h ${source}/src/*.cpp
+    do \
+      tgt=$(basename ${src})
+      condcopy "${src}" "${target_folder}/${tgt}"
+    done
+    # Proxy files
+    target_folder=${target}/src/gromacs/applied_forces/colvarproxy
+    if [ -d ${target_folder} ]
+    then
+      echo "Your ${target} source tree seems to have already been patched."
+      echo "Update with the last Colvars source."
+    else
+      mkdir ${target_folder}
+    fi
+    for src in ${source}/gromacs/src/*.h ${source}/gromacs/gromacs-${GMX_VERSION}/*{cpp,h,txt}
+    do \
+      tgt=$(basename ${src})
+      condcopy "${src}" "${target_folder}/${tgt}"
+    done
+
+  fi
   echo ""
 
   # Copy CMake files

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -524,7 +524,7 @@ then
       condcopy "${src}" "${target_folder}/${tgt}"
     done
     # Proxy files
-    target_folder=${target}/src/gromacs/applied_forces/colvarproxy
+    target_folder=${target}/src/gromacs/applied_forces/colvars
     if [ -d ${target_folder} ]
     then
       echo "Your ${target} source tree seems to have already been patched."

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -171,6 +171,18 @@ then
   GMX_MINOR_VERSION=`get_gromacs_minor_version_cmake ${GMX_VERSION_INFO}`
 
   GMX_VERSION=${GMX_MAJOR_VERSION}.${GMX_MINOR_VERSION}
+
+  # In 2022, version info is in CMakeLists.txt
+  if [ ${GMX_MAJOR_VERSION} = "\${Gromacs_VERSION_MAJOR}" ] ; then
+    CMAKE_LISTS=${target}/CMakeLists.txt
+    if [ ! -f ${CMAKE_LISTS} ] ; then
+      echo "ERROR: Cannot find file ${CMAKE_LISTS}."
+      exit 3
+    fi
+    GMX_VERSION=$(cat ${CMAKE_LISTS} | grep '^project(' | \
+    sed -e 's/project(Gromacs VERSION //' -e 's/)//')
+  fi
+
   echo "Detected GROMACS version ${GMX_VERSION}."
 
   case ${GMX_VERSION} in
@@ -179,6 +191,9 @@ then
       ;;
     2021*)
       GMX_VERSION='2021.x'
+      ;;
+    2022*)
+      GMX_VERSION='2022.x'
       ;;
     *)
     if [ $force_update = 0 ] ; then


### PR DESCRIPTION
Hi,

Here a PR to add support of GROMACS 2022 (better late than never).
I add to modify the patch script because the version number is now in the global CMakeLists.txt.

Issue: I'm not able to compile on the GROMACS 2022 tree. I have `include` errors from the proxy file:
```
gromacs-2022.4_test-colvars/src/external/colvars/colvarproxy_gromacs.cpp:8:10: fatal error: gromacs/mdtypes/inputrec.h: Aucun fichier ou dossier de ce type
 #include "gromacs/mdtypes/inputrec.h"
```

I suspect it's due to the move of Colvars in the `external` folder and  their new CMake modifications (related to this global issue (https://gitlab.com/gromacs/gromacs/-/issues/3288)). 
I tried to find a solution by adapting the CMake files but without success (but I'm really a newbie with Cmake).
Do you have a clue to solve this?
