### PR TITLE
Define programmatically the available CVC types, report them in case of errors

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -60,8 +60,7 @@ jobs:
       backend_repo_ref: devel
       path_compile_script: devel-tools/compile-namd.sh
       test_lib_directory: namd/tests/library
-      # Interface tests disabled until map variables are merged into NAMD3
-      # test_interface_directory: namd/tests/interface
+      test_interface_directory: namd/tests/interface
       rpath_exe: Linux-x86_64-g++.mpi/namd3
       container_name: CentOS7-devel
     secrets:

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -697,6 +697,12 @@ int colvarproxy_namd::check_atom_id(int atom_number)
 }
 
 
+int colvarproxy_namd::check_atom_name_selections_available()
+{
+  return COLVARS_OK;
+}
+
+
 int colvarproxy_namd::init_atom(int atom_number)
 {
   // save time by checking first whether this atom has been requested before

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1271,6 +1271,13 @@ int colvarproxy_namd::set_unit_system(std::string const &units_in, bool /*check_
 
 #if NAMD_VERSION_NUMBER >= 34471681
 
+
+int colvarproxy_namd::check_volmaps_available()
+{
+  return COLVARS_OK;
+}
+
+
 int colvarproxy_namd::init_volmap_by_id(int volmap_id)
 {
   for (size_t i = 0; i < volmaps_ids.size(); i++) {

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -212,6 +212,8 @@ public:
 
 #if NAMD_VERSION_NUMBER >= 34471681
 
+  int check_volmaps_available() override;
+
   int init_volmap_by_id(int volmap_id) override;
 
   int init_volmap_by_name(const char *volmap_name) override;

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -173,6 +173,7 @@ public:
   int replica_comm_recv(char* msg_data, int buf_len, int src_rep) override;
   int replica_comm_send(char* msg_data, int msg_len, int dest_rep) override;
 
+  int check_atom_name_selections_available() override;
   int init_atom(int atom_number) override;
   int check_atom_id(int atom_number) override;
   int init_atom(cvm::residue_id const &residue,

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -910,10 +910,13 @@ int colvar::init_components(std::string const &conf)
   }
 
   if (!cvcs.size() || (error_code != COLVARS_OK)) {
-    cvm::error("Error: no valid components were provided "
-               "for this collective variable.\n",
-               COLVARS_INPUT_ERROR);
-    return COLVARS_INPUT_ERROR;
+    std::string msg("Error: no valid components were provided for this collective variable.\n");
+    msg += "Currently available component types are: \n";
+    for (auto it = global_cvc_desc_map.begin(); it != global_cvc_desc_map.end(); ++it) {
+      msg += "    " + it->first + " -- " + it->second + "\n";
+    }
+    msg += "\nPlease note that some of the above types may still be unavailable, irrespective of this error.\n";
+    return cvm::error(msg, COLVARS_INPUT_ERROR);
   }
 
   // Check for uniqueness of CVC names (esp. if user-provided)

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -836,6 +836,8 @@ int colvar::init_components_type(const std::string& conf, const char* def_config
 
 void colvar::define_component_types()
 {
+  colvarproxy *proxy = cvm::main()->proxy;
+
   add_component_type<distance>("distance", "distance");
   add_component_type<distance_vec>("distance vector", "distanceVec");
   add_component_type<cartesian>("Cartesian coordinates", "cartesian");
@@ -854,8 +856,12 @@ void colvar::define_component_types()
   add_component_type<dipole_angle>("dipole angle", "dipoleAngle");
   add_component_type<dihedral>("dihedral", "dihedral");
   add_component_type<h_bond>("hydrogen bond", "hBond");
-  add_component_type<alpha_angles>("alpha helix", "alpha");
-  add_component_type<dihedPC>("dihedral principal component", "dihedralPC");
+
+  if (proxy->check_atom_name_selections_available() == COLVARS_OK) {
+    add_component_type<alpha_angles>("alpha helix", "alpha");
+    add_component_type<dihedPC>("dihedral principal component", "dihedralPC");
+  }
+
   add_component_type<orientation>("orientation", "orientation");
   add_component_type<orientation_angle>("orientation angle", "orientationAngle");
   add_component_type<orientation_proj>("orientation projection", "orientationProj");
@@ -880,11 +886,16 @@ void colvar::define_component_types()
   add_component_type<euler_phi>("euler phi angle of the optimal orientation", "eulerPhi");
   add_component_type<euler_psi>("euler psi angle of the optimal orientation", "eulerPsi");
   add_component_type<euler_theta>("euler theta angle of the optimal orientation", "eulerTheta");
+
 #ifdef LEPTON
   add_component_type<customColvar>("CV with support of the Lepton custom function", "customColvar");
 #endif
+
   add_component_type<neuralNetwork>("neural network CV for other CVs", "neuralNetwork");
-  add_component_type<map_total>("total value of atomic map", "mapTotal");
+
+  if (proxy->volmaps_available() == COLVARS_OK) {
+    add_component_type<map_total>("total value of atomic map", "mapTotal");
+  }
 }
 
 

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -752,19 +752,18 @@ int colvar::init_output_flags(std::string const &conf)
 
 
 template <typename def_class_name>
-int colvar::init_components_type(std::string const &, char const * /* def_desc */,
-                                 char const *def_config_key)
+void colvar::add_component_type(char const *def_description, char const *def_config_key)
 {
-  global_cvc_map[def_config_key] = [](const std::string &cvc_conf) {
-    return new def_class_name(cvc_conf);
-  };
-  // TODO: maybe it is better to do more check to avoid duplication in the map?
-  return COLVARS_OK;
+  if (global_cvc_map.count(def_config_key) == 0) {
+    global_cvc_map[def_config_key] = [](const std::string &cvc_conf) {
+      return new def_class_name(cvc_conf);
+    };
+    global_cvc_desc_map[def_config_key] = std::string(def_description);
+  }
 }
 
 
-int colvar::init_components_type_from_global_map(const std::string& conf,
-                                                 const char* def_config_key) {
+int colvar::init_components_type(const std::string& conf, const char* def_config_key) {
   size_t def_count = 0;
   std::string def_conf = "";
   size_t pos = 0;
@@ -835,84 +834,72 @@ int colvar::init_components_type_from_global_map(const std::string& conf,
 }
 
 
+void colvar::define_component_types()
+{
+  add_component_type<distance>("distance", "distance");
+  add_component_type<distance_vec>("distance vector", "distanceVec");
+  add_component_type<cartesian>("Cartesian coordinates", "cartesian");
+  add_component_type<distance_dir>("distance vector direction", "distanceDir");
+  add_component_type<distance_z>("distance projection on an axis", "distanceZ");
+  add_component_type<distance_xy>("distance projection on a plane", "distanceXY");
+  add_component_type<polar_theta>("spherical polar angle theta", "polarTheta");
+  add_component_type<polar_phi>("spherical azimuthal angle phi", "polarPhi");
+  add_component_type<distance_inv>("average distance weighted by inverse power", "distanceInv");
+  add_component_type<distance_pairs>("N1xN2-long vector of pairwise distances", "distancePairs");
+  add_component_type<dipole_magnitude>("dipole magnitude", "dipoleMagnitude");
+  add_component_type<coordnum>("coordination number", "coordNum");
+  add_component_type<selfcoordnum>("self-coordination number", "selfCoordNum");
+  add_component_type<groupcoordnum>("group-coordination number", "groupCoord");
+  add_component_type<angle>("angle", "angle");
+  add_component_type<dipole_angle>("dipole angle", "dipoleAngle");
+  add_component_type<dihedral>("dihedral", "dihedral");
+  add_component_type<h_bond>("hydrogen bond", "hBond");
+  add_component_type<alpha_angles>("alpha helix", "alpha");
+  add_component_type<dihedPC>("dihedral principal component", "dihedralPC");
+  add_component_type<orientation>("orientation", "orientation");
+  add_component_type<orientation_angle>("orientation angle", "orientationAngle");
+  add_component_type<orientation_proj>("orientation projection", "orientationProj");
+  add_component_type<tilt>("tilt", "tilt");
+  add_component_type<spin_angle>("spin angle", "spinAngle");
+  add_component_type<rmsd>("RMSD", "rmsd");
+  add_component_type<gyration>("radius of gyration", "gyration");
+  add_component_type<inertia>("moment of inertia", "inertia");
+  add_component_type<inertia_z>("moment of inertia around an axis", "inertiaZ");
+  add_component_type<eigenvector>("eigenvector", "eigenvector");
+  add_component_type<alch_lambda>("alchemical coupling parameter", "alchLambda");
+  add_component_type<alch_Flambda>("force on alchemical coupling parameter", "alchFLambda");
+  add_component_type<aspath>("arithmetic path collective variables (s)", "aspath");
+  add_component_type<azpath>("arithmetic path collective variables (z)", "azpath");
+  add_component_type<gspath>("geometrical path collective variables (s)", "gspath");
+  add_component_type<gzpath>("geometrical path collective variables (z)", "gzpath");
+  add_component_type<linearCombination>("linear combination of other collective variables", "linearCombination");
+  add_component_type<gspathCV>("geometrical path collective variables (s) for other CVs", "gspathCV");
+  add_component_type<gzpathCV>("geometrical path collective variables (z) for other CVs", "gzpathCV");
+  add_component_type<aspathCV>("arithmetic path collective variables (s) for other CVs", "aspathCV");
+  add_component_type<azpathCV>("arithmetic path collective variables (s) for other CVs", "azpathCV");
+  add_component_type<euler_phi>("euler phi angle of the optimal orientation", "eulerPhi");
+  add_component_type<euler_psi>("euler psi angle of the optimal orientation", "eulerPsi");
+  add_component_type<euler_theta>("euler theta angle of the optimal orientation", "eulerTheta");
+#ifdef LEPTON
+  add_component_type<customColvar>("CV with support of the Lepton custom function", "customColvar");
+#endif
+  add_component_type<neuralNetwork>("neural network CV for other CVs", "neuralNetwork");
+  add_component_type<map_total>("total value of atomic map", "mapTotal");
+}
+
+
 int colvar::init_components(std::string const &conf)
 {
   int error_code = COLVARS_OK;
   size_t i = 0, j = 0;
 
-  // in the non-C++11 case, the components are initialized directly by init_components_type;
-  // in the C++11 case, the components are stored in the global_cvc_map at first
-  // by init_components_type, and then the map is iterated to initialize all components.
-  error_code |= init_components_type<distance>(conf, "distance", "distance");
-  error_code |= init_components_type<distance_vec>(conf, "distance vector", "distanceVec");
-  error_code |= init_components_type<cartesian>(conf, "Cartesian coordinates", "cartesian");
-  error_code |= init_components_type<distance_dir>(conf, "distance vector "
-    "direction", "distanceDir");
-  error_code |= init_components_type<distance_z>(conf, "distance projection "
-    "on an axis", "distanceZ");
-  error_code |= init_components_type<distance_xy>(conf, "distance projection "
-    "on a plane", "distanceXY");
-  error_code |= init_components_type<polar_theta>(conf, "spherical polar angle theta",
-    "polarTheta");
-  error_code |= init_components_type<polar_phi>(conf, "spherical azimuthal angle phi",
-    "polarPhi");
-  error_code |= init_components_type<distance_inv>(conf, "average distance "
-    "weighted by inverse power", "distanceInv");
-  error_code |= init_components_type<distance_pairs>(conf, "N1xN2-long vector "
-    "of pairwise distances", "distancePairs");
-  error_code |= init_components_type<dipole_magnitude>(conf, "dipole magnitude",
-    "dipoleMagnitude");
-  error_code |= init_components_type<coordnum>(conf, "coordination "
-    "number", "coordNum");
-  error_code |= init_components_type<selfcoordnum>(conf, "self-coordination "
-    "number", "selfCoordNum");
-  error_code |= init_components_type<groupcoordnum>(conf, "group-coordination "
-    "number", "groupCoord");
-  error_code |= init_components_type<angle>(conf, "angle", "angle");
-  error_code |= init_components_type<dipole_angle>(conf, "dipole angle", "dipoleAngle");
-  error_code |= init_components_type<dihedral>(conf, "dihedral", "dihedral");
-  error_code |= init_components_type<h_bond>(conf, "hydrogen bond", "hBond");
-  error_code |= init_components_type<alpha_angles>(conf, "alpha helix", "alpha");
-  error_code |= init_components_type<dihedPC>(conf, "dihedral "
-    "principal component", "dihedralPC");
-  error_code |= init_components_type<orientation>(conf, "orientation", "orientation");
-  error_code |= init_components_type<orientation_angle>(conf, "orientation "
-    "angle", "orientationAngle");
-  error_code |= init_components_type<orientation_proj>(conf, "orientation "
-    "projection", "orientationProj");
-  error_code |= init_components_type<tilt>(conf, "tilt", "tilt");
-  error_code |= init_components_type<spin_angle>(conf, "spin angle", "spinAngle");
-  error_code |= init_components_type<rmsd>(conf, "RMSD", "rmsd");
-  error_code |= init_components_type<gyration>(conf, "radius of "
-    "gyration", "gyration");
-  error_code |= init_components_type<inertia>(conf, "moment of "
-    "inertia", "inertia");
-  error_code |= init_components_type<inertia_z>(conf, "moment of inertia around an axis", "inertiaZ");
-  error_code |= init_components_type<eigenvector>(conf, "eigenvector", "eigenvector");
-  error_code |= init_components_type<alch_lambda>(conf, "alchemical coupling parameter", "alchLambda");
-  error_code |= init_components_type<alch_Flambda>(conf, "force on alchemical coupling parameter", "alchFLambda");
-  error_code |= init_components_type<aspath>(conf, "arithmetic path collective variables (s)", "aspath");
-  error_code |= init_components_type<azpath>(conf, "arithmetic path collective variables (z)", "azpath");
-  error_code |= init_components_type<gspath>(conf, "geometrical path collective variables (s)", "gspath");
-  error_code |= init_components_type<gzpath>(conf, "geometrical path collective variables (z)", "gzpath");
-  error_code |= init_components_type<linearCombination>(conf, "linear combination of other collective variables", "linearCombination");
-  error_code |= init_components_type<gspathCV>(conf, "geometrical path collective variables (s) for other CVs", "gspathCV");
-  error_code |= init_components_type<gzpathCV>(conf, "geometrical path collective variables (z) for other CVs", "gzpathCV");
-  error_code |= init_components_type<aspathCV>(conf, "arithmetic path collective variables (s) for other CVs", "aspathCV");
-  error_code |= init_components_type<azpathCV>(conf, "arithmetic path collective variables (s) for other CVs", "azpathCV");
-  error_code |= init_components_type<euler_phi>(conf, "euler phi angle of the optimal orientation", "eulerPhi");
-  error_code |= init_components_type<euler_psi>(conf, "euler psi angle of the optimal orientation", "eulerPsi");
-  error_code |= init_components_type<euler_theta>(conf, "euler theta angle of the optimal orientation", "eulerTheta");
-#ifdef LEPTON
-  error_code |= init_components_type<customColvar>(conf, "CV with support of the lepton custom function", "customColvar");
-#endif
-  error_code |= init_components_type<neuralNetwork>(conf, "neural network CV for other CVs", "NeuralNetwork");
-
-  error_code |= init_components_type<map_total>(conf, "total value of atomic map", "mapTotal");
+  if (global_cvc_map.empty()) {
+    define_component_types();
+  }
 
   // iterate over all available CVC in the map
   for (auto it = global_cvc_map.begin(); it != global_cvc_map.end(); ++it) {
-    error_code |= init_components_type_from_global_map(conf, it->first.c_str());
+    error_code |= init_components_type(conf, it->first.c_str());
     // TODO: is it better to check the error code here?
     if (error_code != COLVARS_OK) {
       cvm::log("Failed to initialize " + it->first + " with the following configuration:\n");

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -893,7 +893,7 @@ void colvar::define_component_types()
 
   add_component_type<neuralNetwork>("neural network CV for other CVs", "neuralNetwork");
 
-  if (proxy->volmaps_available() == COLVARS_OK) {
+  if (proxy->check_volmaps_available() == COLVARS_OK) {
     add_component_type<map_total>("total value of atomic map", "mapTotal");
   }
 }

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -920,37 +920,38 @@ int colvar::init_components(std::string const &conf)
     }
   }
 
-  if (!cvcs.size() || (error_code != COLVARS_OK)) {
+  if (!cvcs.size()) {
     std::string msg("Error: no valid components were provided for this collective variable.\n");
     msg += "Currently available component types are: \n";
     for (auto it = global_cvc_desc_map.begin(); it != global_cvc_desc_map.end(); ++it) {
       msg += "    " + it->first + " -- " + it->second + "\n";
     }
     msg += "\nPlease note that some of the above types may still be unavailable, irrespective of this error.\n";
-    return cvm::error(msg, COLVARS_INPUT_ERROR);
+    error_code |= cvm::error(msg, COLVARS_INPUT_ERROR);
   }
 
   // Check for uniqueness of CVC names (esp. if user-provided)
   for (i = 0; i < cvcs.size(); i++) {
-    for (j = i+1; j < cvcs.size(); j++) {
+    for (j = i + 1; j < cvcs.size(); j++) {
       if (cvcs[i]->name == cvcs[j]->name) {
-        cvm::error("Components " + cvm::to_str(i) + " and " + cvm::to_str(j) +\
-          " cannot have the same name \"" +  cvcs[i]->name+ "\".\n", COLVARS_INPUT_ERROR);
-        return COLVARS_INPUT_ERROR;
+        error_code |= cvm::error("Components " + cvm::to_str(i) + " and " + cvm::to_str(j) +
+                                     " cannot have the same name \"" + cvcs[i]->name + "\".\n",
+                                 COLVARS_INPUT_ERROR);
       }
     }
   }
 
-  n_active_cvcs = cvcs.size();
-
-  // Store list of children cvcs for dependency checking purposes
-  for (i = 0; i < cvcs.size(); i++) {
-    add_child(cvcs[i]);
+  if (error_code == COLVARS_OK) {
+    // Store list of children cvcs for dependency checking purposes
+    for (i = 0; i < cvcs.size(); i++) {
+      add_child(cvcs[i]);
+    }
+    // By default all CVCs are active at the start
+    n_active_cvcs = cvcs.size();
+    cvm::log("All components initialized.\n");
   }
 
-  cvm::log("All components initialized.\n");
-
-  return COLVARS_OK;
+  return error_code;
 }
 
 

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -22,9 +22,13 @@
 #include "colvars_memstream.h"
 
 
-std::map<std::string, std::function<colvar::cvc *(const std::string &subcv_conf)>>
+
+std::map<std::string, std::function<colvar::cvc *(const std::string &conf)>>
     colvar::global_cvc_map =
-        std::map<std::string, std::function<colvar::cvc *(const std::string &subcv_conf)>>();
+        std::map<std::string, std::function<colvar::cvc *(const std::string &conf)>>();
+
+std::map<std::string, std::string> colvar::global_cvc_desc_map =
+    std::map<std::string, std::string>();
 
 
 colvar::colvar()

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -249,6 +249,9 @@ public:
   /// Main init function
   int init(std::string const &conf);
 
+  /// Populate the map of available CVC types
+  void define_component_types();
+
   /// Parse the CVC configuration and allocate their data
   int init_components(std::string const &conf);
 
@@ -269,15 +272,12 @@ public:
 
 private:
 
-  /// Parse the CVC configuration for all components of a certain type
-  template<typename def_class_name> int init_components_type(std::string const & conf,
-                                                             char const *def_desc,
-                                                             char const *def_config_key);
+  /// Declare an available CVC type and its description, register them in the global map
+  template <typename def_class_name>
+  void add_component_type(char const *description, char const *config_key);
 
-  /// The names of all available components are registered in the global map
-  /// at first, and then the CVC configuration is parsed by this function
-  int init_components_type_from_global_map(const std::string& conf,
-                                           const char* def_config_key);
+  /// Initialize any CVC objects matching the given key
+  int init_components_type(const std::string &conf, const char *config_key);
 
 public:
 

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -688,8 +688,11 @@ protected:
 #endif
 
   /// A global mapping of cvc names to the cvc constructors
-  static std::map<std::string, std::function<colvar::cvc *(const std::string &subcv_conf)>>
+  static std::map<std::string, std::function<colvar::cvc *(const std::string &conf)>>
       global_cvc_map;
+
+  /// A global mapping of cvc names to the corresponding descriptions
+  static std::map<std::string, std::string> global_cvc_desc_map;
 
   /// Volmap numeric IDs, one for each CVC (-1 if not available)
   std::vector<int> volmap_ids_;

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -73,6 +73,12 @@ int colvarproxy_atoms::check_atom_id(int /* atom_number */)
 }
 
 
+int colvarproxy_atoms::check_atom_name_selections_available()
+{
+  return COLVARS_NOT_IMPLEMENTED;
+}
+
+
 int colvarproxy_atoms::init_atom(cvm::residue_id const & /* residue */,
                                  std::string const     & /* atom_name */,
                                  std::string const     & /* segment_id */)

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -56,6 +56,9 @@ public:
   /// corresponding atom yet
   virtual int check_atom_id(int atom_number);
 
+  /// Check whether it is possible to select atoms by residue number name
+  virtual int check_atom_name_selections_available();
+
   /// Select this atom for collective variables calculation, using name and
   /// residue number.  Not all programs support this: leave this function as
   /// is in those cases.

--- a/src/colvarproxy_volmaps.cpp
+++ b/src/colvarproxy_volmaps.cpp
@@ -21,7 +21,7 @@ colvarproxy_volmaps::colvarproxy_volmaps()
 colvarproxy_volmaps::~colvarproxy_volmaps() {}
 
 
-int colvarproxy_volmaps::volmaps_available()
+int colvarproxy_volmaps::check_volmaps_available()
 {
   return COLVARS_NOT_IMPLEMENTED;
 }

--- a/src/colvarproxy_volmaps.h
+++ b/src/colvarproxy_volmaps.h
@@ -18,8 +18,8 @@ public:
   /// Clear volumetric map data
   int reset();
 
-  /// \brief Whether this implementation has capability to use volumetric maps
-  virtual int volmaps_available();
+  /// Test whether this implementation can use volumetric maps as CVs
+  virtual int check_volmaps_available();
 
   /// Create a slot for a volumetric map not requested yet
   int add_volmap_slot(int volmap_id);

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -758,6 +758,12 @@ int colvarproxy_vmd::init_atom(cvm::residue_id const &resid,
 }
 
 
+int colvarproxy_vmd::check_volmaps_available()
+{
+  return COLVARS_OK;
+}
+
+
 int colvarproxy_vmd::init_volmap_by_id(int volmap_id)
 {
   for (size_t i = 0; i < volmaps_ids.size(); i++) {

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -651,6 +651,12 @@ int colvarproxy_vmd::check_atom_id(int atom_number)
 }
 
 
+int colvarproxy_vmd::check_atom_name_selections_available()
+{
+  return COLVARS_OK;
+}
+
+
 int colvarproxy_vmd::init_atom(int atom_number)
 {
   // save time by checking first whether this atom has been requested before

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -106,6 +106,8 @@ public:
                             std::string const     &atom_name,
                             std::string const     &segment_id);
 
+  virtual int check_volmaps_available();
+
   virtual int init_volmap_by_id(int volmap_id);
 
   virtual int check_volmap_by_id(int volmap_id);

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -91,6 +91,9 @@ public:
                           std::string const &pdb_field,
                           double const pdb_field_value = 0.0);
 
+
+  virtual int check_atom_name_selections_available();
+
   virtual int init_atom(int atom_number);
 
   virtual int check_atom_id(int atom_number);

--- a/vmd/tests/interface/002_error_output/AutoDiff/test.colvars.err
+++ b/vmd/tests/interface/002_error_output/AutoDiff/test.colvars.err
@@ -6,13 +6,11 @@ Command "cv" returned the following errors:
   Error: atom group "group1" has no definition.
   Error: atom group "group2" is required.
   Error: in setting up component "distance".
-  Error: no valid components were provided for this collective variable.
 Error parsing configuration string
 
 Command "cv" returned the following errors:
     Error: invalid atom number specified, 1000
     Error: in definition of atom group "atoms".
   Error: in setting up component "rmsd".
-  Error: no valid components were provided for this collective variable.
 Error parsing configuration string
 


### PR DESCRIPTION
Small but overdue improvement, in the form of introspection code to provide clearer error messages when no suitable function is given for a colvar. This is motivated to improve clarity in light of the fact that the availability of features is increasingly varied between engines/platforms.

@jhenin I was considering exposing the list of components and their descriptions via the scripting interface. Would that be useful for the Dashboard, and if so in what format?