### PR TITLE
New keyword format in documentation

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1488,7 +1488,7 @@ The \texttt{distance \{...\}} block defines a distance component between the two
     {group1}{%
     \texttt{distance}}{%
     First group of atoms}{%
-    Block \texttt{group1 \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     First group of atoms.}
 
 \item %
@@ -1553,7 +1553,7 @@ One of the groups can be set to a dummy atom to allow the use of an absolute Car
     {main}{%
     \texttt{distanceZ}}{%
     Main group of atoms}{%
-    Block \texttt{main \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Group of atoms whose position $\bm{r}$ is measured.}
 
 \item %
@@ -1563,7 +1563,7 @@ One of the groups can be set to a dummy atom to allow the use of an absolute Car
     \texttt{distanceZ}}{%
     Reference group of
     atoms}{%
-    Block \texttt{ref \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Reference group of atoms.  The position of its center of mass is
     noted $\bm{r}_1$ below.}
 
@@ -1574,7 +1574,7 @@ One of the groups can be set to a dummy atom to allow the use of an absolute Car
     \texttt{distanceZ}}{%
     Secondary reference
     group}{%
-    Block \texttt{ref2 \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     none}{%
     Optional group of reference atoms, whose position $\bm{r}_2$ can
     be used to define a dynamic projection axis: $\bm{e}=(\| \bm{r}_2
@@ -3018,7 +3018,7 @@ $(x_1, y_1, z_1, \cdots, x_n, y_n, z_n)$.
     {atoms}{%
     \texttt{cartesian}}{%
     Group of atoms}{%
-    Block \texttt{atoms \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Defines the atoms whose coordinates make up the value of the component.
     If \texttt{rotateToReference}, \texttt{centerToReference}, or \texttt{centerToOrigin} are defined, coordinates
     are evaluated within the moving frame of reference.}
@@ -3069,7 +3069,7 @@ In the \texttt{gspath~\{...\}} and the \texttt{gzpath~\{...\}} block all vectors
     {atoms}{%
     \texttt{gspath} and \texttt{gzpath}}{%
     Group of atoms}{%
-    Block \texttt{atoms \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Defines the atoms whose coordinates make up the value of the component.}
 
 \item %
@@ -3464,7 +3464,7 @@ implementation of the PCV progress component of the Tcl-scripted version
     {atoms}{%
     \texttt{aspath} and \texttt{azpath}}{%
     Group of atoms}{%
-    Block \texttt{atoms \{...\}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Defines the atoms whose coordinates make up the value of the component.}
 
 \item %
@@ -4965,7 +4965,7 @@ Be careful when using these options in ABF simulations or when using total force
     {fittingGroup}{%
     atom group}{%
     Use an alternate set of atoms to define the roto-translation}{%
-    Block \texttt{fittingGroup \{ ... \}}}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     This atom group itself}{%
     If either \texttt{centerToReference} or \texttt{rotateToReference} is defined, this keyword defines an alternate atom group to calculate the optimal roto-translation.
     Use this option to define a continuous rotation if the structure of the group involved changes significantly (a typical symptom would be the message ``Warning: discontinuous rotation!'').

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -626,7 +626,7 @@ For the output files, the prefix of Colvars output files will use the \texttt{-d
 \cvsubsec{Running Colvars in Tinker-HP}{sec:colvars_mdengine_parameters}
 
 To enable Colvars within a Tinker-HP run, just provide a Colvars configuration file with the same prefix as the \texttt{.key} file, and the extension \texttt{.colvars}.
-Tcl-scripted variables and biases Tcl callbacks may be defined by sourcing a script file using the \refkey{sourceTclFile}{Colvars-global|sourceTclFile} option.
+Tcl-scripted variables and biases may be defined by sourcing a script file using the \refkey{sourceTclFile}{Colvars-global|sourceTclFile} option.
 }% \cvtinkerhponly
 
 

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -203,31 +203,22 @@ cv.#1(#2)
 
 % use macros with context field to document keywords
 \newcommand{\key}[5]{%
-  {\bf Keyword} \index{#2!\texttt{#1}}%
-  \colorbox{cvkeyword-background-color}{\large \tt #1} $\langle\,$#3$\,\rangle$\\%
-  {\bf Context: } #2 \\%
-  {\bf Acceptable values: } #4 \\%
-  {\bf Description: } #5%
-}
+  \colorbox{cvkeyword-background-color}{\index{#2!\texttt{#1}}\texttt{#1}} --- \emph{#3}\vspace{1ex}\\%
+  $[$~#4, context: #2~$]$\vspace{1ex}\\%
+  #5}
 
 \newcommand{\keydef}[6]{%
-  {\bf Keyword} \index{#2!\texttt{#1}}%
-  \colorbox{cvkeyword-background-color}{\large \tt #1} $\langle\,$#3$\,\rangle$\\%
-  {\bf Context: } #2 \\%
-  {\bf Acceptable values: } #4 \\%
-  {\bf Default value: } #5 \\%
-  {\bf Description: } #6
-}
+  \colorbox{cvkeyword-background-color}{\index{#2!\texttt{#1}}\texttt{#1}} --- \emph{#3}\vspace{1ex}\\%
+  Default: #5 $[$~#4, context: #2~$]$\vspace{1ex}\\%
+  #6}
 
 \newcommand{\labelkey}[1]{\hypertarget{#1}{~}\label{#1}}
 \newcommand{\refkey}[2]{\hyperlink{#2}{\texttt{#1}}}
 \newcommand{\dupkey}[4]{%
-  {\bf Keyword} \index{#2!\texttt{#1}}%
-  \colorbox{cvkeyword-background-color}{\large \tt #1}: see definition of \hyperlink{#3}{\texttt{#1}} (#4)%
+  \colorbox{cvkeyword-background-color}{\index{#2!\texttt{#1}}\texttt{#1}} --- same definition as \hyperlink{#3}{\texttt{#1}} (#4)%
 }
 \newcommand{\simkey}[3]{%
-  \index{#2!\texttt{#1}}%
-  \colorbox{cvkeyword-background-color}{\large \tt #1}: analogous to \texttt{#3}%
+  \colorbox{cvkeyword-background-color}{\index{#2!\texttt{#1}}\texttt{#1}} --- analogous to \texttt{#3}%
 }
 
 \newcommand{\gradx}{\mbox{\boldmath$\nabla_{\!\!x}\,$}}

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -212,7 +212,7 @@ cv.#1(#2)
   Default: #5 $[$~#4, context: #2~$]$\vspace{1ex}\\%
   #6}
 
-\newcommand{\labelkey}[1]{\hypertarget{#1}{~}\label{#1}}
+\newcommand{\labelkey}[1]{\hypertarget{#1}{}\label{#1}}
 \newcommand{\refkey}[2]{\hyperlink{#2}{\texttt{#1}}}
 \newcommand{\dupkey}[4]{%
   \colorbox{cvkeyword-background-color}{\index{#2!\texttt{#1}}\texttt{#1}} --- same definition as \hyperlink{#3}{\texttt{#1}} (#4)%


### PR DESCRIPTION
Another small enhancement for the doc, reducing the complexity of a keyword entry by eliminating boldface-headers.

_Before:_
![image](https://github.com/Colvars/colvars/assets/4512089/82f40079-ed7f-4a43-95ab-bc8d80af1e39)

_After:_
![image](https://github.com/Colvars/colvars/assets/4512089/f3f327ff-aa4f-4a13-900a-b1215d8fba43)

I added small vertical breaks, but they only work in PDF because each keyword is still contained in a list item `<li>` in HTML. Removing the bullet points would be useful, but it's a bigger change.