### PR TITLE
Separate checking the name of the bias from reading its state data

### DIFF
--- a/src/colvarbias.h
+++ b/src/colvarbias.h
@@ -133,6 +133,9 @@ public:
   /// Write the values of specific mutable properties to a string
   virtual std::string const get_state_params() const;
 
+  /// Check the name of the bias vs. the given string, set the matching_state flag accordingly
+  int check_matching_state(std::string const &conf);
+
   /// Read the values of specific mutable properties from a string
   virtual int set_state_params(std::string const &state_conf);
 


### PR DESCRIPTION
The flexibility introduced in #320 allows adding or removing colvars and biases between consecutive runs.

For biases specifically there is a caveat because the name check is done in `colvarbias::set_state_params()`, which exits right away (as it should), but it is also called indirectly by the functions of the same name in derived classes. These functions would then proceed to load state data even in case of a mismatch.

The chances of this bug affecting a computation seem small: one would need to be adding or removing a history-dependent bias of the same kind to a simulation, which goes contrary to using this kind of bias. Even when two history-dependent biases are used together (meta-eABF comes to mind) this is done in a permanent manner. Nonetheless, this needs to be fixed.

