### PR TITLE
Allow using a Colvars input state file instead of binary checkpoint in GROMACS

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1016,18 +1016,17 @@ Both versions support loading Colvars state files in either format (binary or te
 
 In some cases, it is useful to modify the configuration of variables or biases between consecutive runs, for example by adding or removing a restraint.
 Some special provisions will happen in that case.
-When a state file is loaded, no information is available from in regarding the any newly added variable or bias, which will remain uninitialized until the first compute step.
-Conversely, any information that the state file contains about variables or biases that are no longer defined will be silently ignored.
-Because these checks are performed based only on the \emph{names} of variables and biases, it is your responsibility to ensure that these names have \emph{consistent definitions between runs.}
+When a state file is loaded, no information is available about any newly added variable or bias, which will thus remain uninitialized until the first compute step.
+Conversely, any information that the state file may contain about variables or biases that are no longer defined will be silently ignored.
+Please note that these checks are performed based only on the \emph{names} of variables and biases: it is your responsibility to ensure that these names have \emph{consistent definitions between runs.}
 
-The flexibility just described carries some limitations: namely, it is only supported when reading \emph{text-format} state files.
+The flexibility just described carries some limitations: namely, it is only supported when reading \emph{text-format} Colvars state files.
 Instead, restarting from binary files\cvlammpsonly{ (such as the LAMMPS restart file)}\cvgromacsonly{ (such as the GROMACS checkpoint file)} after a configuration change will trigger an error.
 It is also important to remind that when switching to a different build of \MDENGINE, the binary format may change slightly, even if the release version is the same.
 
-To work around the potential issues just described, a text-format Colvars state file should be used.
-\ifdefined\cvvmdornamd{This is the default in \MDENGINE{} unless the ``\texttt{COLVARS\_BINARY\_RESTART}'' is set to 1, and this information is only provided for troubleshooting.}\fi\cvlammpsonly{This can be achieved by providing an explicit \texttt{input} keyword when initializing the Colvars fix (see \ref{sec:colvars_mdengine_parameters}), which will instruct Colvars to use the given filename instead of the LAMMPS restart file.
-  Furthermore, the \texttt{fix\_modify} scripting command allows to load a Colvars file after initialization (\ref{sec:cv_command_loadsave}).}\cvgromacsonly{In GROMACS, this step would normally entail generating a new TPR file: however, there is no provision to embed a text-format Colvars state file in a TPR file.
-  For this specific use case, the following Colvars option may be used:
+To work around the potential issues just described, a text-format Colvars state file should be loaded.
+\ifdefined\cvvmdornamd{This is the default in \MDENGINE{} unless the ``\texttt{COLVARS\_BINARY\_RESTART}'' is set to 1, and this information is only provided here for troubleshooting purposes.}\fi\cvlammpsonly{This can be achieved by providing an explicit \texttt{input} keyword when initializing the Colvars fix (see \ref{sec:colvars_mdengine_parameters}), which will instruct Colvars to use the given filename, instead of the LAMMPS restart file.
+  Furthermore, the \texttt{fix\_modify} scripting command allows to load a Colvars file after initialization (\ref{sec:cv_command_loadsave}).}\cvgromacsonly{Loading such state file requires an exception to the standard behavior in GROMACS (i.e.\ loading a checkpoint file): this exception is supported by the following Colvars configuration:
 \begin{itemize}
 \item %
   \labelkey{Colvars-global|defaultInputStateFile}
@@ -1035,12 +1034,12 @@ To work around the potential issues just described, a text-format Colvars state 
     global}{%
     Default input state file, if not provided by \MDENGINE}{%
     UNIX filename}{%
-    Define a state file that will be loaded by default, unless \MDENGINE{} provides restarting information through the checkpoint.
+    Define a state file that will be loaded by default, unless \MDENGINE{} provides restarting information for Colvars through the checkpoint file.
   }
 \end{itemize}
-When GROMACS is run using a TPR file that contains \texttt{defaultInputStateFile}, but no checkpoint file is provided, Colvars will attempt to load its state formation from the given file.
-Later, when that simulation is continued using a checkpoint file, Colvars will use that instead.
-While not strictly required, we recommend that as soon as a usable checkpoint file becomes available, a \emph{new TPR file} is produced with \texttt{defaultInputStateFile} \emph{removed}.
+When a Colvars configuration featuring \texttt{defaultInputStateFile} is processed into a TPR file, and a GROMACS simulation is started from this TPR file but without providing a checkpoint, Colvars will load its state from the file named by \texttt{defaultInputStateFile}.
+Later, when that same simulation is continued by providing a checkpoint file to GROMACS, Colvars will ignore \texttt{defaultInputStateFile} and will read its data from the checkpoint file.
+For the sake of clarity, we recommend that as soon as a suitable GROMACS checkpoint is available, the \texttt{defaultInputStateFile} is removed \emph{removed}, and a new TPR file is produced accordingly.
 }
 
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1012,17 +1012,36 @@ Both versions support loading Colvars state files in either format (binary or te
 } % end \cvnamdonly
 
 
-\cvsubsubsec{Restarting after a change in Colvars configuration.}{}
-It useful in some cases to modify the configuration of variables or biases between consecutive runs: a typical example would the addition or removal of a restraint in a simulation.
-By restarting using text-format Colvars state files, it is possible to read previous data while allowing for changes in configuration.
-For each newly defined variable or bias, no information will be read from the state file if this is unavailable: such new objects will remain uninitialized until the first compute step.
-Conversely, any information that the state file has about variables or biases that are no longer defined is silently ignored.
-\emph{Because these checks are performed based solely on the names of variables and biases, it is your responsibility to ensure that these names correspond to consistent definitions between runs.}
+\cvsubsubsec{Changing configuration upon restarting.}{}
 
-When restarting using binary state files, configuration changes are not allowed.  The easiest solution would be to produce a text-format state file specifically for that purpose.
-\ifdefined\cvscriptapi{%
-Alternatively, after restarting Colvars using a state file consistent with the previous configuration, the configuration may be changed using the scripting interface (see \ref{sec:cv_scripting}).
-}\fi
+In some cases, it is useful to modify the configuration of variables or biases between consecutive runs, for example by adding or removing a restraint.
+Some special provisions will happen in that case.
+When a state file is loaded, no information is available from in regarding the any newly added variable or bias, which will remain uninitialized until the first compute step.
+Conversely, any information that the state file contains about variables or biases that are no longer defined will be silently ignored.
+Because these checks are performed based only on the \emph{names} of variables and biases, it is your responsibility to ensure that these names have \emph{consistent definitions between runs.}
+
+The flexibility just described carries some limitations: namely, it is only supported when reading \emph{text-format} state files.
+Instead, restarting from binary files\cvlammpsonly{ (such as the LAMMPS restart file)}\cvgromacsonly{ (such as the GROMACS checkpoint file)} after a configuration change will trigger an error.
+It is also important to remind that when switching to a different build of \MDENGINE, the binary format may change slightly, even if the release version is the same.
+
+To work around the potential issues just described, a text-format Colvars state file should be used.
+\ifdefined\cvvmdornamd{This is the default in \MDENGINE{} unless the ``\texttt{COLVARS\_BINARY\_RESTART}'' is set to 1, and this information is only provided for troubleshooting.}\fi\cvlammpsonly{This can be achieved by providing an explicit \texttt{input} keyword when initializing the Colvars fix (see \ref{sec:colvars_mdengine_parameters}), which will instruct Colvars to use the given filename instead of the LAMMPS restart file.
+  Furthermore, the \texttt{fix\_modify} scripting command allows to load a Colvars file after initialization (\ref{sec:cv_command_loadsave}).}\cvgromacsonly{In GROMACS, this step would normally entail generating a new TPR file: however, there is no provision to embed a text-format Colvars state file in a TPR file.
+  For this specific use case, the following Colvars option may be used:
+\begin{itemize}
+\item %
+  \labelkey{Colvars-global|defaultInputStateFile}
+  \key{defaultInputStateFile}{%
+    global}{%
+    Default input state file, if not provided by \MDENGINE}{%
+    UNIX filename}{%
+    Define a state file that will be loaded by default, unless \MDENGINE{} provides restarting information through the checkpoint.
+  }
+\end{itemize}
+When GROMACS is run using a TPR file that contains \texttt{defaultInputStateFile}, but no checkpoint file is provided, Colvars will attempt to load its state formation from the given file.
+Later, when that simulation is continued using a checkpoint file, Colvars will use that instead.
+While not strictly required, we recommend that as soon as a usable checkpoint file becomes available, a \emph{new TPR file} is produced with \texttt{defaultInputStateFile} \emph{removed}.
+}
 
 
 \cvsubsec{Output files}{sec:colvars_output}

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -490,7 +490,7 @@ Other optional keywords for \texttt{fix colvars} are:
     string}{%
     If a value is provided, it is interpreted as either the name of the input state file, or as the prefix of the file named \emph{input}\texttt{.colvars.state}.
     This file contains information needed to continue a previous collective variables-based calculation, including the number of the last computed step (useful for time-dependent biases).
-    The same information is also stored in the binary restart files written by LAMMPS, so this option is not needed when continuing a calculation from a LAMMPS restart.
+    The same information is also stored in the binary restart files written by LAMMPS, so this option is generally not needed when the \texttt{read\_restart} LAMMPS command is used.
   }
 
 \item %
@@ -966,7 +966,7 @@ The following keywords are available in the global context of the Colvars config
 
 \cvsubsec{Input state file}{sec:colvars_input}
 
-Several of the sampling methods implemented in Colvars are time- or history-dependent, i.e.\ they work by accumulating data as a simulation progresses, and use these data to determine their biasing forces.  If the simulation engine uses a checkpoint or restart file (as GROMACS and LAMMPS do), any data needed by Colvars are embedded inti that file.  Otherwise, a dedicated \emph{state file} can be loaded into Colvars directly.
+Several of the sampling methods implemented in Colvars are time- or history-dependent, i.e.\ they work by accumulating data as a simulation progresses, and use these data to determine their biasing forces.  If the simulation engine uses a checkpoint or restart file (as GROMACS and LAMMPS do), any data needed by Colvars are embedded into that file.  Otherwise, a dedicated \emph{state file} can be loaded into Colvars directly.
 
 When a dedicated Colvars state file is used, it may be in either one of two formats:
 \begin{itemize}
@@ -984,7 +984,10 @@ The step number read from a state file overrides any value that \MDENGINE{} prov
 This means that the step number used internally by Colvars may not always match the step number reported by \MDENGINE{}.
 \cvnamdonly{This is particularly inmportant in NAMD, which represents step numbers as a 32-bit integers that overflows after $\sim$ 2 billion steps, effectively negating the usefulness of the \texttt{firstTimeStep} keyword.  However, step numbers are implemented correctly in the Colvars state file.}
 
-% \cvgromacsonly{\cvsubsubsec{Restarting in GROMACS.}{} TODO }
+\cvgromacsonly{\cvsubsubsec{Restarting in GROMACS.}{}
+  Beginning with GROMACS 2024, all information necessary to restart Colvars is included in the checkpoint ``\texttt{.cpt}'' file.
+  No special provisions are therefore needed compared to a GROMACS simulation without Colvars enabled.
+}
 
 \cvlammpsonly{\cvsubsubsec{Restarting in LAMMPS.}{}
 For continuing a Colvars-based simulation, the recommended method is using the standard LAMMPS \texttt{read\_restart} command, which reads the Colvars state data from the LAMMPS restart file (in binary format).
@@ -1037,13 +1040,10 @@ The state file is used to continue a simulation, and is required to restart a si
 
 \item If the parameter \refkey{colvarsTrajFrequency}{Colvars-global|colvarsTrajFrequency} is greater than 0 (default value: 100 steps), a \emph{trajectory file}, named \outputName\texttt{.colvars.traj}, is written during the simulation.  Unlike the state file, this file is not needed to restart a simulation, but can be used for post-processing and analysis.  The format of this file is described in sec.~\ref{sec:colvars_traj_format}.
 
-\item Additionally, certain features, when enabled, can emit output files with a specific purpose: for example, potentials of mean force can be written to file to be analyzed or plotted.  These files are described in the respective sections, but as a general rule they all use names beginning with the \outputName prefix.
+\item Additionally, certain features, when enabled, can emit output files with a specific purpose: for example, potentials of mean force (PMFs) can be written to file to be analyzed or plotted.  These files are described in the respective sections, but as a general rule they all use names beginning with the \outputName{} prefix.
+Like the trajectory file, these additional files are needed only for analyzing a simulation's results, but not to continue it.
 
 \end{itemize}
-
-Other output files may also be written by specific methods, e.g.{} the ABF or metadynamics methods (\ref{sec:colvarbias_abf}, \ref{sec:colvarbias_meta}).
-Like the trajectory file, they are needed only for analyzing, not continuing a simulation.
-All such files' names also begin with the prefix \outputName.
 
 \cvnamdonly{Lastly, the total energy of all biases or restraints applied to the colvars appears under the NAMD standard output, under the MISC column.}
 

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1046,7 +1046,7 @@ While not strictly required, we recommend that as soon as a usable checkpoint fi
 
 \cvsubsec{Output files}{sec:colvars_output}
 
-If the output prefix \outputName{} is defined, the following output files are written during a simulation run:
+If the output prefix \outputName{} is defined\cvgromacsonly{ (in GROMACS, this is defined by the value of the \texttt{-e} flag of \texttt{mdrun})}, the following output files are written during a simulation run:
 
 \begin{itemize}
 
@@ -1054,7 +1054,7 @@ If the output prefix \outputName{} is defined, the following output files are wr
 This file is in plain text format by default\cvnamdonly{, regardless of the value of \texttt{binaryOutput} of the NAMD coordinate and velocity files}, or in binary format if the environment variable \texttt{COLVARS\_BINARY\_RESTART} is set to a non-zero integer.
 The state file is used to continue a simulation, and is required to restart a simulation unless the engine supports embedding information into their checkpoint file (as GROMACS or LAMMPS currently do).
 
-\item If the parameter \refkey{colvarsRestartFrequency}{Colvars-global|colvarsRestartFrequency} is larger than zero, a \emph{restart file} is written every that many steps: this file is fully equivalent to the final state file.
+\item If the parameter \refkey{colvarsRestartFrequency}{Colvars-global|colvarsRestartFrequency} is larger than zero and \restartName{} is defined\cvgromacsonly{ (this is \emph{not} the case in GROMACS)}, a \emph{restart file} is written every that many steps: this file is fully equivalent to the final state file.
   The name of this file is \restartName\texttt{.colvars.state}.
 
 \item If the parameter \refkey{colvarsTrajFrequency}{Colvars-global|colvarsTrajFrequency} is greater than 0 (default value: 100 steps), a \emph{trajectory file}, named \outputName\texttt{.colvars.traj}, is written during the simulation.  Unlike the state file, this file is not needed to restart a simulation, but can be used for post-processing and analysis.  The format of this file is described in sec.~\ref{sec:colvars_traj_format}.

--- a/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.cpp
+++ b/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.cpp
@@ -128,7 +128,8 @@ ColvarProxyGromacs::ColvarProxyGromacs(const std::string& colvarsConfigString,
         // Citation Reporter
         cvm::log(std::string("\n") + colvars->feature_report(0) + std::string("\n"));
 
-        colvars->set_initial_step(static_cast<cvm::step_number>(0L));
+        // TODO get initial step number from MDModules
+        // colvars->set_initial_step(static_cast<cvm::step_number>(0L));
     }
 }
 

--- a/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.cpp
+++ b/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "colvarproxygromacs.h"
+#include "colvarproxy_gromacs_version.h"
 
 #include <sstream>
 
@@ -57,6 +58,8 @@ ColvarProxyGromacs::ColvarProxyGromacs(const std::string& colvarsConfigString,
                                        int  seed) :
     gmxAtoms_(atoms), pbcType_(pbcType), logger_(logger), doParsing_(doParsing)
 {
+    engine_name_ = "GROMACS";
+    version_int = get_version_from_string(COLVARPROXY_VERSION);
 
     //! From colvarproxy
     //! The 5 variables below are defined in the `colvarproxy` base class

--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -35,6 +35,8 @@ colvarproxy_lammps::colvarproxy_lammps(LAMMPS_NS::LAMMPS *lmp)
 {
   _random = nullptr;
 
+  engine_name_ = "LAMMPS";
+
   first_timestep = true;
   previous_step = -1;
   do_exit = false;

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -42,6 +42,8 @@
 
 colvarproxy_namd::colvarproxy_namd()
 {
+  engine_name_ = "NAMD";
+
   version_int = get_version_from_string(COLVARPROXY_VERSION);
 
   first_timestep = true;

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -407,8 +407,10 @@ int colvarmodule::parse_global_params(std::string const &conf)
   parse->get_keyval(conf, "sourceTclFile", source_Tcl_script);
 #endif
 
-  parse->get_keyval(conf, "defaultInputStateFile", default_input_state_file_,
-                    default_input_state_file_);
+  if (proxy->engine_name() == "GROMACS" && proxy->version_number() >= 20231003) {
+    parse->get_keyval(conf, "defaultInputStateFile", default_input_state_file_,
+                      default_input_state_file_);
+  }
 
   return error_code;
 }

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -452,6 +452,9 @@ private:
 
   template <typename IST> IST & read_state_template_(IST &is);
 
+  /// Default input state file; if given, it is read unless the MD engine provides it
+  std::string default_input_state_file_;
+
   /// Internal state buffer, to be read as an unformatted stream
   std::vector<unsigned char> input_state_buffer_;
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -602,6 +602,11 @@ public:
   /// Destructor
   ~colvarproxy() override;
 
+  inline std::string const &engine_name() const
+  {
+    return engine_name_;
+  }
+
   bool io_available() override;
 
   /// Request deallocation of the module (currently only implemented by VMD)
@@ -715,6 +720,9 @@ protected:
   size_t features_hash;
 
 private:
+
+  /// Name of the simulation engine that the derived proxy object supports
+  std::string engine_name_ = "standalone";
 
   /// Queue of config strings or files to be fed to the module
   void *config_queue_;

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -719,7 +719,7 @@ protected:
   /// Track which features have been acknowledged during the last run
   size_t features_hash;
 
-private:
+protected:
 
   /// Name of the simulation engine that the derived proxy object supports
   std::string engine_name_ = "standalone";

--- a/update-colvars-code.sh
+++ b/update-colvars-code.sh
@@ -654,6 +654,7 @@ then
     mkdir ${target_folder}
     mkdir -p ${target_folder}/tests/refdata
   fi
+  condcopy gromacs/src/colvarproxy_gromacs_version.h "${target_folder}/colvarproxy_gromacs_version.h"
   for src in ${source}/gromacs/gromacs-mdmodules/applied_forces/colvars/*.* ; do
     tgt=$(basename ${src})
     condcopy "${src}" "${target_folder}/${tgt}"

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -77,6 +77,7 @@ colvarproxy_vmd::colvarproxy_vmd(Tcl_Interp *interp, VMDApp *v, int molid)
     msgColvars("colvars: ")
 #endif
 {
+  engine_name_ = "VMD";
   version_int = get_version_from_string(COLVARPROXY_VERSION);
   b_simulation_running = false;
 


### PR DESCRIPTION
See discussion at: https://gitlab.com/gromacs/gromacs/-/merge_requests/3671#note_1577988430

This PR implements that requirement, but in a different manner than was mentioned before: a new keyword internal to the Colvars config file that specifies a state file to be used _unless_ a state is read in any other way, as provided by the MD engine. After the a state is read the first time, the default input state file name is deleted (so that it won't be loaded again).

The new keyword is currently not tested in CI yet. I feel that it would be confusing to expose it to engines other than GROMACS, which don't need it. Currently, it's only _documented_ for that engine. @jhenin What are your thoughts on TinkerHP? 

Note below how the two engines that provide their own restart file differ significantly:
- GROMACS needs a way to continue a simulation when a Colvars config file is changed or when a different build of GROMACS is used (both of which prevent restarting Colvars from the checkpoint file). The proposed change would be to use a default state file for Colvars~~keyword `colvars-inputstatefile` in the MDP~~, which will be superseded when a checkpoint file is read.
- LAMMPS currently allows (since #558) restarting from a Colvars input state file or the LAMMPS restart file. When both are provided, the former overrides the latter, i.e. this behavior is _opposite_ to what seems most appropriate for GROMACS.

~~While I finish the implementation of this feature for GROMACS, I'd appreciate feedback on whether the above inconsistency should be resolved or not.  Mainstream LAMMPS does not contain yet the Colvars code currently in `master`, so there is time to change.~~
EDIT: see here https://github.com/Colvars/colvars/pull/610#issuecomment-1787485033