### PR TITLE
Fix overflow of exp in arithmetic path CVs

### DIFF
--- a/src/colvar_arithmeticpath.h
+++ b/src/colvar_arithmeticpath.h
@@ -109,9 +109,10 @@ void ArithmeticPathBase<element_type, scalar_type, path_type>::computeValue() {
         numerator_s += s_numerator_frame[i_frame];
         denominator_s += s_denominator_frame[i_frame];
     }
-    const auto log_s = cvm::logn(normalization_factor) + logsumexp(exponents, frame_indexes) - logsumexp(exponents);
+    const auto log_sum_exp_ = logsumexp(exponents);
+    const auto log_s = cvm::logn(normalization_factor) + logsumexp(exponents, frame_indexes) - log_sum_exp_;
     s = cvm::exp(log_s);
-    z = -1.0 / lambda * logsumexp(exponents);
+    z = -1.0 / lambda * log_sum_exp_;
 }
 
 template <typename element_type, typename scalar_type, path_sz path_type>

--- a/src/colvar_arithmeticpath.h
+++ b/src/colvar_arithmeticpath.h
@@ -18,9 +18,9 @@ double logsumexp(const vector<T>& a, const vector<T>& b) {
     const auto max_a = *std::max_element(a.begin(), a.end());
     T sum = T();
     for (size_t i = 0; i < a.size(); ++i) {
-        sum += b[i] * std::exp(a[i] - max_a);
+        sum += b[i] * cvm::exp(a[i] - max_a);
     }
-    return max_a + std::log(sum);
+    return max_a + cvm::logn(sum);
 }
 
 template <typename T>
@@ -28,9 +28,9 @@ double logsumexp(const vector<T>& a) {
     const auto max_a = *std::max_element(a.begin(), a.end());
     T sum = T();
     for (size_t i = 0; i < a.size(); ++i) {
-        sum += std::exp(a[i] - max_a);
+        sum += cvm::exp(a[i] - max_a);
     }
-    return max_a + std::log(sum);
+    return max_a + cvm::logn(sum);
 }
 
 enum path_sz {S, Z};

--- a/src/colvar_arithmeticpath.h
+++ b/src/colvar_arithmeticpath.h
@@ -117,8 +117,7 @@ void ArithmeticPathBase<element_type, scalar_type, path_type>::computeValue() {
     }
     log_sum_exp_0 = logsumexp(exponents);
     log_sum_exp_1 = logsumexp(exponents, frame_indexes);
-    const auto log_s = cvm::logn(normalization_factor) + log_sum_exp_1 - log_sum_exp_0;
-    s = cvm::exp(log_s);
+    s = normalization_factor * cvm::exp(log_sum_exp_1 - log_sum_exp_0);
     z = -1.0 / lambda * log_sum_exp_0;
 }
 
@@ -138,9 +137,10 @@ void ArithmeticPathBase<element_type, scalar_type, path_type>::computeDerivative
         scalar_type sign_factor_2, sign_factor_3;
         const auto log_sum_exp_2 = logsumexp(exponents, exponents2, &sign_factor_2);
         const auto log_sum_exp_3 = logsumexp(exponents, exponents3, &sign_factor_3);
-        dsdx[j_elem] = -2.0 * lambda * weights[j_elem] * weights[j_elem] * normalization_factor * sign_factor_3 * cvm::exp(log_sum_exp_3 - log_sum_exp_0)
-                       +2.0 * lambda * weights[j_elem] * weights[j_elem] * normalization_factor * sign_factor_2 * cvm::exp(log_sum_exp_2 + log_sum_exp_1 - 2.0 * log_sum_exp_0);
-        dzdx[j_elem] = 2.0 * weights[j_elem] * weights[j_elem] * sign_factor_2 * cvm::exp(log_sum_exp_2 - log_sum_exp_0);
+        const auto tmp_factor = 2.0 * weights[j_elem] * weights[j_elem];
+        dsdx[j_elem] = -tmp_factor * lambda * normalization_factor *
+                        (sign_factor_3 * cvm::exp(log_sum_exp_3 - log_sum_exp_0) - sign_factor_2 * cvm::exp(log_sum_exp_2 + log_sum_exp_1 - 2.0 * log_sum_exp_0));
+        dzdx[j_elem] = tmp_factor * sign_factor_2 * cvm::exp(log_sum_exp_2 - log_sum_exp_0);
     }
 }
 


### PR DESCRIPTION
Using LogSumExp instead of calculating the equations directly to get rid of NaN in aspathCV and azpathCV.