### PR TITLE
Close, but do not delete input streams

### DIFF
--- a/doc/cvscript-fix-modify.tex
+++ b/doc/cvscript-fix-modify.tex
@@ -250,6 +250,19 @@
 \texttt{\textbf{fix\_modify Colvars listindexfiles}}
 \\
 \-~~~~\texttt{Get a list of the index files loaded in this session}
+\\
+\-~~~~\texttt{\textbf{Returns}}
+\\
+\-~~~~\texttt{list : sequence of strings - List of index file names}
+\end{mdexampleinput}
+\begin{mdexampleinput}{}
+\texttt{\textbf{fix\_modify Colvars listinputfiles}}
+\\
+\-~~~~\texttt{Get a list of all input/configuration files loaded in this session}
+\\
+\-~~~~\texttt{\textbf{Returns}}
+\\
+\-~~~~\texttt{list : sequence of strings - List of file names}
 \end{mdexampleinput}
 \begin{mdexampleinput}{}
 \texttt{\textbf{fix\_modify Colvars load <prefix>}}

--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -250,6 +250,19 @@
 \texttt{\textbf{cv listindexfiles}}
 \\
 \-~~~~\texttt{Get a list of the index files loaded in this session}
+\\
+\-~~~~\texttt{\textbf{Returns}}
+\\
+\-~~~~\texttt{list : sequence of strings - List of index file names}
+\end{mdexampleinput}
+\begin{mdexampleinput}{}
+\texttt{\textbf{cv listinputfiles}}
+\\
+\-~~~~\texttt{Get a list of all input/configuration files loaded in this session}
+\\
+\-~~~~\texttt{\textbf{Returns}}
+\\
+\-~~~~\texttt{list : sequence of strings - List of file names}
 \end{mdexampleinput}
 \begin{mdexampleinput}{}
 \texttt{\textbf{cv load <prefix>}}

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -207,12 +207,12 @@ std::istream &colvarproxy_io::input_stream(std::string const &input_name,
   }
 
   if (colvarproxy_io::input_stream_exists(input_name)) {
-    if (! dynamic_cast<std::ifstream *>(input_streams_[input_name])->is_open()) {
+    std::ifstream *ifs = dynamic_cast<std::ifstream *>(input_streams_[input_name]);
+    if ( ifs && !ifs->is_open()) {
       // This file was opened before, re-open it.  Using std::ios::binary to
       // work around differences in line termination conventions
       // See https://github.com/Colvars/colvars/commit/8236879f7de4
-      dynamic_cast<std::ifstream *>(input_streams_[input_name])->open(input_name.c_str(),
-std::ios::binary);
+      ifs->open(input_name.c_str(), std::ios::binary);
     }
   } else {
     input_streams_[input_name] = new std::ifstream(input_name.c_str(),
@@ -237,7 +237,8 @@ bool colvarproxy_io::input_stream_exists(std::string const &input_name)
 int colvarproxy_io::close_input_stream(std::string const &input_name)
 {
   if (colvarproxy_io::input_stream_exists(input_name)) {
-    dynamic_cast<std::ifstream *>(input_streams_[input_name])->close();
+    std::ifstream *ifs = dynamic_cast<std::ifstream *>(input_streams_[input_name]);
+    if (ifs) ifs->close();
     return COLVARS_OK;
   }
   return cvm::error("Error: input file/channel \""+input_name+

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -238,7 +238,9 @@ int colvarproxy_io::close_input_stream(std::string const &input_name)
 {
   if (colvarproxy_io::input_stream_exists(input_name)) {
     std::ifstream *ifs = dynamic_cast<std::ifstream *>(input_streams_[input_name]);
-    if (ifs) ifs->close();
+    if (ifs && ifs->is_open()) {
+      ifs->close();
+    }
     return COLVARS_OK;
   }
   return cvm::error("Error: input file/channel \""+input_name+

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -248,13 +248,27 @@ int colvarproxy_io::close_input_stream(std::string const &input_name)
 
 int colvarproxy_io::close_input_streams()
 {
-  for (std::map<std::string, std::istream *>::iterator ii = input_streams_.begin();
+  for (std::map<std::string,
+         std::istream *>::iterator ii = input_streams_.begin();
        ii != input_streams_.end();
        ii++) {
     delete ii->second;
   }
   input_streams_.clear();
   return COLVARS_OK;
+}
+
+
+std::list<std::string> colvarproxy_io::list_input_stream_names() const
+{
+  std::list<std::string> result;
+  for (std::map<std::string,
+         std::istream *>::const_iterator ii = input_streams_.begin();
+       ii != input_streams_.end();
+       ii++) {
+    result.push_back(ii->first);
+  }
+  return result;
 }
 
 

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -124,6 +124,9 @@ public:
   /// Closes all input streams
   virtual int close_input_streams();
 
+  /// List all input streams that were opened at some point
+  virtual std::list<std::string> list_input_stream_names() const;
+
   /// Returns a reference to the named output file/channel (open it if needed)
   /// \param output_name File name or identifier
   /// \param description Purpose of the file

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -454,7 +454,8 @@ CVSCRIPT(cv_listcommands,
          )
 
 CVSCRIPT(cv_listindexfiles,
-         "Get a list of the index files loaded in this session",
+         "Get a list of the index files loaded in this session\n"
+         "list : sequence of strings - List of index file names",
          0, 0,
          "",
          int const n_files = script->module()->index_file_names.size();
@@ -462,6 +463,23 @@ CVSCRIPT(cv_listindexfiles,
          for (int i = 0; i < n_files; i++) {
            if (i > 0) result.append(1, ' ');
            result.append(script->module()->index_file_names[i]);
+         }
+         script->set_result_str(result);
+         return COLVARS_OK;
+         )
+
+CVSCRIPT(cv_listinputfiles,
+         "Get a list of all input/configuration files loaded in this session\n"
+         "list : sequence of strings - List of file names",
+         0, 0,
+         "",
+         std::list<std::string> const l =
+           script->proxy()->list_input_stream_names();
+         std::string result;
+         for (std::list<std::string>::const_iterator li = l.begin();
+              li != l.end(); li++) {
+           if (li != l.begin()) result.append(1, ' ');
+           result.append(*li);
          }
          script->set_result_str(result);
          return COLVARS_OK;

--- a/tests/functional/run_colvars_test.cpp
+++ b/tests/functional/run_colvars_test.cpp
@@ -11,9 +11,21 @@
 extern "C" int main(int argc, char *argv[]) {
   if (argc > 1) {
     colvarproxy_stub *proxy = new colvarproxy_stub();
+    int error_code = COLVARS_OK;
+
     // Initialize simple unit system to test file input
-    proxy->set_unit_system("real", false);
-    return proxy->colvars->read_config_file(argv[1]);
+    error_code |= proxy->set_unit_system("real", false);
+    error_code |= proxy->colvars->read_config_file(argv[1]);
+
+    std::cout << std::endl
+              << "Input files read during this test:"
+              << std::endl;
+    unsigned char * args[2] = {
+      (unsigned char *) "cv",
+      (unsigned char *) "listinputfiles" };
+    error_code |= run_colvarscript_command(2, args);
+    std::cout << get_colvarscript_result() << std::endl;
+
   } else {
     std::cerr << "ERROR: Missing configuration file." << std::endl;
   }


### PR DESCRIPTION
Keep the entries in the map of input streams (see #481) accessible to objects derived from `colvarproxy`, as well as returning their names as a list.

@jhenin The latter convenience scripting function might also be useful in the Dashboard, by obtaining all the input files in a single query.  In the case of reused or templated configurations, it may be useful to print out an informational message listing those files for the user's benefit.