### PR TITLE
Only distribute biases over threads if they don't need I/O

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1466,6 +1466,15 @@ int colvarproxy_namd::compute_volmap(int flags,
 
 #if CMK_SMP && USE_CKLOOP // SMP only
 
+int colvarproxy_namd::check_smp_enabled()
+{
+  if (b_smp_active) {
+    return COLVARS_OK;
+  }
+  return COLVARS_ERROR;
+}
+
+
 void calc_colvars_items_smp(int first, int last, void *result, int paramNum, void *param)
 {
   colvarproxy_namd *proxy = (colvarproxy_namd *) param;

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -113,13 +113,7 @@ public:
   }
 
 #if CMK_SMP && USE_CKLOOP
-  int smp_enabled() override
-  {
-    if (b_smp_active) {
-      return COLVARS_OK;
-    }
-    return COLVARS_ERROR;
-  }
+  int check_smp_enabled() override;
 
   int smp_colvars_loop() override;
 

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -447,10 +447,16 @@ int colvarbias::bin_count(int /* bin_index */)
   cvm::error("Error: bin_count() not implemented.\n");
   return COLVARS_NOT_IMPLEMENTED;
 }
+
 int colvarbias::replica_share()
 {
   cvm::error("Error: replica_share() not implemented.\n");
   return COLVARS_NOT_IMPLEMENTED;
+}
+
+size_t colvarbias::replica_share_freq() const
+{
+  return 0;
 }
 
 

--- a/src/colvarbias.h
+++ b/src/colvarbias.h
@@ -93,8 +93,12 @@ public:
   //// Give the count at a given bin index.
   // FIXME this is currently 1D only
   virtual int bin_count(int bin_index);
+
   //// Share information between replicas, whatever it may be.
   virtual int replica_share();
+
+  /// Report the frequency at which this bias needs to communicate with replicas
+  virtual size_t replica_share_freq() const;
 
   /// Perform analysis tasks
   virtual void analyze() {}

--- a/src/colvarbias_abf.cpp
+++ b/src/colvarbias_abf.cpp
@@ -599,6 +599,12 @@ int colvarbias_abf::replica_share() {
 }
 
 
+size_t colvarbias_abf::replica_share_freq() const
+{
+  return shared_freq;
+}
+
+
 template <class T> int colvarbias_abf::write_grid_to_file(T const *grid,
                                                           std::string const &filename,
                                                           bool close) {

--- a/src/colvarbias_abf.cpp
+++ b/src/colvarbias_abf.cpp
@@ -106,12 +106,6 @@ int colvarbias_abf::init(std::string const &conf)
     }
     cvm::log("shared ABF will be applied among "+
              cvm::to_str(proxy->num_replicas()) + " replicas.\n");
-    if (cvm::proxy->smp_enabled() == COLVARS_OK) {
-      cvm::error("Error: shared ABF is currently not available with SMP parallelism; "
-                 "please set \"SMP off\" at the top of the Colvars configuration file.\n",
-                 COLVARS_NOT_IMPLEMENTED);
-      return COLVARS_NOT_IMPLEMENTED;
-    }
 
     // If shared_freq is not set, we default to output_freq
     get_keyval(conf, "sharedFreq", shared_freq, output_freq);

--- a/src/colvarbias_abf.h
+++ b/src/colvarbias_abf.h
@@ -133,8 +133,11 @@ private:
   bool    shared_on;
   size_t  shared_freq;
   cvm::step_number shared_last_step;
+
   // Share between replicas -- may be called independently of update
   virtual int replica_share();
+
+  virtual size_t replica_share_freq() const;
 
   // Store the last set for shared ABF
   colvar_grid_gradient  *last_gradients;

--- a/src/colvarbias_meta.cpp
+++ b/src/colvarbias_meta.cpp
@@ -64,7 +64,6 @@ colvarbias_meta::colvarbias_meta(char const *key)
 
   ebmeta_equil_steps = 0L;
 
-  replica_update_freq = 0;
   replica_id.clear();
 }
 
@@ -985,9 +984,9 @@ void colvarbias_meta::recount_hills_off_grid(colvarbias_meta::hill_iter  h_first
 int colvarbias_meta::replica_share()
 {
   int error_code = COLVARS_OK;
-  colvarproxy *proxy = cvm::proxy;
   // sync with the other replicas (if needed)
   if (comm == multiple_replicas) {
+    colvarproxy *proxy = cvm::main()->proxy;
     // reread the replicas registry
     error_code |= update_replicas_registry();
     // empty the output buffer
@@ -995,6 +994,12 @@ int colvarbias_meta::replica_share()
     error_code |= read_replica_files();
   }
   return error_code;
+}
+
+
+size_t colvarbias_meta::replica_share_freq() const
+{
+  return replica_update_freq;
 }
 
 

--- a/src/colvarbias_meta.h
+++ b/src/colvarbias_meta.h
@@ -52,6 +52,7 @@ public:
   virtual int update_bias();
   virtual int update_grid_data();
   virtual int replica_share();
+  virtual size_t replica_share_freq() const;
 
   virtual int calc_energy(std::vector<colvarvalue> const *values);
   virtual int calc_forces(std::vector<colvarvalue> const *values);
@@ -261,7 +262,7 @@ protected:
   std::vector<colvarbias_meta *> replicas;
 
   /// \brief Frequency at which data the "mirror" biases are updated
-  size_t                 replica_update_freq;
+  size_t replica_update_freq = 0;
 
   /// List of replicas (and their output list files): contents are
   /// copied into replicas_registry for convenience

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -110,7 +110,7 @@ colvarmodule::colvarmodule(colvarproxy *proxy_in)
            "  https://doi.org/10.1080/00268976.2013.813594\n"
            "as well as all other papers listed below for individual features used.\n");
 
-  if (proxy->smp_enabled() == COLVARS_OK) {
+  if (proxy->check_smp_enabled() == COLVARS_OK) {
     cvm::log("SMP parallelism is enabled (num threads = " + to_str(proxy->smp_num_threads()) +
              "); use \"smp off\" to disable if needed.\n");
   }
@@ -901,7 +901,7 @@ int colvarmodule::calc_colvars()
   }
 
   // if SMP support is available, split up the work
-  if (proxy->smp_enabled() == COLVARS_OK) {
+  if (proxy->check_smp_enabled() == COLVARS_OK) {
 
     // first, calculate how much work (currently, how many active CVCs) each colvar has
 
@@ -984,7 +984,7 @@ int colvarmodule::calc_biases()
   }
 
   // if SMP support is available, split up the work
-  if (proxy->smp_enabled() == COLVARS_OK) {
+  if (proxy->check_smp_enabled() == COLVARS_OK) {
 
     if (use_scripted_forces && !scripting_after_biases) {
       // calculate biases and scripted forces in parallel
@@ -1955,7 +1955,7 @@ size_t & colvarmodule::depth()
 {
   // NOTE: do not call log() or error() here, to avoid recursion
   colvarmodule *cv = cvm::main();
-  if (proxy->smp_enabled() == COLVARS_OK) {
+  if (proxy->check_smp_enabled() == COLVARS_OK) {
     int const nt = proxy->smp_num_threads();
     if (int(cv->depth_v.size()) != nt) {
       proxy->smp_lock();

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -110,9 +110,14 @@ colvarmodule::colvarmodule(colvarproxy *proxy_in)
            "  https://doi.org/10.1080/00268976.2013.813594\n"
            "as well as all other papers listed below for individual features used.\n");
 
-  if (proxy->check_smp_enabled() == COLVARS_OK) {
-    cvm::log("SMP parallelism is enabled (num threads = " + to_str(proxy->smp_num_threads()) +
-             "); use \"smp off\" to disable if needed.\n");
+  if (proxy->check_smp_enabled() == COLVARS_NOT_IMPLEMENTED) {
+    cvm::log("SMP parallelism is not available in this build.\n");
+  } else {
+    if (proxy->check_smp_enabled() == COLVARS_OK) {
+      cvm::log("SMP parallelism is enabled (num threads = " + to_str(proxy->smp_num_threads()) + ").\n");
+    } else {
+      cvm::log("SMP parallelism is available in this build but not enabled.\n");
+    }
   }
 
 #if (__cplusplus >= 201103L)

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -983,8 +983,15 @@ int colvarmodule::calc_biases()
     }
   }
 
-  // if SMP support is available, split up the work
-  if (proxy->check_smp_enabled() == COLVARS_OK) {
+  bool biases_need_io = false;
+  for (bi = biases_active()->begin(); bi != biases_active()->end(); bi++) {
+    if (((*bi)->replica_share_freq() > 0) && (step_absolute() % (*bi)->replica_share_freq() == 0)) {
+      biases_need_io = true;
+    }
+  }
+
+  // If SMP support is available, split up the work (unless biases need to use main thread's memory)
+  if (proxy->check_smp_enabled() == COLVARS_OK && !biases_need_io) {
 
     if (use_scripted_forces && !scripting_after_biases) {
       // calculate biases and scripted forces in parallel
@@ -1000,10 +1007,12 @@ int colvarmodule::calc_biases()
       error_code |= calc_scripted_forces();
     }
 
+    // Straight loop over biases on a single thread
     cvm::increase_depth();
     for (bi = biases_active()->begin(); bi != biases_active()->end(); bi++) {
       error_code |= (*bi)->update();
       if (cvm::get_error()) {
+        cvm::decrease_depth();
         return error_code;
       }
     }

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -288,7 +288,7 @@ colvarproxy_smp::~colvarproxy_smp()
 }
 
 
-int colvarproxy_smp::smp_enabled()
+int colvarproxy_smp::check_smp_enabled()
 {
 #if defined(_OPENMP)
   if (b_smp_active) {
@@ -492,8 +492,8 @@ colvarproxy::~colvarproxy()
 
 bool colvarproxy::io_available()
 {
-  return (smp_enabled() == COLVARS_OK && smp_thread_id() == 0) ||
-    (smp_enabled() != COLVARS_OK);
+  return (check_smp_enabled() == COLVARS_OK && smp_thread_id() == 0) ||
+    (check_smp_enabled() != COLVARS_OK);
 }
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -480,7 +480,7 @@ public:
   bool b_smp_active;
 
   /// Whether threaded parallelization is available (TODO: make this a cvm::deps feature)
-  virtual int smp_enabled();
+  virtual int check_smp_enabled();
 
   /// Distribute calculation of colvars (and their components) across threads
   virtual int smp_colvars_loop();


### PR DESCRIPTION
Prevents a possible race condition when running multiple-walkers metadynamics with threads. This didn't use to be an issue until recently, when objects do all I/O operations by modifying members of the `colvarmodule` class.

This fix also removes an earlier restriction on multiple-walkers ABF. No doc changes are needed, since that was not documented anyway.

Possible TODO: check if SMP can be enabled again on NAMD CI jobs, which could have been failing because it's the only engine currently having a CI test for multiple-walkers metadynamics.