### PR TITLE
fix clang12 warnings

### DIFF
--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -167,7 +167,7 @@ public:
   atom_group(std::vector<cvm::atom> const &atoms_in);
 
   /// \brief Destructor
-  ~atom_group();
+  ~atom_group() override;
 
   /// \brief Optional name to reuse properties of this in other groups
   std::string name;
@@ -180,7 +180,7 @@ public:
   int init();
 
   /// \brief Initialize dependency tree
-  virtual int init_dependencies();
+  virtual int init_dependencies() override;
 
   /// \brief Update data required to calculate cvc's
   int setup();
@@ -221,11 +221,11 @@ public:
   static std::vector<feature *> ag_features;
 
   /// \brief Implementation of the feature list accessor for atom group
-  virtual const std::vector<feature *> &features() const
+  virtual const std::vector<feature *> &features() const override
   {
     return ag_features;
   }
-  virtual std::vector<feature *> &modify_features()
+  virtual std::vector<feature *> &modify_features() override
   {
     return ag_features;
   }
@@ -525,7 +525,7 @@ public:
   /// Implements possible actions to be carried out
   /// when a given feature is enabled
   /// This overloads the base function in colvardeps
-  void do_feature_side_effects(int id);
+  void do_feature_side_effects(int id) override;
 };
 
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -262,7 +262,7 @@ public:
   {
     std::string out = "";
     for (size_t i = 0; i < in.size(); i++) {
-      out.append(1, (char) ::tolower(in[i]) );
+      out.append(1, static_cast<char>( ::tolower(in[i])) );
     }
     return out;
   }

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -40,7 +40,7 @@ public:
   void set_string(std::string const &conf);
 
   /// Default destructor
-  virtual ~colvarparse();
+  virtual ~colvarparse() override;
 
   /// Get the configuration string (includes comments)
   inline std::string const & get_config() const
@@ -284,7 +284,7 @@ public:
 
   public:
 
-    read_block(std::string const &key_in, std::string *data_in = NULL);
+    read_block(std::string const &key_in, std::string *data_in = nullptr);
 
     ~read_block();
 
@@ -304,8 +304,8 @@ public:
   /// within "conf", useful when doing multiple calls
   bool key_lookup(std::string const &conf,
                   char const *key,
-                  std::string *data = NULL,
-                  size_t *save_pos = NULL);
+                  std::string *data = nullptr,
+                  size_t *save_pos = nullptr);
 
   /// \brief Reads a configuration line, adds it to config_string, and returns
   /// the stream \param is Input stream \param line String that will hold the

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -604,9 +604,9 @@ public:
   colvarproxy();
 
   /// Destructor
-  virtual ~colvarproxy();
+  virtual ~colvarproxy() override;
 
-  virtual bool io_available() /* override */;
+  virtual bool io_available() override;
 
   /// Request deallocation of the module (currently only implemented by VMD)
   virtual int request_deletion();

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -53,6 +53,12 @@ public:
     }
   }
 
+  /// Explicit Copy constructor
+  inline vector1d(const vector1d&) = default;
+
+  /// Explicit Copy assignement
+  inline vector1d& operator=(const vector1d&) = default;
+
   /// Return a pointer to the data location
   inline T * c_array()
   {
@@ -896,9 +902,6 @@ public:
     zz = zzi;
   }
 
-  /// Destructor
-  inline ~rmatrix()
-  {}
 
   inline void reset()
   {


### PR DESCRIPTION
For the `colvarparse.h`it fixes:
```
/colvars/colvarparse.h:265:21: warning: use of old-style cast [-Wold-style-cast] 
     out.append(1, (char) ::tolower(in[i]) );
```

For the `colvartypes.h`, I'm not sure what is the best solution. The warning is present because there is a explicit destructor for those 2 classes so we need an explicit copy constructor and an explicit copy assignment
```
warning: definition of implicit copy assignment operator for 'vector1d<colvarmodule::rvector>' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-dtor]
  inline ~vector1d()
```
So, I just defined the default ones for `vector1d` but maybe it needs more?
For `rmatrix`, I just removed the destructor since it was empty.


