### PR TITLE
Initialize NAMD ID map entry immediately when requesting a new atom

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -287,18 +287,30 @@ int colvarproxy_namd::setup()
 
 int colvarproxy_namd::reset()
 {
+  if (cvm::debug()) {
+    cvm::log("colvarproxy_namd::reset()\n");
+  }
+
   int error_code = COLVARS_OK;
 
-  // Unrequest all atoms and group from NAMD
+  // Unrequest all positions, total forces, etc from NAMD
   modifyRequestedAtoms().clear();
+  modifyForcedAtoms().clear();
+  modifyAppliedForces().clear();
+
   modifyRequestedGroups().clear();
+  modifyGroupForces().clear();
+
 #if NAMD_VERSION_NUMBER >= 34471681
   modifyRequestedGridObjects().clear();
+  modifyGridObjForces().clear();
 #endif
+
+  requestTotalForce(false);
 
   atoms_map.clear();
 
-  // Clear internal Proxy records
+  // Clear internal atomic data
   error_code |= colvarproxy::reset();
 
   return error_code;

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -166,7 +166,6 @@ int colvarproxy_namd::update_target_temperature()
 void colvarproxy_namd::init_atoms_map()
 {
   size_t const n_all_atoms = Node::Object()->molecule->numAtoms;
-  atoms_map.resize(n_all_atoms);
   atoms_map.assign(n_all_atoms, -1);
 }
 

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -194,6 +194,7 @@ int colvarproxy_namd::update_atoms_map(AtomIDList::const_iterator begin,
       // add it here anyway to avoid having to test for array boundaries at each step
       int const index = add_atom_slot(*a_i);
       atoms_map[*a_i] = index;
+      modifyRequestedAtoms().add(*a_i);
       update_atom_properties(index);
     }
   }

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -378,7 +378,7 @@ void colvarproxy_namd::calculate()
   }
 #endif
 
-  // create the atom map if needed
+  // Create the map of NAMD atom IDs to Colvars internal indices
   size_t const n_all_atoms = Node::Object()->molecule->numAtoms;
   if (atoms_map.size() != n_all_atoms) {
     atoms_map.resize(n_all_atoms);
@@ -386,7 +386,8 @@ void colvarproxy_namd::calculate()
     update_atoms_map(getAtomIdBegin(), getAtomIdEnd());
   }
 
-  // if new atomic positions or forces have been communicated by other GlobalMasters, add them to the atom map
+  // If new atomic positions or forces have been communicated by other
+  // GlobalMaster objects, add these to the atom map as well
   if ((int(atoms_ids.size()) < (getAtomIdEnd() - getAtomIdBegin())) ||
       (int(atoms_ids.size()) < (getForceIdEnd() - getForceIdBegin()))) {
     update_atoms_map(getAtomIdBegin(), getAtomIdEnd());
@@ -687,6 +688,7 @@ int colvarproxy_namd::init_atom(int atom_number)
   }
 
   int const index = add_atom_slot(aid);
+  atoms_map[aid] = index;
   modifyRequestedAtoms().add(aid);
   update_atom_properties(index);
   return index;
@@ -748,6 +750,7 @@ int colvarproxy_namd::init_atom(cvm::residue_id const &residue,
         ") for collective variables calculation.\n");
 
   int const index = add_atom_slot(aid);
+  atoms_map[aid] = index;
   modifyRequestedAtoms().add(aid);
   update_atom_properties(index);
   return index;

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -451,7 +451,8 @@ void colvarproxy_namd::calculate()
         n_total_forces++;
       }
 
-      if (n_total_forces < atoms_ids.size()) {
+      if ( (! b_simulation_continuing) &&
+           (n_total_forces < atoms_ids.size()) ) {
         cvm::error("Error: total forces were requested, but total forces "
                    "were not received for all atoms.\n"
                    "The most probable cause is combination of energy "
@@ -467,7 +468,8 @@ void colvarproxy_namd::calculate()
       ForceList::const_iterator f_i = getGroupTotalForceBegin();
       ForceList::const_iterator f_e = getGroupTotalForceEnd();
       size_t i = 0;
-      if ((f_e - f_i) != ((int) atom_groups_ids.size())) {
+      if ( (! b_simulation_continuing) &&
+           ((f_e - f_i) != ((int) atom_groups_ids.size())) ) {
         cvm::error("Error: total forces were requested for scalable groups, "
                    "but they are not in the same number from the number of groups.\n"
                    "The most probable cause is combination of energy "

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -71,6 +71,9 @@ public:
   /// Get the target temperature from the NAMD thermostats supported so far
   int update_target_temperature();
 
+  /// Allocate an atoms map with the same size as the NAMD topology
+  void init_atoms_map();
+
   // synchronize the local arrays with requested or forced atoms
   int update_atoms_map(AtomIDList::const_iterator begin,
                        AtomIDList::const_iterator end);

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -598,47 +598,78 @@ void colvarproxy::print_input_atomic_data()
   cvm::log(cvm::line_marker);
 
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atoms_ids = "+cvm::to_str(atoms_ids)+"\n");
+           "atoms_ids[size = "+cvm::to_str(atoms_ids.size())+
+           "] = "+cvm::to_str(atoms_ids)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atoms_refcount = "+cvm::to_str(atoms_refcount)+"\n");
+           "atoms_refcount[size = "+cvm::to_str(atoms_refcount.size())+
+           "] = "+cvm::to_str(atoms_refcount)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atoms_masses = "+cvm::to_str(atoms_masses)+"\n");
+           "atoms_masses[size = "+cvm::to_str(atoms_masses.size())+
+           "] = "+cvm::to_str(atoms_masses)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atoms_charges = "+cvm::to_str(atoms_charges)+"\n");
+           "atoms_charges[size = "+cvm::to_str(atoms_charges.size())+
+           "] = "+cvm::to_str(atoms_charges)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atoms_positions = "+cvm::to_str(atoms_positions,
-                                            cvm::cv_width,
-                                            cvm::cv_prec)+"\n");
+           "atoms_positions[size = "+cvm::to_str(atoms_positions.size())+
+           "] = "+cvm::to_str(atoms_positions,
+                              cvm::cv_width,
+                              cvm::cv_prec)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atoms_total_forces = "+cvm::to_str(atoms_total_forces,
-                                               cvm::cv_width,
-                                               cvm::cv_prec)+"\n");
+           "atoms_total_forces[size = "+
+           cvm::to_str(atoms_total_forces.size())+
+           "] = "+cvm::to_str(atoms_total_forces,
+                              cvm::cv_width,
+                              cvm::cv_prec)+"\n");
 
   cvm::log(cvm::line_marker);
 
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atom_groups_ids = "+cvm::to_str(atom_groups_ids)+"\n");
+           "atom_groups_ids[size = "+cvm::to_str(atom_groups_ids.size())+
+           "] = "+cvm::to_str(atom_groups_ids)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atom_groups_refcount = "+cvm::to_str(atom_groups_refcount)+"\n");
+           "atom_groups_refcount[size = "+
+           cvm::to_str(atom_groups_refcount.size())+
+           "] = "+cvm::to_str(atom_groups_refcount)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atom_groups_masses = "+cvm::to_str(atom_groups_masses)+"\n");
+           "atom_groups_masses[size = "+
+           cvm::to_str(atom_groups_masses.size())+
+           "] = "+cvm::to_str(atom_groups_masses)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atom_groups_charges = "+cvm::to_str(atom_groups_charges)+"\n");
+           "atom_groups_charges[size = "+
+           cvm::to_str(atom_groups_charges.size())+
+           "] = "+cvm::to_str(atom_groups_charges)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atom_groups_coms = "+cvm::to_str(atom_groups_coms,
-                                             cvm::cv_width,
-                                             cvm::cv_prec)+"\n");
+           "atom_groups_coms[size = "+
+           cvm::to_str(atom_groups_coms.size())+
+           "] = "+cvm::to_str(atom_groups_coms,
+                              cvm::cv_width,
+                              cvm::cv_prec)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "atom_groups_total_forces = "+cvm::to_str(atom_groups_total_forces,
-                                                     cvm::cv_width,
-                                                     cvm::cv_prec)+"\n");
+           "atom_groups_total_forces[size = "+
+           cvm::to_str(atom_groups_total_forces.size())+
+           "] = "+cvm::to_str(atom_groups_total_forces,
+                              cvm::cv_width,
+                              cvm::cv_prec)+"\n");
 
   cvm::log(cvm::line_marker);
 
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "volmaps_ids = "+cvm::to_str(volmaps_ids)+"\n");
+           "volmaps_ids[size = "+cvm::to_str(volmaps_ids.size())+
+           "] = "+cvm::to_str(volmaps_ids)+"\n");
+
   cvm::log("Step "+cvm::to_str(cvm::step_absolute())+", "+
-           "volmaps_values = "+cvm::to_str(volmaps_values)+"\n");
+           "volmaps_values[size = "+cvm::to_str(volmaps_values.size())+
+           "] = "+cvm::to_str(volmaps_values)+"\n");
 
   cvm::log(cvm::line_marker);
 }

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -493,9 +493,14 @@ bool colvarproxy::io_available()
 
 int colvarproxy::reset()
 {
+  if (cvm::debug()) {
+    cvm::log("colvarproxy::reset()\n");
+  }
   int error_code = COLVARS_OK;
   error_code |= colvarproxy_atoms::reset();
   error_code |= colvarproxy_atom_groups::reset();
+  error_code |= colvarproxy_volmaps::reset();
+  total_force_requested = false;
   return error_code;
 }
 


### PR DESCRIPTION
Works around several issues arising when using NAMD's `GlobalMaster` infrastructure in restarted jobs. Even considering just atoms (i.e. no groups CoMs or volumetric maps), `GlobalMaster` can independently:
1. Gather atomic positions of certain atoms
2. Broadcast forces applied to atoms, which may or may not be the same atoms as above
3. When requested, gather total forces for atoms, which *may or may not be the same atoms as above*

For Colvars the three sets of atoms are meant to be the same for simplicity. However, other `GlobalMaster` based objects (e.g. `tclForces`) may request atoms differently. Therefore, we had a provision in place in `colvarproxy_namd` to request all those atoms within Colvars as well, since a73f32f4cdd3316b1e5f38f75224f2efc5b2e036.

What that provision was not accounting for is that the array of total forces (3) _survives_ a configuration reset. For example, when switching system in the `003_reinitatoms` test, the are 15 alpha carbons requested, but since they are not exactly the same set we end up with 29 total forces retrieved, potentially writing to invalid memory (because those "old" forces do not correspond to atoms currently requested) or raising an error otherwise. There is no easy way to empty that array of total forces without significant changes to NAMD, so I opted for requesting those atoms as well.

This solution may increase the communication overhead when running e.g. constant-pH NAMD where one cycles between multiple topologies, but using CPH in combination with total forces seems unlikely (and probably not appropriate, given its discontinuities).

Fixes #536 

Probably also #501 @jhenin do you mind running again in that same environment as when you opened that issue?