### PR TITLE
Support for properly close istringstreams in input_streams_

### DIFF
--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -238,8 +238,18 @@ int colvarproxy_io::close_input_stream(std::string const &input_name)
 {
   if (colvarproxy_io::input_stream_exists(input_name)) {
     std::ifstream *ifs = dynamic_cast<std::ifstream *>(input_streams_[input_name]);
-    if (ifs && ifs->is_open()) {
-      ifs->close();
+    if (ifs) {
+      if (ifs->is_open()) {
+        ifs->close();
+      }
+    }
+    else {
+      // From a string, just rewind to the begining
+      std::istringstream * iss = dynamic_cast<std::istringstream *>(input_streams_[input_name]);
+      if (iss) {
+        iss->clear();
+        iss->seekg(0);
+      }
     }
     return COLVARS_OK;
   }


### PR DESCRIPTION
Hi,

In the GROMACS proxy, streams can also be `istringstreams` (in the MDmodule version).
This MR add the support too properly close (& reset) this kind of streams in case of the same stream is read twice during parsing.

This modification was in first part in the Colvars GROMACS proxy (in an override) but it may be better to have it directly in the parent class.

I wonder also if it would be nice to have a method to add `istringstreams` in `input_streams_` map directly in the `colvarproxy_io` class, like this:
```c++
void colvarproxy_io::add_input_string(std::string const &input_name, std::string const content)
{
  if (!io_available()) {
    cvm::error("Error: trying to access an input file/channel "
               "from the wrong thread.\n", COLVARS_BUG_ERROR);
    return;
  }
 if (!colvarproxy_io::input_stream_exists(input_name)) {
   input_streams_[input_name] = new std::istringstream(content);
  }
}
```