### PR TITLE
Update containers for Linux CI builds

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -25,6 +25,10 @@ on:
         description: "Name of the branch of the backend repository"
         required: true
         type: string
+      container_name:
+        description: "Name of the container used to build on"
+        required: true
+        type: string
       vmd_plugins_repo:
         description: "Name of the VMD plugins repository"
         required: false
@@ -71,7 +75,7 @@ jobs:
         with:
           path: |
             ~/.ccache
-            ~/ccache_CentOS7-devel
+            ~/ccache_${{ inputs.container_name }}
           key: ${{ runner.os }}-build-${{ inputs.backend_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-build-${{ inputs.backend_name }}-
@@ -122,11 +126,11 @@ jobs:
           wget https://github.com/apptainer/apptainer/releases/download/v1.0.3/apptainer_1.0.3_amd64.deb
           sudo apt-get -y install ./apptainer_1.0.3_amd64.deb
 
-      - name: Get container image of backends' dependencies
+      - name: Get container images for build dependencies
         shell: bash
         working-directory: devel-tools
         run: |
-          # Pull CentOS 7 container used to build backends
+          # Pull all containers used to build backends
           # (contains build tools, OpenMPI, FFTW, Tcl/Tk and Charm++)
           apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
           apptainer remote use SylabsCloud
@@ -136,16 +140,16 @@ jobs:
       - name : Get spiff
         shell: bash
         working-directory: devel-tools
-        run: sudo cp -f $(apptainer exec CentOS7-devel.sif ./get_spiff) /usr/local/bin
+        run: sudo cp -f $(apptainer exec ${{ inputs.container_name }}.sif ./get_spiff) /usr/local/bin
 
       - name: Update and build ${{ inputs.backend_name }}
         shell: bash
         env:
           OPENMM_SOURCE: ${{ github.workspace }}/openmm-source
         run: |
-          apptainer exec devel-tools/CentOS7-devel.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
-          CCACHE_DIR=~/ccache_CentOS7-devel \
-          apptainer exec devel-tools/CentOS7-devel.sif \
+          apptainer exec devel-tools/${{ inputs.container_name }}.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
+          CCACHE_DIR=~/ccache_${{ inputs.container_name }} \
+          apptainer exec devel-tools/${{ inputs.container_name }}.sif \
           bash ${{ inputs.path_compile_script }} ${{ inputs.backend_name }}-source
 
 
@@ -158,7 +162,7 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.test_lib_directory }}
         run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/${{ inputs.container_name }}.sif \
           ./run_tests.sh ${{github.workspace}}/${{ inputs.backend_name }}-source/${{ inputs.rpath_exe }} 0??_*
 
       - name: Run regression tests for ${{ inputs.backend_name }} interface code
@@ -166,5 +170,5 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.test_interface_directory }}
         run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
+          apptainer exec ${{github.workspace}}/devel-tools/${{ inputs.container_name }}.sif \
           ./run_tests.sh ${{github.workspace}}/${{ inputs.backend_name }}-source/${{ inputs.rpath_exe }}

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2022-10-11
+          key: Linux-x86_64-containers-build-2023-07-20
 
       - name: Checkout OpenMM (for Lepton library)
         uses: actions/checkout@v3
@@ -131,6 +131,7 @@ jobs:
           apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
           apptainer remote use SylabsCloud
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
+          apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
 
       - name : Get spiff
         shell: bash

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -26,6 +26,7 @@ jobs:
       backend_name: LAMMPS
       backend_repo: lammps/lammps
       backend_repo_ref: develop
+      container_name: CentOS7-devel
       path_compile_script: devel-tools/compile-lammps.sh
       test_lib_directory: lammps/tests/library
       test_interface_directory: lammps/tests/interface
@@ -43,6 +44,7 @@ jobs:
       backend_name: NAMD
       backend_repo: Colvars/namd
       backend_repo_ref: master
+      container_name: CentOS7-devel
       path_compile_script: devel-tools/compile-namd.sh
       test_lib_directory: namd/tests/library
       test_interface_directory: namd/tests/interface
@@ -68,6 +70,7 @@ jobs:
       # Interface tests disabled until map variables are merged into NAMD3
       # test_interface_directory: namd/tests/interface
       rpath_exe: Linux-x86_64-g++.multicore/namd3
+      container_name: CentOS7-devel
     secrets:
       # Choice of license by UIUC prevents sharing the code, hence the secret
       private_key: ${{ secrets.PULL_NAMD_KEY }}
@@ -84,6 +87,7 @@ jobs:
       backend_name: VMD
       backend_repo: Colvars/vmd
       backend_repo_ref: master
+      container_name: CentOS7-devel
       # Special variable for VMD test case since it's the only one
       # which needs to checkout 2 repos
       vmd_plugins_repo: Colvars/vmd-plugins
@@ -103,6 +107,7 @@ jobs:
       backend_name: GROMACS-2020
       backend_repo: gromacs/gromacs
       backend_repo_ref: release-2020
+      container_name: CentOS7-devel
       path_compile_script: devel-tools/compile-gromacs.sh
       test_lib_directory: gromacs/tests/library
       # Gromacs need to be compiled in double precision to pass the tests
@@ -116,6 +121,7 @@ jobs:
       backend_name: GROMACS-2021
       backend_repo: gromacs/gromacs
       backend_repo_ref: release-2021
+      container_name: CentOS9-devel
       path_compile_script: devel-tools/compile-gromacs.sh
       test_lib_directory: gromacs/tests/library
       rpath_exe: install/bin/gmx_d
@@ -128,6 +134,7 @@ jobs:
       backend_name: GROMACS-2022
       backend_repo: gromacs/gromacs
       backend_repo_ref: release-2022
+      container_name: CentOS9-devel
       path_compile_script: devel-tools/compile-gromacs.sh
       test_lib_directory: gromacs/tests/library
       rpath_exe: install/bin/gmx_d

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -198,7 +198,7 @@ jobs:
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
           apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
 
-      - name: GCC 4.8, C++11
+      - name: GCC 4.8, C++11 (CentOS 7)
         env:
           CXX_STANDARD: 11
           CXX: g++
@@ -208,29 +208,7 @@ jobs:
           apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 8, C++17
-        env:
-          CXX_STANDARD: 17
-          CXX: g++
-          CXX_VERSION: 8
-          CC: gcc
-        run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          scl enable devtoolset-${CXX_VERSION} -- \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
-
-      - name: GCC 11, C++20
-        env:
-          CXX_STANDARD: 20
-          CXX: g++
-          CXX_VERSION: 11
-          CC: gcc
-        run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          scl enable devtoolset-${CXX_VERSION} -- \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
-
-      - name: Clang 3.4, C++11
+      - name: Clang 3.4, C++11 (CentOS 7)
         env:
           CXX_STANDARD: 11
           CXX: clang++
@@ -240,7 +218,7 @@ jobs:
           apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: Clang 7, C++17
+      - name: Clang 7, C++17 (CentOS 7)
         env:
           CXX_STANDARD: 17
           CXX: clang++
@@ -251,29 +229,29 @@ jobs:
           scl enable llvm-toolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 11, C++17
+      - name: GCC 8, C++14 (CentOS 7)
         env:
-          CXX_STANDARD: 17
+          CXX_STANDARD: 14
           CXX: g++
-          CXX_VERSION: 11
+          CXX_VERSION: 8
           CC: gcc
         run: |
           apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 10, C++17
+      - name: GCC 8, C++17 (CentOS 7)
         env:
           CXX_STANDARD: 17
           CXX: g++
-          CXX_VERSION: 10
+          CXX_VERSION: 8
           CC: gcc
         run: |
           apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 9, C++14
+      - name: GCC 9, C++14 (CentOS 7)
         env:
           CXX_STANDARD: 14
           CXX: g++
@@ -284,49 +262,109 @@ jobs:
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 8, C++14
+      - name: GCC 10, C++17 (CentOS 7)
         env:
-          CXX_STANDARD: 14
+          CXX_STANDARD: 17
           CXX: g++
-          CXX_VERSION: 8
+          CXX_VERSION: 10
           CC: gcc
         run: |
           apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           scl enable devtoolset-${CXX_VERSION} -- \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 8, C++11
+
+      - name: GCC 11, C++11 (CentOS 9)
         env:
           CXX_STANDARD: 11
           CXX: g++
-          CXX_VERSION: 8
+          CXX_VERSION: 11
           CC: gcc
         run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          scl enable devtoolset-${CXX_VERSION} -- \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 7, C++14
+      - name: GCC 11, C++14 (CentOS 9)
         env:
           CXX_STANDARD: 14
           CXX: g++
-          CXX_VERSION: 7
+          CXX_VERSION: 11
           CC: gcc
         run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          scl enable devtoolset-${CXX_VERSION} -- \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: GCC 7, C++11
+      - name: GCC 11, C++17 (CentOS 9)
+        env:
+          CXX_STANDARD: 17
+          CXX: g++
+          CXX_VERSION: 11
+          CC: gcc
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+
+      - name: GCC 11, C++20 (CentOS 9)
+        env:
+          CXX_STANDARD: 20
+          CXX: g++
+          CXX_VERSION: 11
+          CC: gcc
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+
+      - name: GCC 12, C++11 (CentOS 9)
         env:
           CXX_STANDARD: 11
           CXX: g++
-          CXX_VERSION: 7
+          CXX_VERSION: 12
           CC: gcc
         run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
-          scl enable devtoolset-${CXX_VERSION} -- \
-          cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          scl enable gcc-toolset-12 -- \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+
+      - name: GCC 12, C++20 (CentOS 9)
+        env:
+          CXX_STANDARD: 20
+          CXX: g++
+          CXX_VERSION: 12
+          CC: gcc
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          scl enable gcc-toolset-12 -- \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+
+      - name: Clang 16, C++11 (CentOS 9)
+        env:
+          CXX_STANDARD: 11
+          CXX: clang++
+          CXX_VERSION: 16
+          CC: clang
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+
+      - name: Clang 16, C++17 (CentOS 9)
+        env:
+          CXX_STANDARD: 17
+          CXX: clang++
+          CXX_VERSION: 16
+          CC: clang
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
+
+      - name: Clang 16, C++20 (CentOS 9)
+        env:
+          CXX_STANDARD: 20
+          CXX: clang++
+          CXX_VERSION: 16
+          CC: clang
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
+          cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
 
   build-linux-x86_64-sun:

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-doc-2022-09-03
+          key: Linux-x86_64-containers-build-doc-2023-07-19
 
       - name: Install Apptainer
         shell: bash
@@ -102,7 +102,7 @@ jobs:
         run: |
           apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
           apptainer remote use SylabsCloud
-          apptainer pull Fedora35-texlive.sif library://giacomofiorin/default/colvars_development:fedora35_texlive
+          apptainer pull texlive.sif library://giacomofiorin/default/colvars_development:texlive
 
       - name: Checkout website repository
         uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
         env:
           COLVARSDIR: ${{ github.workspace }}
           FORCE: 1  # Ignore error if branch isn't master
-        run: apptainer exec ${COLVARSDIR}/devel-tools/Fedora35-texlive.sif make
+        run: apptainer exec ${COLVARSDIR}/devel-tools/texlive.sif make
 
 
   codeql:
@@ -174,7 +174,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2022-10-11
+          key: Linux-x86_64-containers-build-2023-07-20
 
       - name: Get small downloadable packages
         uses: actions/checkout@v3
@@ -196,6 +196,7 @@ jobs:
           apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
           apptainer remote use SylabsCloud
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
+          apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
 
       - name: GCC 4.8, C++11
         env:
@@ -340,7 +341,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2022-10-11
+          key: Linux-x86_64-containers-build-2023-07-20
 
       - name: Checkout Sun compiler (Oracle Developer Studio)
         uses: actions/checkout@v3
@@ -370,6 +371,7 @@ jobs:
           apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
           apptainer remote use SylabsCloud
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
+          apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
 
       - name: Build library with Sun compiler (Oracle Developer Studio)
         shell: bash

--- a/devel-tools/compile-namd.sh
+++ b/devel-tools/compile-namd.sh
@@ -72,7 +72,14 @@ EOF
 
     cmd+=(--tcl-prefix ${TCL_HOME:-/usr})
     cmd+=(--with-fftw3 --fftw-prefix ${FFTW_HOME:-/usr})
-    cmd+=(--with-python)
+
+    local python_version=$(python3 --version 2> /dev/null | cut -d' ' -f 2)
+    python_version=${python_version%.*}
+    if [ "x${python_version}" == "x3.6" ] || [ "x${python_version}" == "x3.7" ] || \
+        [ "x${python_version}" == "x3.8" ] ; then
+        # Currently does not build with >= 3.9 API
+        cmd+=(--with-python)
+    fi
 
     eval ${cmd[@]}
 

--- a/devel-tools/containers/CentOS7-devel.def
+++ b/devel-tools/containers/CentOS7-devel.def
@@ -1,0 +1,49 @@
+BootStrap: library
+From: centos:7
+
+
+%help
+    Development environment for CentOS 7
+
+
+%post
+    yum -y update
+    yum -y install epel-release centos-release-scl
+    yum -y install \
+        redhat-lsb-core "@Development Tools" \
+        ncurses which bc man-db vim emacs screen tmux \
+        gcc gcc-c++ gcc-gfortran glibc-static libstdc++-static clang cppcheck \
+        autoconf automake  cvs git git-cvs cvsps subversion mercurial \
+        rh-git227 devtoolset-{7..11} llvm-toolset-7 cmake3 ccache ninja \
+        doxygen \
+        openmpi-devel fftw-devel tcl-devel \
+        python-{devel,virtualenv} numpy scipy tkinter \
+        python3-{devel,tkinter} python36-{virtualenv,numpy,scipy} \
+        rh-python38-python-{devel,tkinter,numpy,scipy} \
+        boost169-devel \
+        ncurses-devel \
+        rlwrap \
+        tk-devel fltk-devel \
+        sqlite-devel netcdf-devel expat-devel hdf5-devel tng-devel \
+        mesa-dri-drivers mesa-libGL-devel libglvnd-devel \
+        libXi-devel libXinerama-devel libpng-devel \
+        xfce4-terminal \
+        texlive-latex texlive-epstopdf texlive-pdftex latex2html \
+        texlive-graphics texlive-metafont \
+        texlive-collection-latexrecommended texlive-collection-fontsrecommended
+
+    # Build Charm++
+    umask 022
+    git clone --single-branch --depth=1 -b v7.0.0 https://github.com/UIUC-PPL/charm.git /opt/charm && \
+        cd /opt/charm && \
+        ./build charm++ mpi-linux-x86_64 -j\$(nproc) --with-production && \
+        ./build charm++ multicore-linux-x86_64 -j\$(nproc) --with-production && \
+        ./build charm++ netlrts-linux-x86_64 -j\$(nproc) --with-production
+
+    # Load Git 2.27
+    cat > /etc/profile.d/git.sh <<EOF
+if [ \$(id -u) != 0 ] && [ -d /opt/rh/rh-git227 ] ; then
+    source /opt/rh/rh-git227/enable
+fi
+EOF
+

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -1,0 +1,48 @@
+BootStrap: docker
+From: quay.io/centos/centos:stream9
+
+
+%help
+    Development environment for CentOS Stream Linux 9
+
+
+%post
+    dnf -y update
+    dnf -y install dnf-plugins-core
+
+    dnf config-manager --set-enabled crb
+    dnf -y install \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+        https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+
+    dnf -y install \
+        bc man-db vim emacs tcsh \
+        "@Development Tools" \
+        gcc gcc-c++ gcc-gfortran cppcheck \
+        gcc-toolset-{12,13} \
+        autoconf automake cvs git subversion mercurial \
+        cmake ccache \
+        openmpi-devel tbb-devel fftw-devel tcl-devel \
+        python3-{devel,tkinter,virtualenv,numpy,scipy} \
+        ncurses-devel \
+        rlwrap \
+        tk-devel fltk-devel \
+        mesa-dri-drivers mesa-libGL-devel libglvnd-devel \
+        libXi-devel libXinerama-devel libpng-devel \
+        netcdf-devel sqlite-devel \
+        texlive-latex texlive-epstopdf texlive-pdftex latex2html \
+        texlive-graphics texlive-metafont texlive-collection-latexrecommended \
+        texlive-collection-fontsrecommended \
+	squashfs-tools
+
+    source /etc/profile
+    module load mpi
+
+    # Build Charm++
+    umask 022
+    git clone --single-branch --depth=1 -b v7.0.0 https://github.com/UIUC-PPL/charm.git /opt/charm
+    cd /opt/charm
+    export CCACHE_DIR=/tmp
+    ./build charm++ mpi-linux-x86_64 -j\$(nproc) --with-production
+    ./build charm++ netlrts-linux-x86_64 -j\$(nproc) --with-production
+    ./build charm++ multicore-linux-x86_64 -j\$(nproc) --with-production

--- a/devel-tools/containers/README.md
+++ b/devel-tools/containers/README.md
@@ -1,0 +1,12 @@
+1. Install Apptainer (formerly Singularity), either from your Linux
+   distribution's package manager or from https://github.com/apptainer/apptainer/releases/
+
+2. Build a container from its definition file using:
+```
+apptainer build container.sif container.def
+```
+
+3. Run a shell inside the container:
+```
+apptainer run container.sif
+```

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -365,7 +365,7 @@ then
   condcopy "${source}/namd/lepton/Makefile.namd" \
            "${target}/lepton/Makefile.namd"
 
-  if ! grep -q lepton/Makefile.namd "${target}/lepton/Makefile.namd" ; then
+  if ! grep -q lepton/Makefile.namd "${target}/Makefile" ; then
     patch -p1 -N -d ${target} < namd/Makefile.patch
   fi
 

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # -*- sh-basic-offset: 2; sh-indentation: 2; -*-
 
+set -e
+
 # Script to update a NAMD, VMD, LAMMPS or GROMACS source tree with the latest Colvars
 # version.
 


### PR DESCRIPTION
Adding a new container based on CentOS Stream 9, with a package selection equivalent to the pre-existing CentOS 7 container. Although CentOS 7 supports some recent GCC versions, the rest of the OS is quite ancient.

Note: there is a continuing discussion about Red Hat Enterprise Linux, its clones, and other distributions such as Debian or Ubuntu. The choice of CentOS 9 in this PR is only intended out of convenience. 

With the addition of GCC 12 and Clang 16 alongside the older 4.8 and 3.3, there is a better mix of old and new compilers to test on.  For now the backends are still built on CentOS 7, because some regression tests fail slightly (1.0e-5), but otherwise all backends will build and run on the newer container as well.

Notably, when VMD is built with GCC 11, it will assume the default standard, which is C++17, i.e. no patching is needed to build VMD in compliance with modern C++. Maybe we could add Lepton to the build test as well?

Input welcome from all. @HubLot specifically should comment on whether we should build GROMACS on CentOS 9 or wait to change that until the MDModules interface is merged here.