### PR TITLE
Fallback to linearCombination when customFunction is missing in customColvar

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -3749,10 +3749,9 @@ of $1/N$.
 \cvleptononly{
 \cvsubsec{Custom functions}{sec:colvar_custom_function}
 
-Collective variables may be defined by specifying a custom function as an analytical
-expression.
-The expression is parsed by Lepton, the lightweight expression parser written by Peter Eastman (\cvurl{https://simtk.org/projects/lepton}).
-Lepton produces efficient evaluation routines for the function and its derivatives.
+Collective variables may be defined by specifying a custom function of multiple components, i.e.\ an analytical expression that is more general than the linear combinations described in \ref{sec:cvc_superp}.
+Such expression is parsed and calculated by Lepton, the lightweight expression parser written by Peter Eastman (\cvurl{https://simtk.org/projects/lepton}) that produces efficient evaluation routines for both the expression and its derivatives.
+Although Lepton is generally available in most applications and builds where Colvars is included, it is best to check section~\ref{sec:compilation_notes} to confirm.
 
 
 \begin{itemize}
@@ -7146,7 +7145,7 @@ This section lists the few cases where the choice of compilation settings affect
 
 \item Scripting commands using the Tcl language (\cvurl{https://www.tcl.tk}) are supported in VMD and NAMD.  All precompiled builds of each code include Tcl, and it is highly recommended to enable Tcl support in any custom build, using precompiled Tcl libraries from the UIUC website.
 
-\item The Lepton library (\cvurl{https://simtk.org/projects/lepton}) used to implement the \texttt{customFunction} feature is currently included only in NAMD (always on) and in LAMMPS (on by default).  For VMD, a \href{https://github.com/giacomofiorin/vmd-patches}{patch} that allows to link Lepton is available.  There is no mechanism to link Lepton to GROMACS at this moment.
+\item The Lepton library (\cvurl{https://simtk.org/projects/lepton}) used to implement the \texttt{customFunction} feature is currently included only in NAMD (always on), in LAMMPS (on by default) and in the Colvars-patched GROMACS releases.  For VMD, a \href{https://github.com/giacomofiorin/vmd-patches}{patch} that allows to link Lepton is available.
 
 \item Some features require compilation using the C++11 language standard, which is either supported (VMD) or required (GROMACS, LAMMPS, NAMD) by the engines.  However, for historic reasons many of the VMD official builds do not conform to the C++11 standard yet, which results in restricted functionality.  Detailed and up-to-date information can be found at:\\
   \cvurl{https://colvars.github.io/README-c++11.html}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -2996,14 +2996,14 @@ colvar \{\\
 \cvsubsubsec{\texttt{linearCombination}: Helper CV to define a linear combination of other CVs}{sec:cvc_linearCombination}
 \labelkey{colvar|linearCombination}
 
-This is a helper CV which can be defined as a linear combination of other CVs. It maybe useful when you want to define the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} as combinations of other CVs.
+This is a helper CV which can be defined as a linear combination of other CVs. It maybe useful when you want to define the \texttt{gspathCV~\{...\}} and the \texttt{gzpathCV~\{...\}} as combinations of other CVs. Total forces (required by \refkey{ABF}{sec:colvarbias_abf_req}) of this CV are not available.
 
 \cvleptononly{
 \cvsubsubsec{\texttt{customColvar}: Helper CV to define a mathematical expression as CV from other CVs}{sec:cvc_customColvar}
 \labelkey{colvar|customColvar}}
 
 \cvleptononly{
-This is a helper CV which can be defined as a mathematical expression (see \ref{sec:colvar_custom_function}) of other CVs by using \refkey{customFunction}{colvar|customFunction}. Currently only the scalar type of \refkey{customFunction}{colvar|customFunction} is supported. If \refkey{customFunction}{colvar|customFunction} is not provided, this component falls back to \refkey{linearCombination}{colvar|linearCombination}. It maybe useful when you want to define the \texttt{gspathCV~\{...\}}, the \texttt{gzpathCV~\{...\}} and \texttt{NeuralNetwork~\{...\}} as combinations of other CVs.
+This is a helper CV which can be defined as a mathematical expression (see \ref{sec:colvar_custom_function}) of other CVs by using \refkey{customFunction}{colvar|customFunction}. Currently only the scalar type of \refkey{customFunction}{colvar|customFunction} is supported. If \refkey{customFunction}{colvar|customFunction} is not provided, this component falls back to \refkey{linearCombination}{colvar|linearCombination}. It maybe useful when you want to define the \texttt{gspathCV~\{...\}}, the \texttt{gzpathCV~\{...\}} and \texttt{NeuralNetwork~\{...\}} as combinations of other CVs. Total forces (required by \refkey{ABF}{sec:colvarbias_abf_req}) of this CV are not available.
 }
 
 \cvsubsubsec{\texttt{gspathCV}: progress along a path defined in CV space.}{sec:cvc_gspathCV}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -3003,7 +3003,7 @@ This is a helper CV which can be defined as a linear combination of other CVs. I
 \labelkey{colvar|customColvar}}
 
 \cvleptononly{
-This is a helper CV which can be defined as a mathematical expression (see \ref{sec:colvar_custom_function}) of other CVs. It maybe useful when you want to define the \texttt{gspathCV~\{...\}}, the \texttt{gzpathCV~\{...\}} and \texttt{NeuralNetwork~\{...\}} as combinations of other CVs.
+This is a helper CV which can be defined as a mathematical expression (see \ref{sec:colvar_custom_function}) of other CVs by using \refkey{customFunction}{colvar|customFunction}. Currently only the scalar type of \refkey{customFunction}{colvar|customFunction} is supported. If \refkey{customFunction}{colvar|customFunction} is not provided, this component falls back to \refkey{linearCombination}{colvar|linearCombination}. It maybe useful when you want to define the \texttt{gspathCV~\{...\}}, the \texttt{gzpathCV~\{...\}} and \texttt{NeuralNetwork~\{...\}} as combinations of other CVs.
 }
 
 \cvsubsubsec{\texttt{gspathCV}: progress along a path defined in CV space.}{sec:cvc_gspathCV}

--- a/src/colvarcomp_combination.cpp
+++ b/src/colvarcomp_combination.cpp
@@ -226,97 +226,107 @@ colvar::customColvar::~customColvar() {
 #endif
 }
 
+
 void colvar::customColvar::calc_value() {
-#ifdef LEPTON
-    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        cv[i_cv]->calc_value();
-    }
-    x.reset();
-    size_t l = 0;
-    for (size_t i = 0; i < x.size(); ++i) {
-        for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-            const colvarvalue& current_cv_value = cv[i_cv]->value();
-            for (size_t j_elem = 0; j_elem < current_cv_value.size(); ++j_elem) {
-                if (current_cv_value.type() == colvarvalue::type_scalar) {
-                    *(value_eval_var_refs[l++]) = cv[i_cv]->sup_coeff * (cvm::pow(current_cv_value.real_value, cv[i_cv]->sup_np));
-                } else {
-                    *(value_eval_var_refs[l++]) = cv[i_cv]->sup_coeff * current_cv_value[j_elem];
-                }
-            }
-        }
-        x[i] = value_evaluators[i]->evaluate();
-    }
-#endif
     if (!use_custom_function) {
         colvar::linearCombination::calc_value();
+    } else {
+#ifdef LEPTON
+        for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+            cv[i_cv]->calc_value();
+        }
+        x.reset();
+        size_t l = 0;
+        for (size_t i = 0; i < x.size(); ++i) {
+            for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+                const colvarvalue& current_cv_value = cv[i_cv]->value();
+                for (size_t j_elem = 0; j_elem < current_cv_value.size(); ++j_elem) {
+                    if (current_cv_value.type() == colvarvalue::type_scalar) {
+                        *(value_eval_var_refs[l++]) = cv[i_cv]->sup_coeff * (cvm::pow(current_cv_value.real_value, cv[i_cv]->sup_np));
+                    } else {
+                        *(value_eval_var_refs[l++]) = cv[i_cv]->sup_coeff * current_cv_value[j_elem];
+                    }
+                }
+            }
+            x[i] = value_evaluators[i]->evaluate();
+        }
+#else
+        cvm::error("Try to use customColvar with customFunction but without Lepton compiled.\n");
+#endif
     }
 }
 
 void colvar::customColvar::calc_gradients() {
+    if (!use_custom_function) {
+        colvar::linearCombination::calc_gradients();
+    } else {
 #ifdef LEPTON
-    size_t r = 0; // index in the vector of variable references
-    size_t e = 0; // index of the gradient evaluator
-    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) { // for each CV
-        cv[i_cv]->calc_gradients();
-        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
-            const colvarvalue& current_cv_value = cv[i_cv]->value();
-            const cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
-            for (size_t j_elem = 0; j_elem < current_cv_value.size(); ++j_elem) { // for each element in this CV
-                for (size_t c = 0; c < x.size(); ++c) { // for each custom function expression
-                    for (size_t k = 0; k < cv.size(); ++k) { // this is required since we need to feed all CV values to this expression
-                        const cvm::real factor_polynomial_k = getPolynomialFactorOfCVGradient(k);
-                        for (size_t l = 0; l < cv[k]->value().size(); ++l) {
-                            *(grad_eval_var_refs[r++]) = factor_polynomial_k * cv[k]->value()[l];
+        size_t r = 0; // index in the vector of variable references
+        size_t e = 0; // index of the gradient evaluator
+        for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) { // for each CV
+            cv[i_cv]->calc_gradients();
+            if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
+                const colvarvalue& current_cv_value = cv[i_cv]->value();
+                const cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
+                for (size_t j_elem = 0; j_elem < current_cv_value.size(); ++j_elem) { // for each element in this CV
+                    for (size_t c = 0; c < x.size(); ++c) { // for each custom function expression
+                        for (size_t k = 0; k < cv.size(); ++k) { // this is required since we need to feed all CV values to this expression
+                            const cvm::real factor_polynomial_k = getPolynomialFactorOfCVGradient(k);
+                            for (size_t l = 0; l < cv[k]->value().size(); ++l) {
+                                *(grad_eval_var_refs[r++]) = factor_polynomial_k * cv[k]->value()[l];
+                            }
                         }
-                    }
-                    const double expr_grad = gradient_evaluators[e++]->evaluate();
-                    for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
-                        for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
-                            (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = expr_grad * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+                        const double expr_grad = gradient_evaluators[e++]->evaluate();
+                        for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
+                            for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+                                (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = expr_grad * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+                            }
                         }
                     }
                 }
             }
         }
-    }
+#else
+        cvm::error("Try to use customColvar with customFunction but without Lepton compiled.\n");
 #endif
-    if (!use_custom_function) {
-        colvar::linearCombination::calc_gradients();
     }
 }
 
 void colvar::customColvar::apply_force(colvarvalue const &force) {
-#ifdef LEPTON
-    size_t r = 0; // index in the vector of variable references
-    size_t e = 0; // index of the gradient evaluator
-    for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
-        // If this CV us explicit gradients, then atomic gradients is already calculated
-        // We can apply the force to atom groups directly
-        if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
-            for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
-                (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
-            }
-        } else {
-            const colvarvalue& current_cv_value = cv[i_cv]->value();
-            colvarvalue cv_force(current_cv_value.type());
-            const cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
-            for (size_t j_elem = 0; j_elem < current_cv_value.size(); ++j_elem) {
-                for (size_t c = 0; c < x.size(); ++c) {
-                    for (size_t k = 0; k < cv.size(); ++k) {
-                        const cvm::real factor_polynomial_k = getPolynomialFactorOfCVGradient(k);
-                        for (size_t l = 0; l < cv[k]->value().size(); ++l) {
-                            *(grad_eval_var_refs[r++]) = factor_polynomial_k * cv[k]->value()[l];
-                        }
-                    }
-                    cv_force[j_elem] += factor_polynomial * gradient_evaluators[e++]->evaluate() * force.real_value;
-                }
-            }
-            cv[i_cv]->apply_force(cv_force);
-        }
-    }
-#endif
     if (!use_custom_function) {
         colvar::linearCombination::apply_force(force);
+    } else {
+#ifdef LEPTON
+        size_t r = 0; // index in the vector of variable references
+        size_t e = 0; // index of the gradient evaluator
+        for (size_t i_cv = 0; i_cv < cv.size(); ++i_cv) {
+            // If this CV us explicit gradients, then atomic gradients is already calculated
+            // We can apply the force to atom groups directly
+            if (cv[i_cv]->is_enabled(f_cvc_explicit_gradient)) {
+                for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
+                    (cv[i_cv]->atom_groups)[k_ag]->apply_colvar_force(force.real_value);
+                }
+            } else {
+                const colvarvalue& current_cv_value = cv[i_cv]->value();
+                colvarvalue cv_force(current_cv_value.type());
+                const cvm::real factor_polynomial = getPolynomialFactorOfCVGradient(i_cv);
+                for (size_t j_elem = 0; j_elem < current_cv_value.size(); ++j_elem) {
+                    for (size_t c = 0; c < x.size(); ++c) {
+                        for (size_t k = 0; k < cv.size(); ++k) {
+                            const cvm::real factor_polynomial_k = getPolynomialFactorOfCVGradient(k);
+                            for (size_t l = 0; l < cv[k]->value().size(); ++l) {
+                                *(grad_eval_var_refs[r++]) = factor_polynomial_k * cv[k]->value()[l];
+                            }
+                        }
+                        cv_force[j_elem] += factor_polynomial * gradient_evaluators[e++]->evaluate() * force.real_value;
+                    }
+                }
+                cv[i_cv]->apply_force(cv_force);
+            }
+        }
+#else
+        cvm::error("Try to use customColvar with customFunction but without Lepton compiled.\n");
+#endif
     }
 }
 

--- a/src/colvarcomp_combination.cpp
+++ b/src/colvarcomp_combination.cpp
@@ -141,13 +141,15 @@ void colvar::linearCombination::apply_force(colvarvalue const &force) {
 colvar::customColvar::customColvar(std::string const &conf): linearCombination(conf) {
     use_custom_function = false;
     // code swipe from colvar::init_custom_function
-#ifdef LEPTON
     std::string expr_in, expr;
+    size_t pos = 0; // current position in config string
+#ifdef LEPTON
     std::vector<Lepton::ParsedExpression> pexprs;
     Lepton::ParsedExpression pexpr;
     double *ref;
-    size_t pos = 0; // current position in config string
+#endif
     if (key_lookup(conf, "customFunction", &expr_in, &pos)) {
+#ifdef LEPTON
         use_custom_function = true;
         cvm::log("This colvar uses a custom function.\n");
         do {
@@ -208,11 +210,15 @@ colvar::customColvar::customColvar(std::string const &conf): linearCombination(c
         } else {
             x.type(colvarvalue::type_scalar);
         }
-    } else {
-        cvm::log(std::string{"Warning: no customFunction specified.\n"});
-        cvm::log(std::string{"Warning: use linear combination instead.\n"});
-    }
+#else
+        cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
+                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                    COLVARS_INPUT_ERROR);
 #endif
+    } else {
+        cvm::log("Warning: no customFunction specified.\n");
+        cvm::log("Warning: use linear combination instead.\n");
+    }
 }
 
 colvar::customColvar::~customColvar() {
@@ -225,7 +231,6 @@ colvar::customColvar::~customColvar() {
     }
 #endif
 }
-
 
 void colvar::customColvar::calc_value() {
     if (!use_custom_function) {
@@ -251,7 +256,9 @@ void colvar::customColvar::calc_value() {
             x[i] = value_evaluators[i]->evaluate();
         }
 #else
-        cvm::error("Try to use customColvar with customFunction but without Lepton compiled.\n");
+        cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
+                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                    COLVARS_INPUT_ERROR);
 #endif
     }
 }
@@ -287,7 +294,9 @@ void colvar::customColvar::calc_gradients() {
             }
         }
 #else
-        cvm::error("Try to use customColvar with customFunction but without Lepton compiled.\n");
+        cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
+                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                    COLVARS_INPUT_ERROR);
 #endif
     }
 }
@@ -325,7 +334,9 @@ void colvar::customColvar::apply_force(colvarvalue const &force) {
             }
         }
 #else
-        cvm::error("Try to use customColvar with customFunction but without Lepton compiled.\n");
+        cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
+                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                    COLVARS_INPUT_ERROR);
 #endif
     }
 }

--- a/src/colvarcomp_combination.cpp
+++ b/src/colvarcomp_combination.cpp
@@ -212,7 +212,7 @@ colvar::customColvar::customColvar(std::string const &conf): linearCombination(c
         }
 #else
         cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
-                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                   "Please refer to the Compilation Notes section of the Colvars manual for more information.\n",
                     COLVARS_INPUT_ERROR);
 #endif
     } else {
@@ -257,7 +257,7 @@ void colvar::customColvar::calc_value() {
         }
 #else
         cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
-                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                   "Please refer to the Compilation Notes section of the Colvars manual for more information.\n",
                     COLVARS_INPUT_ERROR);
 #endif
     }
@@ -295,7 +295,7 @@ void colvar::customColvar::calc_gradients() {
         }
 #else
         cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
-                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                   "Please refer to the Compilation Notes section of the Colvars manual for more information.\n",
                     COLVARS_INPUT_ERROR);
 #endif
     }
@@ -335,7 +335,7 @@ void colvar::customColvar::apply_force(colvarvalue const &force) {
         }
 #else
         cvm::error("customFunction requires the Lepton library, but it is not enabled during compilation.\n"
-                   "Please refer to https://colvars.github.io/colvars-refman-namd/colvars-refman-namd.html#sec:compilation_notes for more information",
+                   "Please refer to the Compilation Notes section of the Colvars manual for more information.\n",
                     COLVARS_INPUT_ERROR);
 #endif
     }


### PR DESCRIPTION
@fhh2626 reports a crash when using `customColvar` similar to `linearCombination`. My original intention was using `customColvar` for components that have `customFunction`, and only falling back to `linearCombination` when Lepton is not compiled in. @fhh2626 starts to use `customColvar` for general nested CVs. I am not sure if this contradicts the design of Colvars, but this commit allows such usage by falling back to `linearCombination` and avoids the crash.