### PR TITLE
Limit number of GitHub cache instances

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -185,3 +185,18 @@ jobs:
         run: |
           apptainer exec ${{github.workspace}}/devel-tools/${{ inputs.container_name }}.sif \
           ./run_tests.sh ${{github.workspace}}/${{ inputs.backend_name }}-source/${{ inputs.rpath_exe }} 0??_*
+
+      - name: Keep only one cache besides the one from this job
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache;
+          caches=($(gh actions-cache list --key ${{ runner.os }}-build-${{ inputs.backend_name }}- | cut -f 1));
+          i=100;
+          while [ ${i} -ge 1 ] ; do
+              if [ -n "${caches[${i}]}" ] ; then
+                  gh actions-cache delete --confirm "${caches[${i}]}";
+              fi
+              i=$((${i} - 1));
+          done

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -191,12 +191,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh extension install actions/gh-actions-cache;
-          caches=($(gh actions-cache list --key ${{ runner.os }}-build-${{ inputs.backend_name }}- | cut -f 1));
-          i=100;
-          while [ ${i} -ge 1 ] ; do
-              if [ -n "${caches[${i}]}" ] ; then
-                  gh actions-cache delete --confirm "${caches[${i}]}";
-              fi
-              i=$((${i} - 1));
-          done
+          bash ${{ github.workspace }}/devel-tools/cleanup-gh-cache.sh ${{ runner.os }}-build-${{ inputs.backend_name }}-

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -64,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache_${{ inputs.container_name }}
+      # Silence OpenMPI warnings
+      PSM3_MULTI_EP: 1
 
     steps:
       - name: Checkout Colvars

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -22,7 +22,7 @@ jobs:
     name: LAMMPS
     if: |
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-lammps') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-lammps') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: LAMMPS
@@ -40,7 +40,7 @@ jobs:
     # secrets wouldn't be shared
     if: |
       (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD
@@ -61,7 +61,7 @@ jobs:
     # secrets wouldn't be shared
     if: |
       (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD3
@@ -83,7 +83,7 @@ jobs:
     # secrets wouldn't be shared
     if: |
       (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-vmd') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-vmd') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: VMD
@@ -105,7 +105,7 @@ jobs:
     name: GROMACS 2022
     if: |
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2022
@@ -120,7 +120,7 @@ jobs:
     name: GROMACS 2023
     if: |
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2023
@@ -135,7 +135,7 @@ jobs:
     name: GROMACS (MDModules)
     if: |
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master')))
+      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-devel

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -20,7 +20,9 @@ jobs:
 
   lammps:
     name: LAMMPS
-    if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'test-lammps')
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-lammps') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: LAMMPS
@@ -38,7 +40,7 @@ jobs:
     # secrets wouldn't be shared
     if: |
       (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && contains(github.event.head_commit.message, 'test-namd'))
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD
@@ -59,7 +61,7 @@ jobs:
     # secrets wouldn't be shared
     if: |
       (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && contains(github.event.head_commit.message, 'test-namd'))
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD3
@@ -81,7 +83,7 @@ jobs:
     # secrets wouldn't be shared
     if: |
       (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && contains(github.event.head_commit.message, 'test-vmd'))
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-vmd') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: VMD
@@ -101,7 +103,9 @@ jobs:
 
   gromacs-2022:
     name: GROMACS 2022
-    if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'test-gromacs-2022')
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2022
@@ -114,7 +118,9 @@ jobs:
 
   gromacs-2023:
     name: GROMACS 2023
-    if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'test-gromacs-2023')
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2023
@@ -127,7 +133,9 @@ jobs:
 
   gromacs-devel:
     name: GROMACS (MDModules)
-    if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'test-gromacs-devel')
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'push' && ((contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master')))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-devel

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -260,15 +260,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh extension install actions/gh-actions-cache;
-          caches=($(gh actions-cache list --key Linux-build-asan- | cut -f 1));
-          i=100;
-          while [ ${i} -ge 1 ] ; do
-              if [ -n "${caches[${i}]}" ] ; then
-                  gh actions-cache delete --confirm "${caches[${i}]}";
-              fi
-              i=$((${i} - 1));
-          done
+          bash ${{ github.workspace }}/devel-tools/cleanup-gh-cache.sh ${{ runner.os }}-build-asan-
 
 
   build-linux-x86_64-many:
@@ -433,15 +425,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh extension install actions/gh-actions-cache;
-          caches=($(gh actions-cache list --key Linux-build-multiple- | cut -f 1));
-          i=100;
-          while [ ${i} -ge 1 ] ; do
-              if [ -n "${caches[${i}]}" ] ; then
-                  gh actions-cache delete --confirm "${caches[${i}]}";
-              fi
-              i=$((${i} - 1));
-          done
+          bash ${{ github.workspace }}/devel-tools/cleanup-gh-cache.sh Linux-build-multiple-
 
 
   build-linux-x86_64-sun:

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -255,6 +255,21 @@ jobs:
           name: Clang_address_sanitizer_output
           path: ${{github.workspace}}/build/Testing/Temporary/LastTest.log
 
+      - name: Keep only one cache besides the one from this job
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache;
+          caches=($(gh actions-cache list --key Linux-build-asan- | cut -f 1));
+          i=100;
+          while [ ${i} -ge 1 ] ; do
+              if [ -n "${caches[${i}]}" ] ; then
+                  gh actions-cache delete --confirm "${caches[${i}]}";
+              fi
+              i=$((${i} - 1));
+          done
+
 
   build-linux-x86_64-many:
     name: Linux x86_64 (GCC, Clang)

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -413,6 +413,21 @@ jobs:
           apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
           cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
+      - name: Keep only one cache besides the one from this job
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache;
+          caches=($(gh actions-cache list --key Linux-build-multiple- | cut -f 1));
+          i=100;
+          while [ ${i} -ge 1 ] ; do
+              if [ -n "${caches[${i}]}" ] ; then
+                  gh actions-cache delete --confirm "${caches[${i}]}";
+              fi
+              i=$((${i} - 1));
+          done
+
 
   build-linux-x86_64-sun:
     name: Linux x86_64 (Sun compiler)

--- a/devel-tools/cleanup-gh-cache.sh
+++ b/devel-tools/cleanup-gh-cache.sh
@@ -13,7 +13,8 @@ gh actions-cache --help > /dev/null || gh extension install actions/gh-actions-c
 for cache in $(gh actions-cache list --key ${key} | cut -f 1); do
     branch=$(gh actions-cache list --key ${cache} | cut -f 3)
     if [ ${branch} != 'refs/heads/master' ] ; then
-        gh actions-cache delete --confirm "${cache}"
+        # Ignore error if another job just deleted the same cache
+        gh actions-cache delete --confirm "${cache}" || true
     fi
 done
 
@@ -22,7 +23,7 @@ caches=($(gh actions-cache list --key ${key} | cut -f 1))
 i=${#caches[@]}
 while [ ${i} -ge 1 ] ; do
     if [ -n "${caches[${i}]}" ] ; then
-        gh actions-cache delete --confirm "${caches[${i}]}"
+        gh actions-cache delete --confirm "${caches[${i}]}" || true
     fi
     i=$((${i} - 1))
 done

--- a/devel-tools/cleanup-gh-cache.sh
+++ b/devel-tools/cleanup-gh-cache.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+key=${1:-key Linux-build-}
+
+if [ -z "${key}" ] ; then
+    echo "Error: please specify a cache key as argument." >& 2
+    exit 1
+fi
+
+gh actions-cache --help > /dev/null || gh extension install actions/gh-actions-cache
+
+# Delete all caches except those generated from master
+for cache in $(gh actions-cache list --key ${key} | cut -f 1); do
+    branch=$(gh actions-cache list --key ${cache} | cut -f 3)
+    if [ ${branch} != 'refs/heads/master' ] ; then
+        gh actions-cache delete --confirm "${cache}"
+    fi
+done
+
+# Now keep one cache for master
+caches=($(gh actions-cache list --key ${key} | cut -f 1))
+i=${#caches[@]}
+while [ ${i} -ge 1 ] ; do
+    if [ -n "${caches[${i}]}" ] ; then
+        gh actions-cache delete --confirm "${caches[${i}]}"
+    fi
+    i=$((${i} - 1))
+done

--- a/devel-tools/set-ccache.sh
+++ b/devel-tools/set-ccache.sh
@@ -18,4 +18,4 @@ if [ -z "${CCACHE_DIR}" ] || [ "x${CCACHE_DIR}" == "x/var/cache/ccache" ] ; then
 fi
 
 # Report cache statistics
-ccache -s
+ccache -sv


### PR DESCRIPTION
This PR changes the CI jobs so that at most two caches are kept for each job. At the end of the job, all caches except the most recent one right before are deleted. Later, one more instance of the cache will be written by the job itself as it exits. 

Also, the backends' caches are now regenerated when pushing to `master`, ensuring that they are available as starting caches when opening new PRs.