### PR TITLE
Push updated documentation through CI jobs

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -116,12 +116,36 @@ jobs:
       - name: Checkout website repository
         uses: actions/checkout@v4
         with:
+          ssh-key: ${{ secrets.PULL_PUSH_COLVARS_GITHUB_IO }}
           repository: 'Colvars/colvars.github.io'
           path: 'website'
 
-      - name: Build doc
+      - name: Build doc for current branch
         working-directory: doc
-        run: apptainer exec ${{ github.workspace }}/devel-tools/texlive.sif make
+        run: |
+          make clean-all
+          apptainer exec ${{ github.workspace }}/devel-tools/texlive.sif make
+
+      - name: Install SSH key for access to website repository
+        if: contains(github.event.head_commit.message, '[update-doc]')
+        env:
+          WEBSITE_SSH_KEY: ${{ secrets.PULL_PUSH_COLVARS_GITHUB_IO }}
+        run: |
+          mkdir -p -m 700 ~/.ssh
+          echo "${WEBSITE_SSH_KEY}" > ~/.ssh/website
+          chmod 600 ~/.ssh/website
+
+      - name: Push updated doc to website repository
+        working-directory: doc
+        if: contains(github.event.head_commit.message, '[update-doc]')
+        env:
+          COLVARS_WEBSITE_TREE: ${{ github.workspace }}/website
+        run: |
+          apptainer exec ${{ github.workspace }}/devel-tools/texlive.sif make install
+          export GIT_SSH="ssh -i ~/.ssh/website"
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "CI runner"
+          bash update_website.sh ${{ github.workspace }}/website
 
 
   codeql:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ endif
 
 ifeq ($(COLVARS_RELEASE),)
 # If we are not working on a branch, try a tag instead
-COLVARS_RELEASE = $(git describe --tags --exact-match)
+COLVARS_RELEASE = $(shell git describe --tags --exact-match)
 endif
 
 export COLVARS_RELEASE
@@ -121,18 +121,13 @@ IMAGES = cover-512px.jpg eulerangles-512px.png
 # Note: to produce the documentation for a specific release of a MD engine,
 # check out the branch or tag corresponding to that version, clean and rebuild.
 ifeq ($(COLVARS_RELEASE),"master")
+
 webpage: all images doxygen
 	mkdir -p $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE) ; \
 	cp -p -f $(PDF) $(HTML) $(CSS) $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE)/ ; \
 	cp -p -f $(addprefix $(COLVARS_WEBSITE_TREE)/images/, $(IMAGES)) $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE)/ ; \
 	rm -fr $(COLVARS_WEBSITE_TREE)/doxygen/html/* ; \
 	cp -p -r doxygen/html/* $(COLVARS_WEBSITE_TREE)/doxygen/html/
-else
-webpage: all images
-	mkdir -p $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE) ; \
-	cp -p -f $(PDF) $(HTML) $(CSS) $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE)/ ; \
-	cp -p -f $(addprefix $(COLVARS_WEBSITE_TREE)/images/, $(IMAGES)) $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE)/
-endif
 
 # Update HTML pages with older-style paths (without branch/release name)
 webpage-legacy: all images
@@ -143,5 +138,16 @@ webpage-legacy: all images
 	done
 
 install: webpage webpage-legacy
+
+else
+
+webpage: all images
+	mkdir -p $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE) ; \
+	cp -p -f $(PDF) $(HTML) $(CSS) $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE)/ ; \
+	cp -p -f $(addprefix $(COLVARS_WEBSITE_TREE)/images/, $(IMAGES)) $(COLVARS_WEBSITE_TREE)/$(COLVARS_RELEASE)/
+
+install: webpage
+endif
+
 
 endif

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -1805,8 +1805,8 @@ An example is provided in file \texttt{examples/11\_polar\_angles.in} of the Col
   \key
     {atoms}{%
     \texttt{polarPhi}}{%
-    Atom group}{%
-    \texttt{atoms~\{...\}} block}{%
+    Group of atoms defining this function}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Defines the group of atoms for the COM of which the angle should be calculated.
     }
 \end{cvcoptions}
@@ -1834,8 +1834,8 @@ An example is provided in file \texttt{examples/11\_polar\_angles.in} of the Col
   \key
     {atoms}{%
     \texttt{polarPhi}}{%
-    Atom group}{%
-    \texttt{atoms~\{...\}} block}{%
+    Group of atoms defining this function}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Defines the group of atoms for the COM of which the angle should be calculated.
     }
 \end{cvcoptions}
@@ -2088,8 +2088,8 @@ with respect to $\{\mathbf{x}_{i}(t)\}$.
   \key
     {atoms}{%
     \texttt{rmsd}}{%
-    Atom group}{%
-    \texttt{atoms~\{...\}} block}{%
+    Group of atoms defining this function}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     Defines the group of atoms of which the RMSD should be calculated.
     Optimal fit options (such as \texttt{refPositions} and
     \texttt{rotateToReference}) should typically NOT be set within this
@@ -3724,8 +3724,8 @@ Because the volumetric map itself and the atoms affected by it are defined exter
   \key
     {atoms}{%
     \texttt{mapTotal}}{%
-    Atom group}{%
-    \texttt{atoms~\{...\}} block}{%
+    Group of atoms defining this function}{%
+    \hyperref[sec:colvar_atom_groups]{Atom group}}{%
     If defined, this option allows defining the set of atoms to be aligned onto the volumetric map following the syntax described in section \ref{sec:colvar_atom_groups}.
     This also allows, for instance, to express the volumetric map in a rotated frame of reference (see \ref{sec:colvar_atom_groups_ref_frame}).
     \cvvmdonly{In VMD, this definition is required, otherwise the \texttt{mapTotal} value is identically zero.}

--- a/doc/update_website.sh
+++ b/doc/update_website.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+COLVARS_WEBSITE_TREE=${1}
+if [ -z "${COLVARS_WEBSITE_TREE}" ] ; then
+    echo "Error: need the full path to the website repository as argument." >&2
+    exit 1
+fi
+
+if grep -sq colvars ${COLVARS_WEBSITE_TREE}/index.html ; then
+    export COLVARS_WEBSITE_TREE
+else
+    echo "Error: ${COLVARS_WEBSITE_TREE} does not seem to contain a Colvars webpage repository." >&2
+    exit 1
+fi
+
+# If needed, initialize COLVARS_RELEASE in the same way as Makefile would
+if [ -z "${COLVARS_RELEASE}" ] ; then
+    COLVARS_RELEASE=$(git symbolic-ref --short -q HEAD)
+fi
+if [ -z "${COLVARS_RELEASE}" ] ; then
+    # If we are not working on a branch, try a tag instead
+    COLVARS_RELEASE=$(git describe --tags --exact-match)
+fi
+if [ -z "${COLVARS_RELEASE}" ] ; then
+    echo "Error: ${COLVARS_RELEASE} is undefined and could not be configured from a Git branch or tag." >&2
+    exit 1
+fi
+
+if make install && pushd ${COLVARS_WEBSITE_TREE} ; then
+    git add ${COLVARS_RELEASE}
+    if [ "x${COLVARS_RELEASE}" == "xmaster" ] ; then
+        git add doxygen
+        git add colvars-refman-*
+    fi
+    git commit -m "Update doc for version \"${COLVARS_RELEASE}\""
+    # Hard-code the website repository
+    git push git@github.com:Colvars/colvars.github.io master
+    popd
+fi


### PR DESCRIPTION
Support updating the documentation directly from GitHub Actions. Currently, the doc `Makefile` already uses the current Git branch (or tag) to define the version of the code (added in #606).

This PR adds the necessary plumbing to push the documentation just built to the website's repository. In order to do so, we need the following:
1. The commit message must include the string "`[update-doc]`"
2. This commit must be at the head of a push, so that the CI jobs are triggered correctly.

The documentation is added to the website in a sub-folder with the same name as the branch, so that we can preview the documentation in a PR for review purposes. In between PRs, we may want to remove commits for these temporary branches from the website repository to avoid growing its size too much.

When pushing to `master`, Doxygen updates are pushed in addition to the manual. 

I have already verified that the website was correctly updated by generating pages like this:
https://colvars.github.io/push-doc/colvars-refman-namd.html
Will now delete those files from the website repository before attempting to merge into `master`.