### PR TITLE
Fix stalling NAMD jobs in CI

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -48,7 +48,7 @@ jobs:
       path_compile_script: devel-tools/compile-namd.sh
       test_lib_directory: namd/tests/library
       test_interface_directory: namd/tests/interface
-      rpath_exe: Linux-x86_64-g++.multicore/namd2
+      rpath_exe: Linux-x86_64-g++.mpi/namd2
     secrets:
       # Choice of license by UIUC prevents sharing the code, hence the secret
       private_key: ${{ secrets.PULL_NAMD_KEY }}
@@ -69,7 +69,7 @@ jobs:
       test_lib_directory: namd/tests/library
       # Interface tests disabled until map variables are merged into NAMD3
       # test_interface_directory: namd/tests/interface
-      rpath_exe: Linux-x86_64-g++.multicore/namd3
+      rpath_exe: Linux-x86_64-g++.mpi/namd3
       container_name: CentOS7-devel
     secrets:
       # Choice of license by UIUC prevents sharing the code, hence the secret

--- a/devel-tools/compile-namd.sh
+++ b/devel-tools/compile-namd.sh
@@ -2,6 +2,8 @@
 
 source $(dirname $0)/load-recent-git.sh
 
+source $(dirname $0)/load-openmpi.sh
+
 source $(dirname $0)/set-ccache.sh
 
 # Save path to be used later
@@ -14,6 +16,9 @@ compile_namd_target() {
     local dirname_prefix="Linux-x86_64-g++"
 
     local label="multicore"
+    if hash mpicxx >& /dev/null ; then
+        label="mpi"
+    fi
 
     while [ $# -ge 1 ]; do
         if [ -f "${1}/src/NamdTypes.h" ] ; then
@@ -43,10 +48,6 @@ compile_namd_target() {
 
     local -a cmd=(./config ${dirname})
 
-    if [ "${label}" = "multicore" ] ; then
-        cmd+=(--charm-arch multicore-linux-x86_64)
-    fi
-
     if [ "${dirname_prefix}" = "Linux-x86_64-g++-debug" ] ; then
         cat > arch/Linux-x86_64-g++-debug.arch <<EOF
 NAMD_ARCH = Linux-x86_64
@@ -59,8 +60,12 @@ COPTS = \$(CXXOPTS)
 EOF
     fi
 
+    if [ "${label}" = "multicore" ] ; then
+        cmd+=(--charm-arch multicore-linux-x86_64)
+    fi
+
     if [ "${label}" = "mpi" ] ; then
-        cmd+=(--charm-arch mpi-linux-x86_64-mpicxx)
+        cmd+=(--charm-arch mpi-linux-x86_64)
     fi
 
     if [ "${label}" = "netlrts" ] ; then

--- a/namd/tests/library/run_tests.sh
+++ b/namd/tests/library/run_tests.sh
@@ -59,8 +59,20 @@ if ! { echo ${DIRLIST} | grep -q 0 ; } then
   DIRLIST=`eval ls -d [0-9][0-9][0-9]_*`
 fi
 
-NUM_CPUS=$(nproc)
-NUM_THREADS=${NUM_THREADS:-${NUM_CPUS}}
+
+NUM_THREADS=4
+NUM_TASKS=1
+
+CHARM_ARCH=$(${BINARY} 2>&1 | grep 'Info: Based on Charm++/Converse' | cut -d' ' -f 7 || true)
+if [ "x${CHARM_ARCH}" == "xmpi-linux-x86_64" ] && source ${TOPDIR}/devel-tools/load-openmpi.sh ; then
+  NUM_TASKS=${NUM_THREADS}
+  NUM_THREADS=1
+  BINARY="mpirun -n ${NUM_TASKS} -oversubscribe $BINARY"
+else
+  BINARY="$BINARY +p ${NUM_THREADS}"
+fi
+
+echo "Running NAMD as: $BINARY"
 
 TPUT_RED='true'
 TPUT_GREEN='true'
@@ -168,8 +180,7 @@ for dir in ${DIRLIST} ; do
     fi
 
     # Run the test (use a subshell to avoid cluttering stdout)
-    # Use multiple threads to test SMP code (TODO: move SMP tests to interface?)
-    NAMD_CUDASOA=$CUDASOA $BINARY +p ${NUM_THREADS} $script > ${basename}.out
+    NAMD_CUDASOA=$CUDASOA $BINARY $script > ${basename}.out
 
     # Output of Colvars module, minus the version numbers
     grep "^colvars:" ${basename}.out | grep -v 'Initializing the collective variables module' \


### PR DESCRIPTION
After confirming that the recent locks only occur when running on multiple threads, I converted the NAMD build recipe to be consistent with LAMMPS and GROMACS (from #616).

It would seem difficult to try and investigate the source of the problem given the Russian-doll combination of Charm++, the container runtime, and Microsoft's Ubuntu VM running on a physical server. 

Although this fixes the CI lockouts, there is a significant drawback in that the SMP code path is no longer exercised. Maybe the MPI and multicore versions can both be run? 