### PR TITLE
Allow collecting configuration files and strings before setting up interface

### DIFF
--- a/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
@@ -122,11 +122,11 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
 
     auto i = filenames_config.begin();
     for(; i != filenames_config.end(); ++i) {
-        colvars->read_config_file(i->c_str());
+        add_config("configfile", i->c_str());
     }
 
-
-    colvars->setup();
+    colvarproxy::setup_module();
+    colvars->update_engine_parameters();
     colvars->setup_input();
 
     // Citation Reporter

--- a/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
@@ -125,7 +125,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
         add_config("configfile", i->c_str());
     }
 
-    colvarproxy::setup_module();
+    colvarproxy::parse_module_config();
     colvars->update_engine_parameters();
     colvars->setup_input();
 

--- a/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
@@ -124,7 +124,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
         add_config("configfile", i->c_str());
     }
 
-    colvarproxy::setup_module();
+    colvarproxy::parse_module_config();
     colvars->update_engine_parameters();
     colvars->setup_input();
 

--- a/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
@@ -121,11 +121,11 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
 
     auto i = filenames_config.begin();
     for(; i != filenames_config.end(); ++i) {
-        colvars->read_config_file(i->c_str());
+        add_config("configfile", i->c_str());
     }
 
-
-    colvars->setup();
+    colvarproxy::setup_module();
+    colvars->update_engine_parameters();
     colvars->setup_input();
 
     // Citation Reporter

--- a/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
@@ -121,11 +121,11 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step, const gmx_mtop_t &m
 
     auto i = filenames_config.begin();
     for(; i != filenames_config.end(); ++i) {
-        colvars->read_config_file(i->c_str());
+        add_config("configfile", i->c_str());
     }
 
-
-    colvars->setup();
+    colvarproxy::setup_module();
+    colvars->update_engine_parameters();
     colvars->setup_input();
 
     // Citation Reporter

--- a/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
@@ -124,7 +124,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step, const gmx_mtop_t &m
         add_config("configfile", i->c_str());
     }
 
-    colvarproxy::setup_module();
+    colvarproxy::parse_module_config();
     colvars->update_engine_parameters();
     colvars->setup_input();
 

--- a/lammps/src/COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/COLVARS/colvarproxy_lammps.h
@@ -50,7 +50,7 @@ class colvarproxy_lammps : public colvarproxy {
   colvarproxy_lammps(LAMMPS_NS::LAMMPS *lmp, const char *, const char *, const int, const double,
                      MPI_Comm);
   ~colvarproxy_lammps() override;
-  void init(const char *);
+  void init();
   int setup() override;
 
   // disable default and copy constructor

--- a/lammps/src/COLVARS/fix_colvars.cpp
+++ b/lammps/src/COLVARS/fix_colvars.cpp
@@ -443,7 +443,9 @@ void FixColvars::one_time_init()
     }
 
     proxy = new colvarproxy_lammps(lmp,inp_name,out_name,rng_seed,t_target,root2root);
-    proxy->init(conf_file);
+    proxy->init();
+    proxy->add_config("configfile", conf_file);
+    proxy->setup_module();
 
     num_coords = (proxy->modify_atom_positions()->size());
   }

--- a/lammps/src/COLVARS/fix_colvars.cpp
+++ b/lammps/src/COLVARS/fix_colvars.cpp
@@ -445,7 +445,7 @@ void FixColvars::one_time_init()
     proxy = new colvarproxy_lammps(lmp,inp_name,out_name,rng_seed,t_target,root2root);
     proxy->init();
     proxy->add_config("configfile", conf_file);
-    proxy->setup_module();
+    proxy->parse_module_config();
 
     num_coords = (proxy->modify_atom_positions()->size());
   }

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -106,7 +106,7 @@ colvarproxy_namd::colvarproxy_namd()
   }
 
   // Trigger immediate initialization of the module
-  colvarproxy::setup_module();
+  colvarproxy::parse_module_config();
   colvarproxy_namd::setup();
   colvars->update_engine_parameters();
   colvars->setup_input();

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -298,9 +298,6 @@ int colvarmodule::parse_config(std::string &conf)
   cvm::log("Collective variables module (re)initialized.\n");
   cvm::log(cvm::line_marker);
 
-  // Update any necessary proxy data
-  proxy->setup();
-
   if (source_Tcl_script.size() > 0) {
     run_tcl_script(source_Tcl_script);
   }
@@ -1207,7 +1204,7 @@ int colvarmodule::end_of_step()
 }
 
 
-int colvarmodule::setup()
+int colvarmodule::update_engine_parameters()
 {
   if (this->size() == 0) return cvm::get_error();
   for (std::vector<colvar *>::iterator cvi = variables()->begin();

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -439,9 +439,9 @@ public:
   // from the proxy that may change during program execution)
   // No additional parsing is done within these functions
 
-  /// (Re)initialize internal data (currently used by LAMMPS)
+  /// (Re)initialize any internal data affected by changes in the engine
   /// Also calls setup() member functions of colvars and biases
-  int setup();
+  int update_engine_parameters();
 
   /// (Re)initialize and (re)read the input state file calling read_restart()
   int setup_input();

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -523,7 +523,7 @@ int colvarproxy::setup()
 }
 
 
-int colvarproxy::setup_module()
+int colvarproxy::parse_module_config()
 {
   int error_code = COLVARS_OK;
   // Read any configuration queued up for Colvars

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -697,6 +697,8 @@ protected:
   /// Track which features have been acknowledged during the last run
   size_t features_hash;
 
+private:
+
   /// Queue of config strings or files to be fed to the module
   void *config_queue_;
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -599,18 +599,30 @@ public:
   /// \brief Reset proxy state, e.g. requested atoms
   virtual int reset();
 
-  /// (Re)initialize required member data after construction
+  /// (Re)initialize the module
+  virtual int setup_module();
+
+  /// (Re)initialize required member data (called after the module)
   virtual int setup();
 
-  /// \brief Update data required by the colvars module (e.g. cache atom positions)
+  /// Whether the engine allows to fully initialize Colvars immediately
+  inline bool engine_ready() const
+  {
+    return engine_ready_;
+  }
+
+  /// Enqueue new configuration text, to be parsed as soon as possible
+  void add_config(std::string const &cmd, std::string const &conf);
+
+  /// Update data required by Colvars module (e.g. read atom positions)
   ///
   /// TODO Break up colvarproxy_namd and colvarproxy_lammps function into these
   virtual int update_input();
 
-  /// \brief Update data based from the results of a module update (e.g. send forces)
+  /// Update data based on the results of a Colvars call (e.g. send forces)
   virtual int update_output();
 
-  /// Carry out operations needed before next step is run
+  /// Carry out operations needed before next simulation step is run
   int end_of_step();
 
   /// Print a message to the main log
@@ -662,6 +674,9 @@ public:
 
 protected:
 
+  /// Whether the engine allows to fully initialize Colvars immediately
+  bool engine_ready_;
+
   /// Collected error messages
   std::string error_output;
 
@@ -681,6 +696,9 @@ protected:
 
   /// Track which features have been acknowledged during the last run
   size_t features_hash;
+
+  /// Queue of config strings or files to be fed to the module
+  void *config_queue_;
 
 };
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -600,7 +600,7 @@ public:
   virtual int reset();
 
   /// (Re)initialize the module
-  virtual int setup_module();
+  virtual int parse_module_config();
 
   /// (Re)initialize required member data (called after the module)
   virtual int setup();

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -134,11 +134,19 @@ CVSCRIPT(cv_config,
          char const *conf_str =
            script->obj_to_str(script->get_module_cmd_arg(0, objc, objv));
          std::string const conf(conf_str);
-         if (cvm::main()->read_config_string(conf) == COLVARS_OK) {
-           return COLVARS_OK;
+         script->proxy()->add_config("config", conf);
+         if (script->proxy()->engine_ready()) {
+           // Engine allows immediate initialization
+           if ((script->proxy()->setup_module() |
+                script->proxy()->setup()) == COLVARS_OK) {
+             return COLVARS_OK;
+           } else {
+             script->add_error_msg("Error parsing configuration string");
+             return COLVARSCRIPT_ERROR;
+           }
          }
-         script->add_error_msg("Error parsing configuration string");
-         return COLVARSCRIPT_ERROR;
+         // Engine not ready, config will be read during proxy->setup()
+         return COLVARS_OK;
          )
 
 CVSCRIPT(cv_configfile,
@@ -146,13 +154,20 @@ CVSCRIPT(cv_configfile,
          1, 1,
          "conf_file : string - Path to configuration file",
          char const *conf_file_name =
-           script->obj_to_str(script->get_module_cmd_arg(0, objc, objv));
-         if (script->module()->read_config_file(conf_file_name) == COLVARS_OK) {
-           return COLVARS_OK;
-         } else {
-           script->add_error_msg("Error parsing configuration file");
-           return COLVARSCRIPT_ERROR;
+         script->obj_to_str(script->get_module_cmd_arg(0, objc, objv));
+         script->proxy()->add_config("configfile", std::string(conf_file_name));
+         if (script->proxy()->engine_ready()) {
+           // Engine allows immediate initialization
+           if ((script->proxy()->setup_module() |
+                script->proxy()->setup()) == COLVARS_OK) {
+             return COLVARS_OK;
+           } else {
+             script->add_error_msg("Error parsing configuration file");
+             return COLVARSCRIPT_ERROR;
+           }
          }
+         // Engine not ready, config will be read during proxy->setup()
+         return COLVARS_OK;
          )
 
 CVSCRIPT(cv_delete,

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -137,7 +137,7 @@ CVSCRIPT(cv_config,
          script->proxy()->add_config("config", conf);
          if (script->proxy()->engine_ready()) {
            // Engine allows immediate initialization
-           if ((script->proxy()->setup_module() |
+           if ((script->proxy()->parse_module_config() |
                 script->proxy()->setup()) == COLVARS_OK) {
              return COLVARS_OK;
            } else {
@@ -158,7 +158,7 @@ CVSCRIPT(cv_configfile,
          script->proxy()->add_config("configfile", std::string(conf_file_name));
          if (script->proxy()->engine_ready()) {
            // Engine allows immediate initialization
-           if ((script->proxy()->setup_module() |
+           if ((script->proxy()->parse_module_config() |
                 script->proxy()->setup()) == COLVARS_OK) {
              return COLVARS_OK;
            } else {

--- a/tests/stubs/colvarproxy_stub.cpp
+++ b/tests/stubs/colvarproxy_stub.cpp
@@ -44,7 +44,7 @@ colvarproxy_stub::~colvarproxy_stub()
 int colvarproxy_stub::setup()
 {
   if (colvars) {
-    return colvars->setup();
+    return colvars->update_engine_parameters();
   }
   return COLVARS_OK;
 }

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -133,6 +133,7 @@ int colvarproxy_vmd::request_deletion()
 
 int colvarproxy_vmd::setup()
 {
+  int error_code = colvarproxy::setup();
   vmdmol = vmd->moleculeList->mol_from_id(vmdmolid);
   if (vmdmol) {
     set_frame(vmdmol->frame());

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -141,12 +141,10 @@ int colvarproxy_vmd::setup()
     return COLVARS_ERROR;
   }
 
-  if (colvars) {
-    return colvars->setup();
-  }
-
-  return COLVARS_OK;
+  return colvars->update_engine_parameters();
 }
+
+
 cvm::real colvarproxy_vmd::rand_gaussian()
 {
   return vmd_random_gaussian();


### PR DESCRIPTION
This is mostly related to #418, but ideally the code path to bootstrap the module ought to be consistent across engines.

In LAMMPS, the module is typically created before all the atomic data necessary to configure it are available: the latter will happen during the beginning of a `run` command execution. Therefore, this constraint prevents manipulating the module through the scripting interface before the run begins. Also, these differences between the initialization code paths between engines are error-prone long term.

The solution proposed here adds the ability to collect all configuration before it is consumed, whether that happens immediately or not. 