### PR TITLE
Disable Sun compiler +w, use Clang -Wshadow-field when available 

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -52,7 +52,14 @@ endif()
 
 target_compile_options(colvars PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Intel>>:-Wall -pedantic>)
 
-target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:SunPro>:+w>)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_VERSION GREATER 6)
+    target_compile_options(colvars PRIVATE -Wshadow-field)
+  endif()
+endif()
+
+# # Note: disabled +w flags for Sun compiler due to their inconsistency
+# target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:SunPro>:+w>)
 # # Uncomment the line below to enable more thorough checks with Sun Compiler
 # target_compile_options(colvars PRIVATE $<$<CXX_COMPILER_ID:SunPro>:+w2>)
 

--- a/src/colvarbias_abf.h
+++ b/src/colvarbias_abf.h
@@ -39,9 +39,6 @@ public:
 
 private:
 
-  /// Filename prefix for human-readable gradient/sample count output
-  std::string  output_prefix;
-
   /// Base filename(s) for reading previous gradient data (replaces data from restart file)
   std::vector<std::string> input_prefix;
 


### PR DESCRIPTION
The "additional" warnings from the Sun compilers seem to become less useful, e.g. I've recently come across some clear false positives. This PR keeps the compilation but disables the +w flag. 

One of its most useful functions is to warn about shadowing members from a parent class. GCC and Clang have a -Wshadow flag, which is too aggressive, but Clang has a -Wshadow-field that seems just right.