### PR TITLE
Use GitHub-hosted container images for CI workflows

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -81,14 +81,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-${{ inputs.backend_name }}-
 
-      # Using an exact key to forgo saving it in case of a match (tarring up
-      # is expensive); also including a date to allow a force-update.
-      - name: Load containers cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.apptainer
-          key: Linux-x86_64-containers-build-code
-
       - name: Checkout OpenMM (for Lepton library)
         uses: actions/checkout@v3
         with:
@@ -132,12 +124,8 @@ jobs:
         shell: bash
         working-directory: devel-tools
         run: |
-          # Pull all containers used to build backends
-          # (contains build tools, OpenMPI, FFTW, Tcl/Tk and Charm++)
-          apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
-          apptainer remote use SylabsCloud
-          apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
-          apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
+          apptainer pull CentOS7-devel.sif oras://ghcr.io/Colvars/devel-containers:CentOS7-devel
+          apptainer pull CentOS9-devel.sif oras://ghcr.io/Colvars/devel-containers:CentOS9-devel
 
       - name: Update and build ${{ inputs.backend_name }}
         shell: bash

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -93,12 +93,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Load containers cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.apptainer
-          key: Linux-x86_64-containers-build-doc-2023-07-19
-
       - name: Install Apptainer
         shell: bash
         run: |
@@ -110,9 +104,7 @@ jobs:
         shell: bash
         working-directory: devel-tools
         run: |
-          apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
-          apptainer remote use SylabsCloud
-          apptainer pull texlive.sif library://giacomofiorin/default/colvars_development:texlive
+          apptainer pull texlive.sif oras://ghcr.io/Colvars/devel-containers:texlive
 
       - name: Checkout website repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -228,14 +228,6 @@ jobs:
           key: ${{ runner.os }}-build-multiple-${{ github.sha }}
           restore-keys: ${{ runner.os }}-build-multiple-
 
-      # Using an exact key to forgo saving it in case of a match (tarring up
-      # is expensive); also including a date to allow a force-update.
-      - name: Load containers cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.apptainer
-          key: Linux-x86_64-containers-build-code
-
       - name: Get small downloadable packages
         uses: actions/checkout@v3
         with:
@@ -250,14 +242,12 @@ jobs:
           sudo apt update
           sudo apt install -y apptainer-suid
 
-      - name: Get container image
+      - name: Get container images for build dependencies
         shell: bash
         working-directory: devel-tools
         run: |
-          apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
-          apptainer remote use SylabsCloud
-          apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
-          apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
+          apptainer pull CentOS7-devel.sif oras://ghcr.io/Colvars/devel-containers:CentOS7-devel
+          apptainer pull CentOS9-devel.sif oras://ghcr.io/Colvars/devel-containers:CentOS9-devel
 
       - name: GCC 4.8, C++11 (CentOS 7)
         env:
@@ -384,12 +374,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Load containers cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.apptainer
-          key: Linux-x86_64-containers-build-code
-
       - name: Checkout Sun compiler (Oracle Developer Studio)
         uses: actions/checkout@v3
         with:
@@ -412,14 +396,11 @@ jobs:
           sudo apt update
           sudo apt install -y apptainer-suid
 
-      - name: Get container image
+      - name: Get container images for build dependencies
         shell: bash
         working-directory: devel-tools
         run: |
-          apptainer remote status SylabsCloud || apptainer remote add --no-login SylabsCloud cloud.sylabs.io
-          apptainer remote use SylabsCloud
-          apptainer pull CentOS7-devel.sif library://giacomofiorin/default/colvars_development:centos7
-          apptainer pull CentOS9-devel.sif library://giacomofiorin/default/colvars_development:centos9
+          apptainer pull CentOS7-devel.sif oras://ghcr.io/Colvars/devel-containers:CentOS7-devel
 
       - name: Build library with Sun compiler (Oracle Developer Studio)
         shell: bash


### PR DESCRIPTION
This PR removes the need to use SyLabs hosting for container images, replacing with GitHub hosting. Because downloading the latter is much faster when used in CI, there is no need to cache the images any longer. This frees up more than half of the currently allotted cache (10 GB).