### PR TITLE
Initialize input string streams alongside input file streams

### DIFF
--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -273,16 +273,14 @@ bool colvarproxy_io::input_stream_exists(std::string const &input_name)
 int colvarproxy_io::close_input_stream(std::string const &input_name)
 {
   if (colvarproxy_io::input_stream_exists(input_name)) {
-    std::ifstream *ifs =
-      dynamic_cast<std::ifstream *>(input_streams_[input_name]);
+    std::ifstream *ifs = dynamic_cast<std::ifstream *>(input_streams_[input_name]);
     if (ifs) {
       if (ifs->is_open()) {
         ifs->close();
       }
     } else {
       // From a string, just rewind to the begining
-      std::istringstream * iss =
-        dynamic_cast<std::istringstream *>(input_streams_[input_name]);
+      std::istringstream * iss = dynamic_cast<std::istringstream *>(input_streams_[input_name]);
       if (iss) {
         iss->clear();
         iss->seekg(0);

--- a/src/colvarproxy_io.cpp
+++ b/src/colvarproxy_io.cpp
@@ -273,15 +273,16 @@ bool colvarproxy_io::input_stream_exists(std::string const &input_name)
 int colvarproxy_io::close_input_stream(std::string const &input_name)
 {
   if (colvarproxy_io::input_stream_exists(input_name)) {
-    std::ifstream *ifs = dynamic_cast<std::ifstream *>(input_streams_[input_name]);
+    std::ifstream *ifs =
+      dynamic_cast<std::ifstream *>(input_streams_[input_name]);
     if (ifs) {
       if (ifs->is_open()) {
         ifs->close();
       }
-    }
-    else {
+    } else {
       // From a string, just rewind to the begining
-      std::istringstream * iss = dynamic_cast<std::istringstream *>(input_streams_[input_name]);
+      std::istringstream * iss =
+        dynamic_cast<std::istringstream *>(input_streams_[input_name]);
       if (iss) {
         iss->clear();
         iss->seekg(0);

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -107,25 +107,28 @@ public:
     return input_buffer_;
   }
 
+  // The input stream functions below are not virtual, because they currently
+  // rely on the fact that either std::ifstream or std::istringstream is used
+
   /// Returns a reference to given input stream, creating it if needed
   /// \param input_name File name (later only a handle)
   /// \param description Purpose of the file
   /// \param error_on_fail Raise error when failing to open (allow testing)
-  virtual std::istream &input_stream(std::string const &input_name,
-                                     std::string const description = "file/channel",
-                                     bool error_on_fail = true);
+  std::istream & input_stream(std::string const &input_name,
+                              std::string const description = "file/channel",
+                              bool error_on_fail = true);
 
   /// Check if the file/channel is open (without opening it if not)
-  virtual bool input_stream_exists(std::string const &input_name);
+  bool input_stream_exists(std::string const &input_name);
 
   /// Closes the given input stream
-  virtual int close_input_stream(std::string const &input_name);
+  int close_input_stream(std::string const &input_name);
 
   /// Closes all input streams
-  virtual int close_input_streams();
+  int close_input_streams();
 
   /// List all input streams that were opened at some point
-  virtual std::list<std::string> list_input_stream_names() const;
+  std::list<std::string> list_input_stream_names() const;
 
   /// Returns a reference to the named output file/channel (open it if needed)
   /// \param output_name File name or identifier

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -101,12 +101,6 @@ public:
   /// Communicate/set the restart frequency of the simulation engine
   virtual int set_default_restart_frequency(int freq);
 
-  /// Buffer from which the input state information may be read
-  inline char const * & input_buffer()
-  {
-    return input_buffer_;
-  }
-
   // The input stream functions below are not virtual, because they currently
   // rely on the fact that either std::ifstream or std::istringstream is used
 
@@ -117,6 +111,14 @@ public:
   std::istream & input_stream(std::string const &input_name,
                               std::string const description = "file/channel",
                               bool error_on_fail = true);
+
+  /// Returns a reference to given input stream, creating it if needed
+  /// \param input_name Identifier of the input stream
+  /// \param content Set this string as the stream's buffer
+  /// \param description Purpose of the stream
+  std::istream & input_stream_from_string(std::string const &input_name,
+                                          std::string const &content,
+                                          std::string const description = "string");
 
   /// Check if the file/channel is open (without opening it if not)
   bool input_stream_exists(std::string const &input_name);

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -506,7 +506,8 @@ CVSCRIPT(cv_loadfromstring,
          "buffer : string - String buffer containing the state information",
          char const *arg =
            script->obj_to_str(script->get_module_cmd_arg(0, objc, objv));
-         script->proxy()->input_buffer() = arg;
+         script->proxy()->input_stream_from_string("input state string",
+                                                   std::string(arg));
          if (script->module()->setup_input() == COLVARS_OK) {
            return COLVARS_OK;
          } else {


### PR DESCRIPTION
Implement suggestion raised in #542.

The logic of using `dynamic_cast` to check whether a pointer is `std::ifstream *` and `std::istringstream *` can easily become fragile in derived classes, so I removed the `virtual` qualifier. GROMACS proxy functions should wrap around these functions without overriding them. 

This arrangement could be changed later as far as I'm concerned, but I feel safer to not override for now.
