### PR TITLE
Remove unused includes

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -18,7 +18,7 @@
 #include "colvarparse.h"
 #include "colvarcomp.h"
 #include "colvar.h"
-#include "colvarscript.h"
+#include "colvarbias.h"
 #include "colvars_memstream.h"
 
 

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -11,6 +11,7 @@
 #define COLVAR_H
 
 #include <functional>
+#include <list>
 #include <iosfwd>
 #include <map>
 

--- a/src/colvarbias_alb.cpp
+++ b/src/colvarbias_alb.cpp
@@ -9,7 +9,6 @@
 
 #include <iostream>
 #include <iomanip>
-#include <cstdlib>
 
 #include "colvarmodule.h"
 #include "colvarproxy.h"

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -7,8 +7,6 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
-#include <iostream>
-#include <sstream>
 #include <fstream>
 #include <iomanip>
 #include <algorithm>

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -19,8 +19,6 @@
 // this can be done straightforwardly by using the macro:
 // simple_scalar_dist_functions (derived_class)
 
-#include <functional>
-#include <map>
 #include <memory>
 
 #include "colvarmodule.h"

--- a/src/colvarcomp_alchlambda.cpp
+++ b/src/colvarcomp_alchlambda.cpp
@@ -12,7 +12,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 

--- a/src/colvarcomp_apath.cpp
+++ b/src/colvarcomp_apath.cpp
@@ -9,13 +9,11 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <numeric>
 
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 #include "colvar_arithmeticpath.h"

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -8,7 +8,6 @@
 // Colvars repository at GitHub.
 
 #include "colvarmodule.h"
-#include "colvarparse.h"
 #include "colvaratoms.h"
 #include "colvarvalue.h"
 #include "colvar.h"

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -11,7 +11,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 #include "colvar_rotation_derivative.h"

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -10,13 +10,11 @@
 #include <numeric>
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 #include <fstream>
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 

--- a/src/colvarcomp_neuralnetwork.cpp
+++ b/src/colvarcomp_neuralnetwork.cpp
@@ -9,7 +9,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 #include "colvar_neuralnetworkcompute.h"

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -11,7 +11,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -9,7 +9,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 #include "colvar_rotation_derivative.h"

--- a/src/colvarcomp_volmaps.cpp
+++ b/src/colvarcomp_volmaps.cpp
@@ -9,7 +9,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarparse.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 

--- a/src/colvargrid.cpp
+++ b/src/colvargrid.cpp
@@ -8,13 +8,11 @@
 // Colvars repository at GitHub.
 
 #include <ctime>
-#include <fstream>
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 #include "colvarparse.h"
 #include "colvar.h"
-#include "colvarcomp.h"
 #include "colvargrid.h"
 #include "colvargrid_def.h"
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -7,13 +7,9 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <map>
-#include <sstream>
+#include <memory>
 #include <vector>
 
 #include "colvarmodule.h"

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -10,8 +10,6 @@
 #ifndef COLVARMODULE_H
 #define COLVARMODULE_H
 
-#include <cmath>
-
 #include "colvars_version.h"
 
 #ifndef COLVARS_DEBUG
@@ -35,16 +33,15 @@ Please note that this documentation is only supported for the master branch, and
 /// shared between all object instances) to be accessed from other
 /// objects.
 
+#include <cmath>
+#include <iosfwd>
 #include <string>
 #include <vector>
-#include <list>
-#include <iosfwd>
 
 class colvarparse;
 class colvar;
 class colvarbias;
 class colvarproxy;
-class colvarscript;
 class colvarvalue;
 
 
@@ -82,8 +79,6 @@ public:
   }
 
   friend class colvarproxy;
-  // TODO colvarscript should be unaware of colvarmodule's internals
-  friend class colvarscript;
 
   /// Use a 64-bit integer to store the step number
   typedef long long step_number;

--- a/src/colvarparse.cpp
+++ b/src/colvarparse.cpp
@@ -8,7 +8,6 @@
 // Colvars repository at GitHub.
 
 #include <sstream>
-#include <iostream>
 #include <algorithm>
 
 #include "colvarmodule.h"

--- a/src/colvarparse.h
+++ b/src/colvarparse.h
@@ -11,6 +11,7 @@
 #define COLVARPARSE_H
 
 #include <cstring>
+#include <list>
 #include <string>
 
 #include "colvarmodule.h"

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -13,8 +13,9 @@
 
 #include "colvarmodule.h"
 #include "colvarproxy.h"
+#include "colvar.h"
+#include "colvarbias.h"
 #include "colvarscript.h"
-#include "colvaratoms.h"
 #include "colvarmodule_utils.h"
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -12,7 +12,6 @@
 
 #include "colvarmodule.h"
 #include "colvartypes.h"
-#include "colvarvalue.h"
 #include "colvarproxy_io.h"
 #include "colvarproxy_system.h"
 #include "colvarproxy_tcl.h"

--- a/src/colvarproxy_io.h
+++ b/src/colvarproxy_io.h
@@ -10,9 +10,10 @@
 #ifndef COLVARPROXY_IO_H
 #define COLVARPROXY_IO_H
 
+#include <iosfwd>
+#include <list>
 #include <map>
 #include <string>
-#include <iosfwd>
 
 
 /// Methods for data input/output

--- a/src/colvarscript.cpp
+++ b/src/colvarscript.cpp
@@ -7,8 +7,6 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
-#include <cstdlib>
-#include <cstring>
 #include <sstream>
 
 #include "colvarproxy.h"
@@ -769,7 +767,7 @@ extern "C" int tcl_run_colvarscript_command(ClientData /* clientData */,
 int colvarscript::set_result_text_from_str(std::string const &x_str,
                                            unsigned char *obj) {
   if (obj) {
-    strcpy(reinterpret_cast<char *>(obj), x_str.c_str());
+    std::memcpy(reinterpret_cast<char *>(obj), x_str.c_str(), x_str.size());
   } else {
     set_result_str(x_str);
   }

--- a/src/colvarscript.h
+++ b/src/colvarscript.h
@@ -16,7 +16,6 @@
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"
-#include "colvarbias.h"
 #include "colvarproxy.h"
 
 
@@ -24,6 +23,8 @@
 #define COLVARSCRIPT_ERROR -1
 #define COLVARSCRIPT_OK 0
 
+
+class colvardeps;
 
 class colvarscript  {
 

--- a/src/colvarscript_commands.cpp
+++ b/src/colvarscript_commands.cpp
@@ -8,9 +8,9 @@
 // Colvars repository at GitHub.
 
 #include <vector>
-#include <cstdlib>
-#include <string.h>
 
+#include "colvar.h"
+#include "colvarbias.h"
 #include "colvarproxy.h"
 #include "colvardeps.h"
 #include "colvarscript.h"

--- a/src/colvarscript_commands_bias.cpp
+++ b/src/colvarscript_commands_bias.cpp
@@ -9,11 +9,9 @@
 
 
 #include <vector>
-#include <cstdlib>
-#include <stdlib.h>
-#include <string.h>
 
 #include "colvarproxy.h"
+#include "colvarbias.h"
 #include "colvardeps.h"
 #include "colvarscript.h"
 #include "colvarscript_commands.h"

--- a/src/colvarscript_commands_colvar.cpp
+++ b/src/colvarscript_commands_colvar.cpp
@@ -11,8 +11,8 @@
 #include <vector>
 #include <cstdlib>
 #include <stdlib.h>
-#include <string.h>
 
+#include "colvar.h"
 #include "colvarproxy.h"
 #include "colvardeps.h"
 #include "colvarscript.h"

--- a/src/colvartypes.cpp
+++ b/src/colvartypes.cpp
@@ -7,12 +7,8 @@
 // If you wish to distribute your changes, please submit them to the
 // Colvars repository at GitHub.
 
-#include <cstdlib>
-#include <cstring>
-
 #include "colvarmodule.h"
 #include "colvartypes.h"
-#include "colvarparse.h"
 #include "colvaratoms.h"
 #include "colvar_rotation_derivative.h"
 

--- a/src/colvarvalue.cpp
+++ b/src/colvarvalue.cpp
@@ -8,8 +8,6 @@
 // Colvars repository at GitHub.
 
 #include <vector>
-#include <sstream>
-#include <iostream>
 
 #include "colvarmodule.h"
 #include "colvarvalue.h"

--- a/src/colvarvalue.h
+++ b/src/colvarvalue.h
@@ -10,6 +10,8 @@
 #ifndef COLVARVALUE_H
 #define COLVARVALUE_H
 
+#include <list>
+
 #include "colvarmodule.h"
 #include "colvartypes.h"
 


### PR DESCRIPTION
Identified a couple by hand, and a ton more using IWYU. No effect on the compiled code, but should minimize build times due to changes in unneeded headers.

`colvarproxy.h` in particular becomes a lot lighter, but it's not yet at the point where the clang-tidy checks in GROMACS can pass yet.