### PR TITLE
Silence clang-tidy warnings

### DIFF
--- a/lammps/src/COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/COLVARS/colvarproxy_lammps.h
@@ -77,7 +77,7 @@ class colvarproxy_lammps : public colvarproxy {
   double compute();
 
   // Request to set the units used internally by Colvars
-  int set_unit_system(std::string const &units_in, bool check_only = false) override;
+  int set_unit_system(std::string const &units_in, bool check_only) override;
 
   /// Convert a command-line argument to string
   char const *script_obj_to_str(unsigned char *obj);

--- a/misc_interfaces/C_fortran/colvarproxy_C.h
+++ b/misc_interfaces/C_fortran/colvarproxy_C.h
@@ -12,7 +12,7 @@ public:
   ~colvarproxy_C();
 
 private:
-  int set_unit_system(std::string const &units, bool check_only = false) { return 0.; }
+  int set_unit_system(std::string const &units, bool check_only) { return 0.; }
 
   /// \brief Boltzmann constant
   cvm::real boltzmann() { return 0.; }

--- a/misc_interfaces/stubs/colvarproxy_stub.cpp
+++ b/misc_interfaces/stubs/colvarproxy_stub.cpp
@@ -78,7 +78,7 @@ int colvarproxy_stub::set_unit_system(std::string const &units_in,
                                             bool check_only)
 {
   // if check_only is specified, just test for compatibility
-  // cvolvarmodule does that if new units are requested while colvars are already defined
+  // colvarmodule sets this flag if new units are requested while colvars are already defined
   if (check_only) {
     if ((units != "" && units_in != units) || (units == "" && units_in != "real")) {
       cvm::error("Specified unit system \"" + units_in + "\" is incompatible with previous setting \""

--- a/misc_interfaces/stubs/colvarproxy_stub.h
+++ b/misc_interfaces/stubs/colvarproxy_stub.h
@@ -35,7 +35,7 @@ public:
 
   void error(std::string const &message) override;
 
-  int set_unit_system(std::string const &units_in, bool check_only = false) override;
+  int set_unit_system(std::string const &units_in, bool check_only) override;
 
   int init_atom(int atom_number) override;
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -82,7 +82,7 @@ public:
 
   void log(std::string const &message) override;
   void error(std::string const &message) override;
-  int set_unit_system(std::string const &units_in, bool check_only = false) override;
+  int set_unit_system(std::string const &units_in, bool check_only) override;
   void add_energy(cvm::real energy) override;
   void request_total_force(bool yesno) override;
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -191,13 +191,13 @@ public:
   int load_atoms(char const *filename,
                  cvm::atom_group &atoms,
                  std::string const &pdb_field,
-                 double const pdb_field_value = 0.0) override;
+                 double const pdb_field_value) override;
 
   int load_coords(char const *filename,
                   std::vector<cvm::atom_pos> &pos,
                   const std::vector<int> &indices,
                   std::string const &pdb_field,
-                  double const pdb_field_value = 0.0) override;
+                  double const pdb_field_value) override;
 
 
   int scalable_group_coms() override

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -250,7 +250,7 @@ public:
 #endif
 
   std::ostream &output_stream(std::string const &output_name,
-                              std::string const description = "file/channel") override;
+                              std::string const description) override;
 
   int flush_output_stream(std::string const &output_name) override;
 

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -2974,14 +2974,11 @@ int colvar::calc_runave()
         runave_variance *= 1.0 / cvm::real(runave_length-1);
 
         if (runave_outfile.size() > 0) {
-          std::ostream &runave_os = proxy->output_stream(runave_outfile);
-          runave_os << std::setw(cvm::it_width) << cvm::step_relative()
-                    << "   "
-                    << std::setprecision(cvm::cv_prec)
-                    << std::setw(cvm::cv_width)
-                    << runave << " "
-                    << std::setprecision(cvm::cv_prec)
-                    << std::setw(cvm::cv_width)
+          std::ostream &runave_os =
+              proxy->output_stream(runave_outfile, "running average output file");
+          runave_os << std::setw(cvm::it_width) << cvm::step_relative() << "   "
+                    << std::setprecision(cvm::cv_prec) << std::setw(cvm::cv_width) << runave << " "
+                    << std::setprecision(cvm::cv_prec) << std::setw(cvm::cv_width)
                     << cvm::sqrt(runave_variance) << "\n";
         }
       }

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -183,7 +183,7 @@ public:
   int init();
 
   /// \brief Initialize dependency tree
-  virtual int init_dependencies() override;
+  int init_dependencies() override;
 
   /// \brief Update data required to calculate cvc's
   int setup();
@@ -224,16 +224,13 @@ public:
   static std::vector<feature *> ag_features;
 
   /// \brief Implementation of the feature list accessor for atom group
-  virtual const std::vector<feature *> &features() const override
+  const std::vector<feature *> &features() const override { return ag_features; }
+
+  std::vector<feature *> &modify_features() override { return ag_features; }
+
+  static void delete_features()
   {
-    return ag_features;
-  }
-  virtual std::vector<feature *> &modify_features() override
-  {
-    return ag_features;
-  }
-  static void delete_features() {
-    for (size_t i=0; i < ag_features.size(); i++) {
+    for (size_t i = 0; i < ag_features.size(); i++) {
       delete ag_features[i];
     }
     ag_features.clear();

--- a/src/colvarbias_abf.cpp
+++ b/src/colvarbias_abf.cpp
@@ -602,7 +602,7 @@ int colvarbias_abf::replica_share() {
 template <class T> int colvarbias_abf::write_grid_to_file(T const *grid,
                                                           std::string const &filename,
                                                           bool close) {
-  std::ostream &os = cvm::proxy->output_stream(filename);
+  std::ostream &os = cvm::proxy->output_stream(filename, "multicolumn grid file");
   if (!os) {
     return cvm::error("Error opening file " + filename + " for writing.\n", COLVARS_ERROR | COLVARS_FILE_ERROR);
   }
@@ -620,7 +620,7 @@ template <class T> int colvarbias_abf::write_grid_to_file(T const *grid,
   // (could be implemented as multiple dx files)
   if (num_variables() > 2 && close) {
     std::string  dx = filename + ".dx";
-    std::ostream &dx_os = cvm::proxy->output_stream(dx);
+    std::ostream &dx_os = cvm::proxy->output_stream(dx, "OpenDX grid file");
     if (!dx_os)  {
       return cvm::error("Error opening file " + dx + " for writing.\n", COLVARS_ERROR | COLVARS_FILE_ERROR);
     }

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -624,7 +624,7 @@ int colvarbias_meta::update_bias()
       add_hill(hill(cvm::step_absolute(), hill_weight*hills_scale,
                     colvar_values, colvar_sigmas, replica_id));
       std::ostream &replica_hills_os =
-        cvm::proxy->output_stream(replica_hills_file);
+        cvm::proxy->output_stream(replica_hills_file, "replica hills file");
       if (replica_hills_os) {
         write_hill(replica_hills_os, hills.back());
       } else {
@@ -1777,7 +1777,7 @@ int colvarbias_meta::setup_output()
 
     // if we're running without grids, use a growing list of "hills" files
     // otherwise, just one state file and one "hills" file as buffer
-    std::ostream &list_os = cvm::proxy->output_stream(replica_list_file);
+    std::ostream &list_os = cvm::proxy->output_stream(replica_list_file, "replica list file");
     if (list_os) {
       list_os << "stateFile " << replica_state_file << "\n";
       list_os << "hillsFile " << replica_hills_file << "\n";
@@ -1799,7 +1799,7 @@ int colvarbias_meta::setup_output()
 
   if (b_hills_traj) {
     std::ostream &hills_traj_os =
-      cvm::proxy->output_stream(hills_traj_file_name());
+      cvm::proxy->output_stream(hills_traj_file_name(), "hills trajectory file");
     if (!hills_traj_os) {
       error_code |= COLVARS_FILE_ERROR;
     }
@@ -1902,7 +1902,7 @@ int colvarbias_meta::write_output_files()
   }
   if (b_hills_traj) {
     std::ostream &hills_traj_os =
-      cvm::proxy->output_stream(hills_traj_file_name());
+        cvm::proxy->output_stream(hills_traj_file_name(), "hills trajectory file");
     hills_traj_os << hills_traj_os_buf.str();
     cvm::proxy->flush_output_stream(hills_traj_file_name());
     // clear the buffer
@@ -2008,7 +2008,7 @@ int colvarbias_meta::write_replica_state_file()
   // Write to temporary state file
   std::string const tmp_state_file(replica_state_file+".tmp");
   error_code |= proxy->remove_file(tmp_state_file);
-  std::ostream &rep_state_os = cvm::proxy->output_stream(tmp_state_file);
+  std::ostream &rep_state_os = cvm::proxy->output_stream(tmp_state_file, "temporary state file");
   if (rep_state_os) {
     if (!write_state(rep_state_os)) {
       error_code |= cvm::error("Error: in writing to temporary file \""+
@@ -2027,11 +2027,11 @@ int colvarbias_meta::reopen_replica_buffer_file()
 {
   int error_code = COLVARS_OK;
   colvarproxy *proxy = cvm::proxy;
-  if (proxy->output_stream(replica_hills_file)) {
+  if (proxy->output_stream(replica_hills_file, "replica hills file")) {
     error_code |= proxy->close_output_stream(replica_hills_file);
   }
   error_code |= proxy->remove_file(replica_hills_file);
-  std::ostream &replica_hills_os = proxy->output_stream(replica_hills_file);
+  std::ostream &replica_hills_os = proxy->output_stream(replica_hills_file, "replica hills file");
   if (replica_hills_os) {
     replica_hills_os.setf(std::ios::scientific, std::ios::floatfield);
   } else {

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -784,7 +784,7 @@ public:
   std::string   restart_out_name;
 
   /// Pseudo-random number with Gaussian distribution
-  static real rand_gaussian(void);
+  static real rand_gaussian();
 
 protected:
 

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -40,7 +40,7 @@ public:
   void set_string(std::string const &conf);
 
   /// Default destructor
-  virtual ~colvarparse() override;
+  ~colvarparse() override;
 
   /// Get the configuration string (includes comments)
   inline std::string const & get_config() const

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -608,7 +608,7 @@ public:
   virtual int request_deletion();
 
   /// Whether deallocation was requested
-  inline bool delete_requested()
+  inline bool delete_requested() const
   {
     return b_delete_requested;
   }

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -600,9 +600,9 @@ public:
   colvarproxy();
 
   /// Destructor
-  virtual ~colvarproxy() override;
+  ~colvarproxy() override;
 
-  virtual bool io_available() override;
+  bool io_available() override;
 
   /// Request deallocation of the module (currently only implemented by VMD)
   virtual int request_deletion();

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -72,30 +72,26 @@ public:
   /// (costly) set the corresponding atoms_refcount to zero
   virtual void clear_atom(int index);
 
-  /// \brief Select atom IDs from a file (usually PDB) \param filename name of
-  /// the file \param atoms array to which atoms read from "filename" will be
-  /// appended \param pdb_field (optional) if the file is a PDB and this
-  /// string is non-empty, select atoms for which this field is non-zero
-  /// \param pdb_field_value (optional) if non-zero, select only atoms whose
-  /// pdb_field equals this
-  virtual int load_atoms(char const *filename,
-                         cvm::atom_group &atoms,
-                         std::string const &pdb_field,
-                         double pdb_field_value = 0.0);
+  /// \brief Read a selection of atom IDs from a coordinate file (only PDB is supported)
+  /// \param[in] filename name of the file
+  /// \param[in,out] atoms array into which atoms will be read from "filename"
+  /// \param[in] pdb_field if the file is a PDB and this string is non-empty,
+  /// select atoms for which this field is non-zero
+  /// \param[in] pdb_field_value if non-zero, select only atoms whose pdb_field equals this
+  virtual int load_atoms(char const *filename, cvm::atom_group &atoms, std::string const &pdb_field,
+                         double pdb_field_value);
 
-  /// \brief Load a set of coordinates from a file (usually PDB); if "pos" is
-  /// already allocated, the number of its elements must match the number of
-  /// entries in "filename" \param filename name of the file \param pos array
-  /// of coordinates \param sorted_ids array of sorted internal IDs, used to
-  /// loop through the file only once \param pdb_field (optional) if the file
-  /// is a PDB and this string is non-empty, select atoms for which this field
-  /// is non-zero \param pdb_field_value (optional) if non-zero, select only
-  /// atoms whose pdb_field equals this
-  virtual int load_coords(char const *filename,
-                          std::vector<cvm::atom_pos> &pos,
-                          std::vector<int> const &sorted_ids,
-                          std::string const &pdb_field,
-                          double pdb_field_value = 0.0);
+  /// \brief Load a set of coordinates from a file (PDB or XYZ)
+  /// \param[in] filename name of the file
+  /// \param[in,out] pos array of coordinates; if not empty, the number of its elements must match
+  /// the number of entries in "filename"
+  /// \param[in] sorted_ids array of sorted internal IDs, used to loop through the file only once
+  /// \param[in] pdb_field if the file is a PDB and this string is non-empty, only atoms for which
+  /// this field is non-zero will be processed
+  /// \param[in] pdb_field_value if non-zero, process only atoms whose pdb_field equals this
+  virtual int load_coords(char const *filename, std::vector<cvm::atom_pos> &pos,
+                          std::vector<int> const &sorted_ids, std::string const &pdb_field,
+                          double pdb_field_value);
 
   /// Clear atomic data
   int reset();

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -139,7 +139,7 @@ public:
   /// \param output_name File name or identifier
   /// \param description Purpose of the file
   virtual std::ostream &output_stream(std::string const &output_name,
-                                      std::string const description = "file/channel");
+                                      std::string const description);
 
   /// Check if the file/channel is open (without opening it if not)
   virtual bool output_stream_exists(std::string const &output_name);

--- a/src/colvarproxy_system.h
+++ b/src/colvarproxy_system.h
@@ -32,7 +32,7 @@ public:
   std::string units;
 
   /// \brief Request to set the units used internally by Colvars
-  virtual int set_unit_system(std::string const &units, bool check_only = false);
+  virtual int set_unit_system(std::string const &units, bool check_only);
 
   /// \brief Convert a length from Angstrom to internal
   inline cvm::real angstrom_to_internal(cvm::real l) const

--- a/tests/functional/run_colvars_test.cpp
+++ b/tests/functional/run_colvars_test.cpp
@@ -18,7 +18,7 @@ extern "C" int main(int argc, char *argv[]) {
 
   colvarproxy_stub *proxy = new colvarproxy_stub();
   // Initialize simple unit system to test file input
-  err |= proxy->set_unit_system("real");
+  err |= proxy->set_unit_system("real", false);
 
   if (argc > 3) {
     err |= proxy->set_output_prefix(argv[3]);

--- a/tests/unittests/read_xyz_traj.cpp
+++ b/tests/unittests/read_xyz_traj.cpp
@@ -9,7 +9,7 @@
 extern "C" int main(int argc, char *argv[]) {
 
   colvarproxy_stub *proxy = new colvarproxy_stub();
-  proxy->set_unit_system("real");
+  proxy->set_unit_system("real", false);
   proxy->set_output_prefix("test.out");
   proxy->colvars->setup_input();
   proxy->colvars->setup_output();

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -68,7 +68,7 @@ public:
 
   virtual void error(std::string const &message);
 
-  virtual int set_unit_system(std::string const &units_in, bool check_only = false);
+  virtual int set_unit_system(std::string const &units_in, bool check_only);
 
   virtual int run_force_callback();
 


### PR DESCRIPTION
Silencing some warnings generated during build jobs of the [GROMACS interface](https://gitlab.com/gromacs/gromacs/-/merge_requests/3671), specifically by library header files  included by files under `src/gromacs/applied_forces/colvars`.

There are certainly more that could be silenced, but those included here are the those that seemed to me more substantial than cosmetic.

@jhenin One of the warnings is about the default argument in `set_unit_system()` just introduced by you. Do you want to revert #573 or just ignore it?

