### PR TITLE
Reset error code when invoking colvarmodule::reset()

### DIFF
--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -1279,7 +1279,9 @@ int colvarmodule::reset()
   proxy->flush_output_streams();
   proxy->reset();
 
-  return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);
+  clear_error();
+
+  return COLVARS_OK;
 }
 
 


### PR DESCRIPTION
When `reset()` is called it is not an automatic operation but it is invoked by design, so it should be interpreted as part of the caller's way to deal with whatever error was there. Directly affects GROMACS interface, VMD CLI interface and Dashboard GUI.
