### PR TITLE
Fix ref count

### DIFF
--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -144,6 +144,33 @@
 \texttt{-------}
 \\
 \texttt{E : float - Amount of energy (internal units)}
+\item \texttt{cv getnumactiveatomgroups}
+\\
+\texttt{Get the number of atom groups that currently have positive ref counts}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{count : integer - Total number of atom groups}
+\item \texttt{cv getnumactiveatoms}
+\\
+\texttt{Get the number of atoms that currently have positive ref counts}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{count : integer - Total number of atoms}
+\item \texttt{cv getnumatoms}
+\\
+\texttt{Get the number of requested atoms, including those not in use now}
+\\
+\texttt{Returns}
+\\
+\texttt{-------}
+\\
+\texttt{count : integer - Total number of atoms}
 \item \texttt{cv getstepabsolute}
 \\
 \texttt{Get the current step number of the simulation (including restarts)}

--- a/namd/tests/library/Common/measure_net_force_torque.tcl
+++ b/namd/tests/library/Common/measure_net_force_torque.tcl
@@ -36,8 +36,11 @@ tclForcesScript {
         }
       }
       #      print "[expr $t-1]   Force: ( $tot )   Torque: ( $torque )"
-      print "TOTAL FORCE: ( $tot )"
-      print "TOTAL TORQUE: ( $torque )"
+      print "NUM. ATOMS REQUESTED:  [cv getnumatoms]"
+      print "NUM. ATOMS USED:       [cv getnumactiveatoms]"
+      print "NUM. ATOM GROUPS USED: [cv getnumactiveatomgroups]"
+      print [format "TOTAL FORCE:  \{ %.16f %.16f %.16f \}" {*}$tot]
+      print [format "TOTAL TORQUE: \{ %.16f %.16f %.16f \}" {*}$torque]
       array set prev_c [array get c]
     }
     incr t

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -31,12 +31,8 @@ cvm::atom::atom()
 
 cvm::atom::atom(int atom_number)
 {
-  colvarproxy *p = cvm::proxy;
+  colvarproxy *p = cvm::main()->proxy;
   index = p->init_atom(atom_number);
-  if (cvm::debug()) {
-    cvm::log("The index of this atom in the colvarproxy arrays is "+
-             cvm::to_str(index)+".\n");
-  }
   id = p->get_atom_id(index);
   update_mass();
   update_charge();
@@ -48,12 +44,8 @@ cvm::atom::atom(cvm::residue_id const &residue,
                 std::string const     &atom_name,
                 std::string const     &segment_id)
 {
-  colvarproxy *p = cvm::proxy;
+  colvarproxy *p = cvm::main()->proxy;
   index = p->init_atom(residue, atom_name, segment_id);
-  if (cvm::debug()) {
-    cvm::log("The index of this atom in the colvarproxy_namd arrays is "+
-             cvm::to_str(index)+".\n");
-  }
   id = p->get_atom_id(index);
   update_mass();
   update_charge();
@@ -76,7 +68,7 @@ cvm::atom::atom(atom const &a)
 cvm::atom::~atom()
 {
   if (index >= 0) {
-    (cvm::proxy)->clear_atom(index);
+    (cvm::main()->proxy)->clear_atom(index);
   }
 }
 
@@ -84,7 +76,7 @@ cvm::atom::~atom()
 cvm::atom & cvm::atom::operator = (cvm::atom const &a)
 {
   index = a.index;
-  id = (cvm::proxy)->get_atom_id(index);
+  id = (cvm::main()->proxy)->get_atom_id(index);
   update_mass();
   update_charge();
   reset_data();
@@ -117,7 +109,7 @@ cvm::atom_group::atom_group(std::vector<cvm::atom> const &atoms_in)
 cvm::atom_group::~atom_group()
 {
   if (is_enabled(f_ag_scalable) && !b_dummy) {
-    (cvm::proxy)->clear_atom_group(index);
+    (cvm::main()->proxy)->clear_atom_group(index);
     index = -1;
   }
 
@@ -334,7 +326,7 @@ void cvm::atom_group::update_total_mass()
   }
 
   if (is_enabled(f_ag_scalable)) {
-    total_mass = (cvm::proxy)->get_atom_group_mass(index);
+    total_mass = (cvm::main()->proxy)->get_atom_group_mass(index);
   } else {
     total_mass = 0.0;
     for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
@@ -355,7 +347,7 @@ void cvm::atom_group::update_total_charge()
   }
 
   if (is_enabled(f_ag_scalable)) {
-    total_charge = (cvm::proxy)->get_atom_group_charge(index);
+    total_charge = (cvm::main()->proxy)->get_atom_group_charge(index);
   } else {
     total_charge = 0.0;
     for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -64,7 +64,9 @@ cvm::atom::atom(cvm::residue_id const &residue,
 cvm::atom::atom(atom const &a)
   : index(a.index)
 {
-  id = (cvm::proxy)->get_atom_id(index);
+  colvarproxy *p = cvm::main()->proxy;
+  id = p->get_atom_id(index);
+  p->increase_refcount(index);
   update_mass();
   update_charge();
   reset_data();

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -104,6 +104,16 @@ void colvarproxy_atoms::clear_atom(int index)
 }
 
 
+size_t colvarproxy_atoms::get_num_active_atoms() const
+{
+  size_t result = 0;
+  for (size_t i = 0; i < atoms_ncopies.size(); i++) {
+    if (atoms_ncopies[i] > 0) result++;
+  }
+  return result;
+}
+
+
 int colvarproxy_atoms::load_atoms(char const * /* filename */,
                                   cvm::atom_group & /* atoms */,
                                   std::string const & /* pdb_field */,
@@ -219,6 +229,16 @@ void colvarproxy_atom_groups::clear_atom_group(int index)
   if (atom_groups_ncopies[index] > 0) {
     atom_groups_ncopies[index] -= 1;
   }
+}
+
+
+size_t colvarproxy_atom_groups::get_num_active_atom_groups() const
+{
+  size_t result = 0;
+  for (size_t i = 0; i < atom_groups_ncopies.size(); i++) {
+    if (atom_groups_ncopies[i] > 0) result++;
+  }
+  return result;
 }
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -157,6 +157,9 @@ public:
     return &atoms_ids;
   }
 
+  /// Return number of atoms with positive reference count
+  size_t get_num_active_atoms() const;
+
   inline std::vector<cvm::real> const *get_atom_masses() const
   {
     return &atoms_masses;
@@ -356,6 +359,9 @@ public:
   {
     return &atom_groups_ids;
   }
+
+  /// Return number of atom groups with positive reference count
+  size_t get_num_active_atom_groups() const;
 
   inline std::vector<cvm::real> *modify_atom_group_masses()
   {

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -112,6 +112,13 @@ public:
     return atoms_masses[index];
   }
 
+  /// Increase the reference count of the given atom
+  /// \param index Internal index in the Colvars arrays
+  inline void increase_refcount(int index)
+  {
+    atoms_ncopies[index] += 1;
+  }
+
   /// Get the charge of the given atom
   inline cvm::real get_atom_charge(int index) const
   {

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -100,13 +100,15 @@ public:
   /// Clear atomic data
   int reset();
 
-  /// Get the numeric ID of the given atom (for the program)
+  /// Get the numeric ID of the given atom
+  /// \param index Internal index in the Colvars arrays
   inline int get_atom_id(int index) const
   {
     return atoms_ids[index];
   }
 
   /// Get the mass of the given atom
+  /// \param index Internal index in the Colvars arrays
   inline cvm::real get_atom_mass(int index) const
   {
     return atoms_masses[index];
@@ -120,24 +122,29 @@ public:
   }
 
   /// Get the charge of the given atom
+  /// \param index Internal index in the Colvars arrays
   inline cvm::real get_atom_charge(int index) const
   {
     return atoms_charges[index];
   }
 
   /// Read the current position of the given atom
+  /// \param index Internal index in the Colvars arrays
   inline cvm::rvector get_atom_position(int index) const
   {
     return atoms_positions[index];
   }
 
   /// Read the current total force of the given atom
+  /// \param index Internal index in the Colvars arrays
   inline cvm::rvector get_atom_total_force(int index) const
   {
     return atoms_total_forces[index];
   }
 
   /// Request that this force is applied to the given atom
+  /// \param index Internal index in the Colvars arrays
+  /// \param new_force Force to add
   inline void apply_atom_force(int index, cvm::rvector const &new_force)
   {
     atoms_new_colvar_forces[index] += new_force;

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -309,6 +309,33 @@ CVSCRIPT(cv_getenergy,
          return COLVARS_OK;
          )
 
+CVSCRIPT(cv_getnumactiveatomgroups,
+         "Get the number of atom groups that currently have positive ref counts\n"
+         "count : integer - Total number of atom groups",
+         0, 0,
+         "",
+         script->set_result_int(static_cast<int>(script->proxy()->get_num_active_atom_groups()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getnumactiveatoms,
+         "Get the number of atoms that currently have positive ref counts\n"
+         "count : integer - Total number of atoms",
+         0, 0,
+         "",
+         script->set_result_int(static_cast<int>(script->proxy()->get_num_active_atoms()));
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_getnumatoms,
+         "Get the number of requested atoms, including those not in use now\n"
+         "count : integer - Total number of atoms",
+         0, 0,
+         "",
+         script->set_result_int(static_cast<int>(script->proxy()->get_atom_ids()->size()));
+         return COLVARS_OK;
+         )
+
 CVSCRIPT(cv_getstepabsolute,
          "Get the current step number of the simulation (including restarts)\n"
          "step : int - Absolute step number",


### PR DESCRIPTION
The number of Colvars objects that use each atom was not being updated correctly due to a missing increment in reference count in a copy constructor. This is harmless because the refcounts are not used anywhere at the moment, but may cause subtle bugs in the future.

Scripting methods to get the numbers of atoms and groups currently being used by Colvars are added; for atoms, there are two distinct commands, one that returns the number of all atoms ever requested, the other for the one currently in use.