### PR TITLE
Forward-declare OpenMP lock

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.9)
 
 project(colvars CXX)
 get_filename_component(COLVARS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
@@ -71,6 +71,17 @@ if(WARNINGS_ARE_ERRORS)
   target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:SunPro>:-xwe>)
   target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/WX>)
 endif()
+
+
+option(COLVARS_OPENMP "Build Colvars with (still limited) OpenMP support" ON)
+
+if(COLVARS_OPENMP)
+  find_package(OpenMP)
+  if(OpenMP_CXX_FOUND)
+    target_link_libraries(colvars OpenMP::OpenMP_CXX)
+  endif()
+endif()
+
 
 include(buildColvarsLepton)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -73,7 +73,12 @@ if(WARNINGS_ARE_ERRORS)
 endif()
 
 
-option(COLVARS_OPENMP "Build Colvars with (still limited) OpenMP support" ON)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(COLVARS_OPENMP_DEFAULT OFF)
+else()
+  set(COLVARS_OPENMP_DEFAULT ON)
+endif()
+option(COLVARS_OPENMP "Build Colvars with (still limited) OpenMP support" ${COLVARS_OPENMP_DEFAULT})
 
 if(COLVARS_OPENMP)
   find_package(OpenMP)

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -9,10 +9,6 @@
 
 #include <fstream>
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include "colvarmodule.h"
 #include "colvarproxy.h"
 #include "colvarscript.h"
@@ -263,8 +259,8 @@ colvarproxy_smp::colvarproxy_smp()
   omp_lock_state = NULL;
 #if defined(_OPENMP)
   if (omp_get_thread_num() == 0) {
-    omp_lock_state = reinterpret_cast<void *>(new omp_lock_t);
-    omp_init_lock(reinterpret_cast<omp_lock_t *>(omp_lock_state));
+    omp_lock_state = new omp_lock_t;
+    omp_init_lock(omp_lock_state);
   }
 #endif
 }
@@ -275,7 +271,7 @@ colvarproxy_smp::~colvarproxy_smp()
 #if defined(_OPENMP)
   if (omp_get_thread_num() == 0) {
     if (omp_lock_state) {
-      delete reinterpret_cast<omp_lock_t *>(omp_lock_state);
+      delete omp_lock_state;
     }
   }
 #endif
@@ -394,7 +390,7 @@ int colvarproxy_smp::smp_num_threads()
 int colvarproxy_smp::smp_lock()
 {
 #if defined(_OPENMP)
-  omp_set_lock(reinterpret_cast<omp_lock_t *>(omp_lock_state));
+  omp_set_lock(omp_lock_state);
 #endif
   return COLVARS_OK;
 }
@@ -403,8 +399,7 @@ int colvarproxy_smp::smp_lock()
 int colvarproxy_smp::smp_trylock()
 {
 #if defined(_OPENMP)
-  return omp_test_lock(reinterpret_cast<omp_lock_t *>(omp_lock_state)) ?
-    COLVARS_OK : COLVARS_ERROR;
+  return omp_test_lock(omp_lock_state) ? COLVARS_OK : COLVARS_ERROR;
 #else
   return COLVARS_OK;
 #endif
@@ -414,7 +409,7 @@ int colvarproxy_smp::smp_trylock()
 int colvarproxy_smp::smp_unlock()
 {
 #if defined(_OPENMP)
-  omp_unset_lock(reinterpret_cast<omp_lock_t *>(omp_lock_state));
+  omp_unset_lock(omp_lock_state);
 #endif
   return COLVARS_OK;
 }

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -444,6 +444,12 @@ protected:
 };
 
 
+#if defined(_OPENMP)
+#include <omp.h>
+#else
+struct omp_lock_t;
+#endif
+
 /// \brief Methods for SMP parallelization
 class colvarproxy_smp {
 
@@ -489,7 +495,7 @@ public:
 protected:
 
   /// Lock state for OpenMP
-  void *omp_lock_state;
+  omp_lock_t *omp_lock_state;
 };
 
 


### PR DESCRIPTION
Based on conversations from #526 

Also include OpenMP support in test builds using CMake :-)  The version required is now >= 3.9, but RHEL7 fulfills it via `cmake3` and everything else is also more recent.