### PR TITLE
Several CI ccache related fixes and improvements

### DIFF
--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -133,9 +133,11 @@ jobs:
           OPENMM_SOURCE: ${{ github.workspace }}/openmm-source
           CMAKE_GENERATOR: Ninja
         run: |
-          apptainer exec devel-tools/${{ inputs.container_name }}.sif ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
           apptainer exec devel-tools/${{ inputs.container_name }}.sif \
-          bash ${{ inputs.path_compile_script }} ${{ inputs.backend_name }}-source
+              ./update-colvars-code.sh -f ${{ inputs.backend_name }}-source
+          mkdir -p ${CCACHE_DIR}
+          apptainer exec devel-tools/${{ inputs.container_name }}.sif \
+              bash ${{ inputs.path_compile_script }} ${{ inputs.backend_name }}-source
 
 
       # 2 types of tests can be performed with the MD engine: library & interface

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -63,9 +63,7 @@ jobs:
   test_backends:
     runs-on: ubuntu-latest
     env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache_${{ inputs.container_name }}
-      # Silence OpenMPI warnings
-      PSM3_MULTI_EP: 1
+      CCACHE_DIR: ~/ccache_${{ inputs.container_name }}
 
     steps:
       - name: Checkout Colvars

--- a/.github/workflows/backend-template.yml
+++ b/.github/workflows/backend-template.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ${{ github.workspace }}/ccache_${{ inputs.container_name }}
+            ~/ccache_${{ inputs.container_name }}
           key: ${{ runner.os }}-build-${{ inputs.backend_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-build-${{ inputs.backend_name }}-

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -1,6 +1,6 @@
 name: "Backends"
 
-on: [push, pull_request]
+on: [push]
 
 # These jobs call a template workflow `backend-template.yml`, which performs
 # all the necessary steps to run the regression tests of the backend.
@@ -20,9 +20,6 @@ jobs:
 
   lammps:
     name: LAMMPS
-    if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-lammps') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: LAMMPS
@@ -38,9 +35,6 @@ jobs:
     name: NAMD
     # Prevent running this job on PRs across different accounts, because
     # secrets wouldn't be shared
-    if: |
-      (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD
@@ -59,9 +53,6 @@ jobs:
     name: NAMD3 (no CUDA)
     # Prevent running this job on PRs across different accounts, because
     # secrets wouldn't be shared
-    if: |
-      (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-namd') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD3
@@ -81,9 +72,6 @@ jobs:
     name: VMD
     # Prevent running this job on PRs across different accounts, because
     # secrets wouldn't be shared
-    if: |
-      (github.event_name == 'pull_request' && github.repository_owner == github.event.pull_request.head.repo.owner.login) ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-vmd') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: VMD
@@ -103,9 +91,6 @@ jobs:
 
   gromacs-2022:
     name: GROMACS 2022
-    if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2022
@@ -118,9 +103,6 @@ jobs:
 
   gromacs-2023:
     name: GROMACS 2023
-    if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2023
@@ -133,9 +115,6 @@ jobs:
 
   gromacs-devel:
     name: GROMACS (MDModules)
-    if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'push' && (contains(github.event.head_commit.message, 'test-gromacs') || github.event.base_ref == 'refs/heads/master'))
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-devel

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -1,6 +1,6 @@
 name: "Library"
 
-on: [push, pull_request]
+on: [push]
 
 
 jobs:
@@ -9,7 +9,6 @@ jobs:
 
     name: Basic checks
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     outputs:
       hassecrets: ${{ steps.checksecrets.outputs.hassecrets }}
     env:
@@ -267,7 +266,6 @@ jobs:
     name: Linux x86_64 (GCC, Clang)
     runs-on: ubuntu-latest
     needs: basicchecks
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
       CCACHE: ccache
       CMAKE_GENERATOR: Ninja
@@ -478,7 +476,6 @@ jobs:
     name: Windows x86_64 (MSVC)
     runs-on: windows-latest
     needs: basicchecks
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
 
@@ -500,7 +497,6 @@ jobs:
     name: macOS x86_64 (AppleClang)
     runs-on: macos-latest
     needs: basicchecks
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
 

--- a/devel-tools/cleanup-gh-cache.sh
+++ b/devel-tools/cleanup-gh-cache.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-key=${1:-key Linux-build-}
+key=${1:-Linux-build-}
 
 if [ -z "${key}" ] ; then
     echo "Error: please specify a cache key as argument." >& 2
@@ -9,7 +9,7 @@ fi
 
 gh actions-cache --help >& /dev/null || gh extension install actions/gh-actions-cache
 
-# Keep at least one cache for each branch
+# Keep at most one cache for each branch
 branches=$(gh actions-cache list --key ${key} | cut -f 3 | uniq)
 for branch in ${branches} ; do
     caches=($(gh actions-cache list --key ${key} --branch ${branch} | cut -f 1))

--- a/devel-tools/compile-lammps.sh
+++ b/devel-tools/compile-lammps.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-source $(dirname $0)/load-recent-git.sh
+source $(dirname $0)/load-openmpi.sh
 
 source $(dirname $0)/set-ccache.sh
-
-source $(dirname $0)/load-openmpi.sh
 
 
 compile_lammps_target() {
@@ -74,6 +72,10 @@ compile_lammps_target() {
     fi
 
     LAMMPS_BUILD_OPTS+=("-DPKG_PYTHON=on")
+
+    if hash ccache >& /dev/null ; then
+        LAMMPS_BUILD_OPTS+=(-DCMAKE_{CXX,CC}_COMPILER_LAUNCHER=ccache)
+    fi
 
     if hash ninja >& /dev/null ; then
         LAMMPS_BUILD_OPTS+=("-G" "Ninja")

--- a/devel-tools/compile-namd.sh
+++ b/devel-tools/compile-namd.sh
@@ -6,6 +6,11 @@ source $(dirname $0)/load-openmpi.sh
 
 source $(dirname $0)/set-ccache.sh
 
+# Set explicit path for non-CMake targets
+if [ -n "${CCACHE_HOME}" ] ; then
+    export PATH=${CCACHE_HOME}:${PATH}
+fi
+
 # Save path to be used later
 devel_tools_folder=$(realpath $(dirname $0))
 

--- a/devel-tools/compile-vmd.sh
+++ b/devel-tools/compile-vmd.sh
@@ -4,6 +4,11 @@ source $(dirname $0)/load-recent-git.sh
 
 source $(dirname $0)/set-ccache.sh
 
+# Set explicit path for non-CMake targets
+if [ -n "${CCACHE_HOME}" ] ; then
+    export PATH=${CCACHE_HOME}:${PATH}
+fi
+
 detect_os() {
 
     # TODO This only works for RedHat-style Linux environments

--- a/devel-tools/load-openmpi.sh
+++ b/devel-tools/load-openmpi.sh
@@ -1,5 +1,7 @@
 # Ensure that Lmod is properly initialized
-source /etc/profile
+if [ -f /etc/profile.d/modules.sh ] ; then
+    source /etc/profile.d/modules.sh
+fi
 
 if declare -f module >& /dev/null ; then
     # Default modulefile in OpenMPI RPM package

--- a/devel-tools/set-ccache.sh
+++ b/devel-tools/set-ccache.sh
@@ -5,8 +5,6 @@ if [ -d /usr/lib64/ccache ] ; then
     export CCACHE_HOME=/usr/lib64/ccache
 fi
 
-export PATH=${CCACHE_HOME}:${PATH}
-
 if [ -z "${CCACHE_DIR}" ] || [ "x${CCACHE_DIR}" == "x/var/cache/ccache" ] ; then
     # Test for default setting in RHEL-like distributions
     if grep -sq 'CCACHE_DIR=/var/cache/ccache' /etc/profile.d/ccache.sh ; then
@@ -18,4 +16,9 @@ if [ -z "${CCACHE_DIR}" ] || [ "x${CCACHE_DIR}" == "x/var/cache/ccache" ] ; then
 fi
 
 # Report cache statistics
-ccache -sv
+if ccache -sv >& /dev/null ; then
+    ccache -sv
+else
+    # Old versions
+    ccache -s
+fi


### PR DESCRIPTION
The most significant change is the removal of the conditions that runs the backend jobs only on pull requests. This should allow their cache output to become associated with the `master` branch, which in turn would be available to CI jobs in other branches.

Also included are fixes to ensure correct ccache behavior when building the backends, including in the rare case when there is initially no cache.