### PR TITLE
Restore multi-threaded tests for NAMD

### DIFF
--- a/namd/tests/library/run_tests.sh
+++ b/namd/tests/library/run_tests.sh
@@ -59,11 +59,8 @@ if ! { echo ${DIRLIST} | grep -q 0 ; } then
   DIRLIST=`eval ls -d [0-9][0-9][0-9]_*`
 fi
 
-NUM_THREADS=1
 NUM_CPUS=$(nproc)
-if [ ${NUM_THREADS} -gt ${NUM_CPUS} ] ; then
-  NUM_THREADS=${NUM_CPUS}
-fi
+NUM_THREADS=${NUM_THREADS:-${NUM_CPUS}}
 
 TPUT_RED='true'
 TPUT_GREEN='true'


### PR DESCRIPTION
The initial number of threads was reduced to 1 [here](https://github.com/Colvars/colvars/commit/39ed3abdeefce453936fc7f507c7dd7455452d16), due to the errors related to `reinitatoms`, which were later fixed [here](https://github.com/Colvars/colvars/pull/537).