### PR TITLE
Add Tcl 8.6 to CentOS 7 container (NAMD 3.x now requires it)

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build
+          key: Linux-x86_64-containers-build-code
 
       - name: Checkout OpenMM (for Lepton library)
         uses: actions/checkout@v3

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2023-09-05
+          key: Linux-x86_64-containers-build
 
       - name: Checkout OpenMM (for Lepton library)
         uses: actions/checkout@v3

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -74,6 +74,8 @@ jobs:
     secrets:
       # Choice of license by UIUC prevents sharing the code, hence the secret
       private_key: ${{ secrets.PULL_NAMD_KEY }}
+    env:
+      TCL_HOME: /opt/tcl/8.6
 
   vmd:
     name: VMD

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build
+          key: Linux-x86_64-containers-build-code
 
       - name: Get small downloadable packages
         uses: actions/checkout@v3
@@ -388,7 +388,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build
+          key: Linux-x86_64-containers-build-code
 
       - name: Checkout Sun compiler (Oracle Developer Studio)
         uses: actions/checkout@v3

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -234,7 +234,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2023-09-05
+          key: Linux-x86_64-containers-build
 
       - name: Get small downloadable packages
         uses: actions/checkout@v3
@@ -388,7 +388,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.apptainer
-          key: Linux-x86_64-containers-build-2023-09-05
+          key: Linux-x86_64-containers-build
 
       - name: Checkout Sun compiler (Oracle Developer Studio)
         uses: actions/checkout@v3

--- a/devel-tools/compile-namd.sh
+++ b/devel-tools/compile-namd.sh
@@ -72,11 +72,14 @@ EOF
         fi
     fi
 
-    if [ -f /usr/local/include/tcl.h ] ; then
-        cmd+=(--tcl-prefix /usr/local)
-    else
-        cmd+=(--tcl-prefix ${TCL_HOME:-/usr})
+    if [ -z "${TCL_HOME}" ] ; then
+        if [ -f /usr/local/include/tcl.h ] ; then
+            export TCL_HOME=/usr/local
+        else
+            export TCL_HOME=/usr
+        fi
     fi
+    cmd+=(--tcl-prefix ${TCL_HOME})
 
     cmd+=(--with-fftw3 --fftw-prefix ${FFTW_HOME:-/usr})
 

--- a/devel-tools/containers/CentOS7-devel.def
+++ b/devel-tools/containers/CentOS7-devel.def
@@ -10,8 +10,9 @@ From: centos:7
     yum -y update
     yum -y install epel-release centos-release-scl
     yum -y install \
-        redhat-lsb-core "@Development Tools" \
-        ncurses which bc man-db vim emacs screen tmux \
+        redhat-lsb-core \
+        bc man-db vim emacs tcsh which bash-completion screen tmux \
+        "@Development Tools" \
         gcc gcc-c++ gcc-gfortran glibc-static libstdc++-static clang cppcheck \
         autoconf automake cvs git git-cvs cvsps subversion mercurial \
         rh-git227 devtoolset-{7..11} llvm-toolset-7 cmake3 ccache ninja-build \
@@ -55,3 +56,11 @@ EOF
     git clone https://github.com/jhenin/spiff /tmp/spiff && \
         make -C /tmp/spiff && \
         install /tmp/spiff/spiff /usr/local/bin/
+
+    # Build and install Tcl 8.6 to support newer NAMD versions
+    cd /tmp && \
+        curl -O https://newcontinuum.dl.sourceforge.net/project/tcl/Tcl/8.6.13/tcl8.6.13-src.tar.gz && \
+        tar xzf tcl8.6.13-src.tar.gz && \
+        cd tcl8.6.13/unix && \
+        ./configure --prefix=/usr/local && \
+        make -j install


### PR DESCRIPTION
The updated definition file included here was already used to update the [CentOS 7 image](https://cloud.sylabs.io/library/giacomofiorin/default/colvars_development). 

Eventually it would be good to cache these images locally using the GHCR, but that takes a bit more work. Trying to limit the number of large GH caches would seem more pressing. 

@jhenin Can you please check and merge if the tests pass?