### PR TITLE
Apply @zwpku's fix to colvargid::get_grad

### DIFF
--- a/src/colvargrid.cpp
+++ b/src/colvargrid.cpp
@@ -666,24 +666,23 @@ void integrate_potential::update_div_neighbors(const std::vector<int> &ix0)
 
 void integrate_potential::get_grad(cvm::real * g, std::vector<int> &ix)
 {
-  size_t count, i;
-  bool edge = gradients->wrap_edge(ix); // Detect edge if non-PBC
+    size_t count, i;
+    bool edge = gradients->wrap_edge(ix);
+    if (!edge) {
+        if (gradients->samples) {
+          count = gradients->samples->value(ix);
+        } else {
+          count = 1;
+        }
+        cvm::real fact = 0.0;
+        if (count) fact = 1.0 / count;
+        cvm::real const *grad = &(gradients->value(ix));
 
-  if (gradients->samples) {
-    count = gradients->samples->value(ix);
-  } else {
-    count = 1;
-  }
-
-  if (!edge && count) {
-    cvm::real const *grad = &(gradients->value(ix));
-    cvm::real const fact = 1.0 / count;
-    for ( i = 0; i<nd; i++ ) {
-      g[i] = fact * grad[i];
-    }
+        for ( i = 0; i<nd; i++ )
+          g[i] = fact * grad[i];
   } else {
     for ( i = 0; i<nd; i++ ) {
-      g[i] = 0.0;
+          g[i] = 0.0;
     }
   }
 }


### PR DESCRIPTION
to avoid accessing illegal memory locations.
Fixes #621 