### PR TITLE
Use Ninja when available to build CMake targets

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2023-07-20
+          key: Linux-x86_64-containers-build-2023-09-05
 
       - name: Checkout OpenMM (for Lepton library)
         uses: actions/checkout@v3

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -137,11 +137,6 @@ jobs:
           apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
           apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
 
-      - name : Get spiff
-        shell: bash
-        working-directory: devel-tools
-        run: sudo cp -f $(apptainer exec ${{ inputs.container_name }}.sif ./get_spiff) /usr/local/bin
-
       - name: Update and build ${{ inputs.backend_name }}
         shell: bash
         env:

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -146,6 +146,7 @@ jobs:
         shell: bash
         env:
           OPENMM_SOURCE: ${{ github.workspace }}/openmm-source
+          CMAKE_GENERATOR: Ninja
         run: |
           apptainer exec devel-tools/${{ inputs.container_name }}.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
           CCACHE_DIR=~/ccache_${{ inputs.container_name }} \

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2023-07-20
+          key: Linux-x86_64-containers-build-2023-09-05
 
       - name: Get small downloadable packages
         uses: actions/checkout@v3
@@ -388,7 +388,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2023-07-20
+          key: Linux-x86_64-containers-build-2023-09-05
 
       - name: Checkout Sun compiler (Oracle Developer Studio)
         uses: actions/checkout@v3

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -165,6 +165,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
       CCACHE: ccache
+      CMAKE_GENERATOR: Ninja
 
     steps:
       - uses: actions/checkout@v3

--- a/devel-tools/containers/CentOS7-devel.def
+++ b/devel-tools/containers/CentOS7-devel.def
@@ -14,7 +14,7 @@ From: centos:7
         ncurses which bc man-db vim emacs screen tmux \
         gcc gcc-c++ gcc-gfortran glibc-static libstdc++-static clang cppcheck \
         autoconf automake  cvs git git-cvs cvsps subversion mercurial \
-        rh-git227 devtoolset-{7..11} llvm-toolset-7 cmake3 ccache ninja \
+        rh-git227 devtoolset-{7..11} llvm-toolset-7 cmake3 ccache ninja-build \
         doxygen \
         openmpi-devel fftw-devel tcl-devel \
         python-{devel,virtualenv} numpy scipy tkinter \

--- a/devel-tools/containers/CentOS7-devel.def
+++ b/devel-tools/containers/CentOS7-devel.def
@@ -34,11 +34,14 @@ From: centos:7
 
     # Build Charm++
     umask 022
-    git clone --single-branch --depth=1 -b v7.0.0 https://github.com/UIUC-PPL/charm.git /opt/charm && \
-        cd /opt/charm && \
-        ./build charm++ mpi-linux-x86_64 -j\$(nproc) --with-production && \
-        ./build charm++ multicore-linux-x86_64 -j\$(nproc) --with-production && \
-        ./build charm++ netlrts-linux-x86_64 -j\$(nproc) --with-production
+    source /etc/profile
+    module load mpi
+    git clone --single-branch --depth=1 -b v7.0.0 https://github.com/UIUC-PPL/charm.git /opt/charm
+    cd /opt/charm
+    export CCACHE_DIR=/tmp
+    ./build charm++ mpi-linux-x86_64 -j16 --with-production && \
+    ./build charm++ multicore-linux-x86_64 -j16 --with-production && \
+    ./build charm++ netlrts-linux-x86_64 -j16 --with-production
 
     # Load Git 2.27
     cat > /etc/profile.d/git.sh <<EOF
@@ -47,3 +50,8 @@ if [ \$(id -u) != 0 ] && [ -d /opt/rh/rh-git227 ] ; then
 fi
 EOF
 
+    # Build and install spiff
+    rm -fr /tmp/spiff
+    git clone https://github.com/jhenin/spiff /tmp/spiff && \
+        make -C /tmp/spiff && \
+        install /tmp/spiff/spiff /usr/local/bin/

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -21,7 +21,7 @@ From: quay.io/centos/centos:stream9
         gcc gcc-c++ gcc-gfortran cppcheck \
         gcc-toolset-{12,13} \
         autoconf automake cvs git subversion mercurial \
-        cmake ccache \
+        cmake ccache ninja-build \
         openmpi-devel tbb-devel fftw-devel tcl-devel \
         python3-{devel,tkinter,virtualenv,numpy,scipy} \
         ncurses-devel \

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -40,9 +40,17 @@ From: quay.io/centos/centos:stream9
 
     # Build Charm++
     umask 022
+    source /etc/profile
+    module load mpi
     git clone --single-branch --depth=1 -b v7.0.0 https://github.com/UIUC-PPL/charm.git /opt/charm
     cd /opt/charm
     export CCACHE_DIR=/tmp
-    ./build charm++ mpi-linux-x86_64 -j\$(nproc) --with-production
-    ./build charm++ netlrts-linux-x86_64 -j\$(nproc) --with-production
-    ./build charm++ multicore-linux-x86_64 -j\$(nproc) --with-production
+    ./build charm++ mpi-linux-x86_64 -j16 --with-production && \
+    ./build charm++ multicore-linux-x86_64 -j16 --with-production && \
+    ./build charm++ netlrts-linux-x86_64 -j16 --with-production
+
+    # Build and install spiff
+    rm -fr /tmp/spiff
+    git clone https://github.com/jhenin/spiff /tmp/spiff && \
+        make -C /tmp/spiff && \
+        install /tmp/spiff/spiff /usr/local/bin/


### PR DESCRIPTION
Also, due to changes in libcurses version, spiff executables are no longer portable, so I updated the container images to bundle it.