### PR TITLE
Option to run NAMD regtests in GPU-resident mode

### DIFF
--- a/namd/tests/library/Common/common.namd
+++ b/namd/tests/library/Common/common.namd
@@ -70,7 +70,8 @@ if { [info exists xsc_file] > 0 } {
 }
 
 COMmotion               no
-zeroMomentum            yes
+# incompatible with TclForces as of 07/2023
+#zeroMomentum            yes
 
 timestep                1.0
 

--- a/namd/tests/library/Common/common.namd
+++ b/namd/tests/library/Common/common.namd
@@ -70,7 +70,7 @@ if { [info exists xsc_file] > 0 } {
 }
 
 COMmotion               no
-# incompatible with TclForces as of 07/2023
+# incompatible with CUDASOAIntegrate as of 09/2023
 #zeroMomentum            yes
 
 timestep                1.0

--- a/namd/tests/library/Common/test.namd
+++ b/namd/tests/library/Common/test.namd
@@ -3,7 +3,14 @@
 # Note: see also test.restart.namd, test.legacy.namd, test.restart.legacy.namd
 
 source ../Common/common.namd
-source ../Common/measure_net_force_torque.tcl
+
+if { [info exists env(NAMD_CUDASOA)] && $env(NAMD_CUDASOA) } {
+  CUDASOAIntegrate on
+  # incompatible with TclForces as of 07/2023
+} else {
+  source ../Common/measure_net_force_torque.tcl
+}
+
 
 colvars on
 

--- a/namd/tests/library/README.md
+++ b/namd/tests/library/README.md
@@ -12,7 +12,7 @@ This is the usage information for `run_tests.sh`:
 ```
 Usage: ./run_tests.sh [-h] [-g] [path_to_namd2] [testdir1 [testdir2 ...]]
     The -g option (re)generates reference outputs in the given directories
-    The -gpu option enables the GPU-resident NAMD3 code path (CUDASOAIntegrate)
+    The -cudasoa option enables the GPU-resident NAMD3 code path (CUDASOAIntegrate)
     If no executable is given, "namd2" is used
     If no directories are given, all matches of [0-9][0-9][0-9]_* are used
 ```

--- a/namd/tests/library/README.md
+++ b/namd/tests/library/README.md
@@ -12,6 +12,7 @@ This is the usage information for `run_tests.sh`:
 ```
 Usage: ./run_tests.sh [-h] [-g] [path_to_namd2] [testdir1 [testdir2 ...]]
     The -g option (re)generates reference outputs in the given directories
+    The -gpu option enables the GPU-resident NAMD3 code path (CUDASOAIntegrate)
     If no executable is given, "namd2" is used
     If no directories are given, all matches of [0-9][0-9][0-9]_* are used
 ```

--- a/namd/tests/library/run_tests.sh
+++ b/namd/tests/library/run_tests.sh
@@ -299,11 +299,11 @@ else
   echo "$(${TPUT_RED})There were failed tests.$(${TPUT_CLEAR})"
   if [ ${#failed_tests[@]} -gt 0 ]; then
     echo "The following tests are failed:"
-    printf "%s\n" "${failed_tests[@]}"
+    printf "%s\n" "${failed_tests[@]}" | sort -u
   fi
   if [ ${#failed_tests_low_prec[@]} -gt 0 ]; then
     echo "The following tests are failed, but passed at low precisions:"
-    printf "%s\n" "${failed_tests_low_prec[@]}"
+    printf "%s\n" "${failed_tests_low_prec[@]}" | sort -u
   fi
   exit 1
 fi

--- a/namd/tests/library/run_tests.sh
+++ b/namd/tests/library/run_tests.sh
@@ -24,15 +24,15 @@ while [ $# -ge 1 ]; do
     gen_ref_output='yes'
     echo "Generating reference output"
   elif [ "x$1" = 'x-h' ]; then
-    echo "Usage: ./run_tests.sh [-h] [-g] [-gpu] [path_to_namd2] [testdir1 [testdir2 ...]]"  >& 2
+    echo "Usage: ./run_tests.sh [-h] [-g] [-cudasoa] [path_to_namd2] [testdir1 [testdir2 ...]]"  >& 2
     echo "    The -g option (re)generates reference outputs in the given directories" >& 2
-    echo "    The -gpu option enables the GPU-resident NAMD3 code path (CUDASOAIntegrate)" >& 2
+    echo "    The -cudasoa option enables the GPU-resident NAMD3 code path (CUDASOAIntegrate)" >& 2
     echo "    If no executable is given, \"namd2\" is used" >& 2
     echo "    If no directories are given, all matches of [0-9][0-9][0-9]_* are used" >& 2
     echo "    This script relies on the executable spiff to be available, and will try to " >& 2
     echo "    download and build it into $TMPDIR if needed." >& 2
     exit 0
-  elif [ "x$1" = 'x-gpu' ]; then
+  elif [ "x$1" = 'x-cudasoa' ]; then
     CUDASOA=1
   else
     DIRLIST=`echo ${DIRLIST} $1`


### PR DESCRIPTION
using the option CUDASOAintegrate in NAMD3
This is controlled by the new script option -gpu, via the environment variable NAMD_CUDASOA.
This required disabling zeroMomentum and tclForces.

For now, only the tests using the common NAMD script are affected. Many of the other tests could use it as well.