### PR TITLE
Add minimal .clang-format for library source code

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,11 @@
+---
+Language: Cpp
+ColumnLimit: 100
+UseTab: Never
+TabWidth: 2
+IndentWidth: 2
+ObjCBlockIndentWidth: 2
+PenaltyBreakAssignment: 2
+AccessModifierOffset: -2
+BreakBeforeBraces: Stroustrup
+...


### PR DESCRIPTION
Specific options are to be consistent with most the existing codebase, while everything else is at default.