### PR TITLE
Update required C++ language version to C++11

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -327,28 +327,6 @@ jobs:
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 4.8, C++98
-        env:
-          CXX_STANDARD: 98
-          CXX: g++
-          CXX_VERSION: 4.8
-          CC: gcc
-        run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
-
-      - name: GCC 4.8, C++98, no-for-scope (VMD uses it)
-        env:
-          CXX_STANDARD: 98
-          CXX: g++
-          CXX_VERSION: 4.8
-          CC: gcc
-          CXXFLAGS: -fno-for-scope
-          CMAKE_BUILD_DIR: build_g++4.8_C++98_no-for-scope
-        run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
-
 
   build-linux-x86_64-sun:
     name: Linux x86_64 (Sun compiler)

--- a/README-c++11.md
+++ b/README-c++11.md
@@ -25,6 +25,6 @@ We no longer support using extremely old compilers and OSes that are well past t
 
 ### Building VMD is quite complicated: could you just provide a working VMD build?
 
-In theory we *could*, but because of UIUC's restrictive license we are unfortunately unable to redistribute any version of VMD (modified or not).  It is worth noting that the UIUC license violates several of the best practice set forth by the National Institutes of Health (NIH), which funds the development of VMD:
+In theory we *could*, but because of UIUC's restrictive license we are unfortunately unable to redistribute any version of VMD (modified or not).  It is worth noting that the UIUC license violates several of the best practices set forth by the National Institutes of Health (NIH), which funds the development of NAMD and VMD:
 [https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq](https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq)
 We hope that this arrangement will change in the future, and we encourage you to let your preference known to the VMD and NAMD development teams.

--- a/README-c++11.md
+++ b/README-c++11.md
@@ -20,4 +20,11 @@ We no longer support using extremely old compilers and OSes that are well past t
 
 - **NAMD** follows the C++11 standard.
 
-- **VMD** precompiled builds *do not* use C++11 yet, and the optional `CXX11` flag in VMD's `configure` script does not work yet.  Please use the `c++11` patch from [this repository](https://github.com/giacomofiorin/vmd-patches/) to enable compilation of VMD.  What this patch does is to instruct the compilers to use C++11, if it's not the default.
+- **VMD** precompiled builds *do not* use C++11 yet, and the optional `CXX11` flag in VMD's `configure` script does not work yet.  Please apply the `c++11` patch from [this repository](https://github.com/giacomofiorin/vmd-patches/) to allow building VMD with C++11 whenever supported.
+
+
+### Building VMD is quite complicated: could you just provide a working VMD build?
+
+In theory we *could*, but because of UIUC's restrictive license we are unfortunately unable to redistribute any version of VMD (modified or not).  It is worth noting that the UIUC license violates several of the best practice set forth by the National Institutes of Health (NIH), which funds the development of VMD:
+[https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq](https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq)
+We hope that this arrangement will change in the future, and we encourage you to let your preference known to the VMD and NAMD development teams.

--- a/README-c++11.md
+++ b/README-c++11.md
@@ -25,6 +25,4 @@ We no longer support using extremely old compilers and OSes that are well past t
 
 ### Building VMD is quite complicated: could you just provide a working VMD build?
 
-In theory we *could*, but because of UIUC's restrictive license we are unfortunately unable to redistribute any version of VMD (modified or not).  It is worth noting that the UIUC license violates several of the best practices set forth by the National Institutes of Health (NIH), which funds the development of NAMD and VMD:
-[https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq](https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq)
-We hope that this arrangement will change in the future, and we encourage you to let your preference known to the VMD and NAMD development teams.
+In theory we *could*, but due to UIUC's restrictive license we are curently unable to distribute any version of VMD, modified or not.  We hope that this restriction is lifted in the future, through the adoption of best practices for [research software sharing](https://datascience.nih.gov/tools-and-analytics/best-practices-for-sharing-research-software-faq).

--- a/README-c++11.md
+++ b/README-c++11.md
@@ -1,27 +1,23 @@
-## Availability of Colvars features on different C++ versions
+## Availability of Colvars features depending on C++ language versions
 
-The majority of the Colvars module can be built with all major versions of the C++ language.  A few recent features are an exception, and require an executable built with C++11, which all recent compilers support but not all enable by default yet.
+The majority of the Colvars module can be built with all major versions of the C++ language.  In general, the accepted standard is **C++11**, which is supported by all major OSes and compilers currently in use.  Any future exceptions to this will be listed here, as well as in the "Compilation notes" section of the Colvars doc.
 
-At this time, the issue only affects VMD, whose build system aims to keep supporting also some Linux versions that are no longer under active support.
-
-Upon initialization, Colvars will always print the version of C++ with which it was built, so that you may compare it with the information in this README.
+Because Colvars relies on the build system of each engine, there is nothing for you to do, whether you are using a precompiled build or making your own.  The only exception to this is VMD, whose build system requires some patching in order to work on modern architectures (details below).
 
 
-### Specific Colvars features that require C++11
+### Backward compatibility notes
 
-Currently the following variable types are only available when the code is built with C++11 standard or higher:
-- `gspath` and `gzpath`
-- `gspathCV` and `gzpathCV`
-- `aspathCV` and `azpathCV`
+If you are reading this page following an error message from Colvars, you are probably using an earlier version of the code, which at the time was supporting C++11 as an option but not *requiring* it yet.  Consider upgrading your engine and/or Colvars, as you will also get new features and improvements.
 
-Starting from 2019-06-02 `customFunction` also requires C++11, due to improvements in the Lepton library available from [the OpenMM repository](https://github.com/openmm/openmm).
+We no longer support using extremely old compilers and OSes that are well past their end of life (for example, GCC 4.4 and CentOS 6).
 
-### Status of C++ support in MD engines (as of 2021-01-21)
 
-- **GROMACS** currently follows the C++14 standard, which is backward compatible with C++11.
+### Status of C++ language support in MD engines (as of 2023-06-22)
+
+- **GROMACS** follows the C++17 standard.
 
 - **LAMMPS** follows the C++11 standard.
 
-- **NAMD** follows the C++11 standard, required by Charm++.
+- **NAMD** follows the C++11 standard.
 
-- **VMD** precompiled builds *do not* use C++11 yet.  If you are building your own VMD, try using the optional `CXX11` flag when running the `configure` script, which will activate C++11 flags for the `LINUXAMD64` architecture: however, support for this option is still a work in progress.  Alternatively, you may use the custom `c++11` patch from [this repository](https://github.com/giacomofiorin/vmd-patches/) as a temporary fix.
+- **VMD** precompiled builds *do not* use C++11 yet, and the optional `CXX11` flag in VMD's `configure` script does not work yet.  Please use the `c++11` patch from [this repository](https://github.com/giacomofiorin/vmd-patches/) to enable compilation of VMD.  What this patch does is to instruct the compilers to use C++11, if it's not the default.

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ and run the provided `update-colvars-code.sh` script against the unpacked source
 and recompile them.
 
 The `update-colvars-code.sh` script support patching the latest development version of each program:
-- the [LAMMPS GitHub repository](https://github.com/lammps/lammps);
-- the [NAMD GitLab repository](https://gitlab.com/tcbgUIUC/namd);
-- the [CVS repositories of VMD and its plugins](https://www.ks.uiuc.edu/Research/vmd/doxygen/cvsget.html).
+- [LAMMPS](https://github.com/lammps/lammps);
+- [NAMD](https://gitlab.com/tcbgUIUC/namd);
+- [VMD and its plugins](https://www.ks.uiuc.edu/Research/vmd/doxygen/cvsget.html); note that starting from Colvars version 2023-06-23, some updates are needed to the VMD build script (see [here](https://colvars.github.io/README-c++11.html) for details).
 
 For [GROMACS](http://www.gromacs.org/), support for specific release series is currently maintained; pre-patched versions of specific releases are provided [below](#gromacs-colvars-releases).
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -11,6 +11,15 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+else()
+  if(${CMAKE_CXX_STANDARD} STREQUAL "98")
+    message(FATAL_ERROR "CMAKE_CXX_STANDARD must be 11 or later")
+  endif()
+endif()
+
 option(WARNINGS_ARE_ERRORS "Treats warnings as errors" OFF)
 
 option(ADDRESS_SANITIZER "Build with Address Sanitizer for memory debugging" OFF)
@@ -34,17 +43,6 @@ endif()
 
 option(COLVARS_LEPTON "Build and link the Lepton library" ${COLVARS_LEPTON_DEFAULT})
 
-if(COLVARS_LEPTON)
-  if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  else()
-    if(${CMAKE_CXX_STANDARD} STREQUAL "98")
-      message(FATAL_ERROR "With -DCOLVARS_LEPTON=ON, CMAKE_CXX_STANDARD must be 11 or later")
-    endif()
-  endif()
-endif()
-
 file(GLOB COLVARS_SOURCES ${COLVARS_SOURCE_DIR}/src/[^.]*.cpp)
 
 add_library(colvars ${COLVARS_SOURCES})
@@ -53,9 +51,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 target_compile_options(colvars PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Intel>>:-Wall -pedantic>)
-
-target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-long-long>)
-target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-long-long>)
 
 target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:SunPro>:+w>)
 # # Uncomment the line below to enable more thorough checks with Sun Compiler
@@ -119,10 +114,6 @@ endif()
 option(BUILD_TOOLS "Build standalone tools" ON)
 
 option(BUILD_TESTS "Build tests" ON)
-if((${CMAKE_CXX_STANDARD} STREQUAL "98") AND BUILD_TESTS)
-  message(WARNING "Will not build tests under the (legacy) C++98 standard")
-  set(BUILD_TESTS OFF)
-endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # TODO fix linkage errors with Visual Studio...
@@ -131,10 +122,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 option(BUILD_UNITTESTS "Build unit tests" ${BUILD_TESTS})
-if((${CMAKE_CXX_STANDARD} STREQUAL "98") AND BUILD_UNITTESTS)
-  message(WARNING "Will not build unit tests under the (legacy) C++98 standard")
-  set(BUILD_UNITTESTS OFF)
-endif()
 
 if(BUILD_TOOLS)
   add_subdirectory(${COLVARS_SOURCE_DIR}/colvartools colvartools)

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -7193,7 +7193,7 @@ This section lists the few cases where the choice of compilation settings affect
 
 \item The Lepton library (\cvurl{https://simtk.org/projects/lepton}) used to implement the \texttt{customFunction} feature is currently included only in NAMD (always on), in LAMMPS (on by default) and in the Colvars-patched GROMACS releases.  For VMD, a \href{https://github.com/giacomofiorin/vmd-patches}{patch} that allows to link Lepton is available.
 
-\item Some features require compilation using the C++11 language standard, which is either supported (VMD) or required (GROMACS, LAMMPS, NAMD) by the engines.  However, for historic reasons many of the VMD official builds do not conform to the C++11 standard yet, which results in restricted functionality.  Detailed and up-to-date information can be found at:\\
+\item Colvars requires the C++11 language standard, which is either supported (VMD) or required (GROMACS, LAMMPS, NAMD) by all the engines.  However, many of the VMD official builds are produced on very old architectures.  For details please see:\\
   \cvurl{https://colvars.github.io/README-c++11.html}
 \end{itemize}
 

--- a/doc/cv_version.tex
+++ b/doc/cv_version.tex
@@ -1,1 +1,1 @@
-\newcommand{\cvversion}{2023-06-21}
+\newcommand{\cvversion}{2023-06-23}

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -11,11 +11,8 @@
 #define COLVAR_H
 
 #include <iostream>
-
-#if (__cplusplus >= 201103L)
 #include <map>
 #include <functional>
-#endif
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
@@ -271,17 +268,16 @@ public:
   virtual int init_dependencies();
 
 private:
+
   /// Parse the CVC configuration for all components of a certain type
   template<typename def_class_name> int init_components_type(std::string const & conf,
                                                              char const *def_desc,
                                                              char const *def_config_key);
-#if (__cplusplus >= 201103L)
-  /// For the C++11 case, the names of all available components are
-  /// registered in the global map at first, and then the CVC configuration
-  /// is parsed by this function
+
+  /// The names of all available components are registered in the global map
+  /// at first, and then the CVC configuration is parsed by this function
   int init_components_type_from_global_map(const std::string& conf,
                                            const char* def_config_key);
-#endif
 
 public:
 
@@ -626,13 +622,12 @@ public:
   // components that do not handle any atoms directly
   class map_total;
 
-  /// getter of the global cvc map
-#if (__cplusplus >= 201103L)
   /// A global mapping of cvc names to the cvc constructors
-  static const std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>>& get_global_cvc_map() {
-      return global_cvc_map;
+  static const std::map<std::string, std::function<colvar::cvc *(const std::string &subcv_conf)>> &
+  get_global_cvc_map()
+  {
+    return global_cvc_map;
   }
-#endif
 
   /// \brief function for sorting cvcs by their names
   static bool compare_cvc(const colvar::cvc* const i, const colvar::cvc* const j);
@@ -671,10 +666,9 @@ protected:
   double dev_null;
 #endif
 
-#if (__cplusplus >= 201103L)
   /// A global mapping of cvc names to the cvc constructors
-  static std::map<std::string, std::function<colvar::cvc* (const std::string& subcv_conf)>> global_cvc_map;
-#endif
+  static std::map<std::string, std::function<colvar::cvc *(const std::string &subcv_conf)>>
+      global_cvc_map;
 
   /// Volmap numeric IDs, one for each CVC (-1 if not available)
   std::vector<int> volmap_ids_;

--- a/src/colvar_neuralnetworkcompute.cpp
+++ b/src/colvar_neuralnetworkcompute.cpp
@@ -10,7 +10,6 @@
 #include <iostream>
 #include <fstream>
 
-#if (__cplusplus >= 201103L)
 #include "colvar_neuralnetworkcompute.h"
 #include "colvarparse.h"
 #include "colvarproxy.h"
@@ -306,5 +305,3 @@ void neuralNetworkCompute::compute() {
     }
 }
 }
-
-#endif

--- a/src/colvar_neuralnetworkcompute.h
+++ b/src/colvar_neuralnetworkcompute.h
@@ -7,7 +7,6 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
-#if (__cplusplus >= 201103L)
 #ifndef NEURALNETWORKCOMPUTE_H
 #define NEURALNETWORKCOMPUTE_H
 
@@ -144,5 +143,4 @@ public:
 };
 
 }
-#endif
 #endif

--- a/src/colvarbias_histogram_reweight_amd.h
+++ b/src/colvarbias_histogram_reweight_amd.h
@@ -18,15 +18,9 @@ class colvarbias_reweightaMD : public colvarbias_histogram {
 public:
   colvarbias_reweightaMD(char const *key);
   virtual ~colvarbias_reweightaMD();
-#if (__cplusplus >= 201103L)
   virtual int init(std::string const &conf) override;
   virtual int update() override;
   virtual int write_output_files() override;
-#else
-  virtual int init(std::string const &conf);
-  virtual int update();
-  virtual int write_output_files();
-#endif
 
   /// @brief convert histogram to PMF by taking logarithm and multiplying
   ///        it with -1/beta
@@ -86,13 +80,9 @@ protected:
   bool b_write_gradients;
 
   /// save and restore
-#if (__cplusplus >= 201103L)
   virtual std::istream & read_state_data(std::istream &is) override;
   virtual std::ostream & write_state_data(std::ostream &os) override;
-#else
-  virtual std::istream & read_state_data(std::istream &is);
-  virtual std::ostream & write_state_data(std::ostream &os);
-#endif
+
 private:
   /// temporary grids for evaluating PMFs
   colvar_grid_scalar  *pmf_grid_exp_avg;

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -19,20 +19,15 @@
 // this can be done straightforwardly by using the macro:
 // simple_scalar_dist_functions (derived_class)
 
+#include <functional>
+#include <map>
+#include <memory>
 
 #include "colvarmodule.h"
-#include "colvar.h"
 #include "colvaratoms.h"
+#include "colvar.h"
 #include "colvar_arithmeticpath.h"
-
-#if (__cplusplus >= 201103L)
-// C++11-only functions
 #include "colvar_geometricpath.h"
-#include <memory>
-#include <functional>
-#endif
-
-#include <map>
 
 
 /// \brief Colvar component (base class for collective variables)
@@ -1540,7 +1535,6 @@ public:
 
 
 
-#if (__cplusplus >= 201103L)
 class colvar::CartesianBasedPath
   : public colvar::cvc
 {
@@ -1745,6 +1739,7 @@ namespace neuralnetworkCV {
     class neuralNetworkCompute;
 }
 
+
 class colvar::neuralNetwork
   : public linearCombination
 {
@@ -1760,80 +1755,6 @@ public:
     virtual void calc_gradients();
     virtual void apply_force(colvarvalue const &force);
 };
-
-#else // if the compiler doesn't support C++11
-
-class colvar::linearCombination
-  : public colvar::componentDisabled
-{
-public:
-    linearCombination(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::CartesianBasedPath
-  : public colvar::componentDisabled
-{
-public:
-    CartesianBasedPath(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::CVBasedPath
-  : public colvar::componentDisabled
-{
-public:
-    CVBasedPath(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::gspath
-  : public colvar::componentDisabled
-{
-public:
-    gspath(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::gzpath
-  : public colvar::componentDisabled
-{
-public:
-    gzpath(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::gspathCV
-  : public colvar::componentDisabled
-{
-public:
-    gspathCV(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::gzpathCV
-  : public colvar::componentDisabled
-{
-public:
-    gzpathCV(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::aspathCV
-  : public colvar::componentDisabled
-{
-public:
-    aspathCV(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::azpathCV
-  : public colvar::componentDisabled
-{
-public:
-    azpathCV(std::string const &conf) : componentDisabled(conf) {}
-};
-
-class colvar::neuralNetwork
-  : public colvar::componentDisabled
-{
-public:
-    neuralNetwork(std::string const &conf) : componentDisabled(conf) {}
-};
-
-#endif // C++11 checking
 
 
 // \brief Colvar component: total value of a scalar map

--- a/src/colvarcomp_apath.cpp
+++ b/src/colvarcomp_apath.cpp
@@ -1,4 +1,11 @@
-#if (__cplusplus >= 201103L)
+// -*- c++ -*-
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
 
 #include <numeric>
 #include <algorithm>
@@ -181,4 +188,3 @@ void colvar::azpathCV::apply_force(colvarvalue const &force) {
 
 colvar::azpathCV::~azpathCV() {}
 
-#endif

--- a/src/colvarcomp_combination.cpp
+++ b/src/colvarcomp_combination.cpp
@@ -1,4 +1,4 @@
-#if (__cplusplus >= 201103L)
+// -*- c++ -*-
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
@@ -340,5 +340,3 @@ void colvar::customColvar::apply_force(colvarvalue const &force) {
 #endif
     }
 }
-
-#endif // __cplusplus >= 201103L

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -1,4 +1,4 @@
-#if (__cplusplus >= 201103L)
+// -*- c++ -*-
 
 // This file is part of the Collective Variables module (Colvars).
 // The original version of Colvars and its updates are located at:
@@ -794,5 +794,3 @@ void colvar::gzpathCV::apply_force(colvarvalue const &force) {
         }
     }
 }
-
-#endif

--- a/src/colvarcomp_neuralnetwork.cpp
+++ b/src/colvarcomp_neuralnetwork.cpp
@@ -1,4 +1,11 @@
-#if (__cplusplus >= 201103L)
+// -*- c++ -*-
+
+// This file is part of the Collective Variables module (Colvars).
+// The original version of Colvars and its updates are located at:
+// https://github.com/Colvars/colvars
+// Please update all Colvars source files before making any changes.
+// If you wish to distribute your changes, please submit them to the
+// Colvars repository at GitHub.
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
@@ -184,5 +191,3 @@ void colvar::neuralNetwork::apply_force(colvarvalue const &force) {
         }
     }
 }
-
-#endif

--- a/src/colvars_version.h
+++ b/src/colvars_version.h
@@ -1,3 +1,3 @@
 #ifndef COLVARS_VERSION
-#define COLVARS_VERSION "2023-06-21"
+#define COLVARS_VERSION "2023-06-23"
 #endif

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -47,14 +47,10 @@
 // If CVSCRIPT is not defined, this file yields the function prototypes
 #ifndef CVSCRIPT
 
-#ifdef __cplusplus
 #define CVSCRIPT_COMM_PROTO(COMM)                                       \
   extern "C" int CVSCRIPT_COMM_FNAME(COMM)(void *,                      \
-                                           int, unsigned char *const *);
-#else
-#define CVSCRIPT_COMM_PROTO(COMM)                                       \
-  int CVSCRIPT_COMM_FNAME(COMM)(void *, int, unsigned char *const *);
-#endif
+                                           int,                         \
+                                           unsigned char *const *);
 
 #define CVSCRIPT(COMM,HELP,N_ARGS_MIN,N_ARGS_MAX,ARGS,FN_BODY)  \
   CVSCRIPT_COMM_PROTO(COMM)


### PR DESCRIPTION
Recent versions of GROMACS are warning at build time when a derived-class function is lacking `override`, or when the `NULL` macro is used for pointers. Rather than making additional efforts to work around these warnings and similar ones, it makes much more sense to just begin adopting the standard everywhere.

VMD is the only holdout, and the problem is not even with the application itself (which builds just fine with C++11) but rather with the very old OS used at UIUC to build VMD for distribution. We are unaware of their current status (last non-C++11 VMD alpha build is October 2021). However, they will have to address this sooner or later, and probably not because of a small library like Colvars but a much bigger one (i.e. CUDA).

Checklist:
- [x] Update README
- [x] Update documentation
- [x] Remove `#ifdef` guards, which are unreliable for Visual Studio
- [x] Remove pre-C++11 CI jobs