### PR TITLE
Removing CI job for NAMD branch no longer maintained

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -20,8 +20,8 @@ env:
 
 jobs:
 
-  lammps:
-    name: LAMMPS
+  lammps-develop:
+    name: LAMMPS (develop)
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: LAMMPS
@@ -33,31 +33,13 @@ jobs:
       test_interface_directory: lammps/tests/interface
       rpath_exe: install/bin/lmp
 
-  namd:
-    name: NAMD
+  namd-devel:
+    name: NAMD (devel)
     # Prevent running this job on PRs across different accounts, because
     # secrets wouldn't be shared
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: NAMD
-      backend_repo: Colvars/namd
-      backend_repo_ref: master
-      container_name: CentOS7-devel
-      path_compile_script: devel-tools/compile-namd.sh
-      test_lib_directory: namd/tests/library
-      test_interface_directory: namd/tests/interface
-      rpath_exe: Linux-x86_64-g++.mpi/namd2
-    secrets:
-      # Choice of license by UIUC prevents sharing the code, hence the secret
-      private_key: ${{ secrets.PULL_NAMD_KEY }}
-
-  namd3:
-    name: NAMD3 (no CUDA)
-    # Prevent running this job on PRs across different accounts, because
-    # secrets wouldn't be shared
-    uses: ./.github/workflows/backend-template.yml
-    with:
-      backend_name: NAMD3
       backend_repo: Colvars/namd
       backend_repo_ref: devel
       path_compile_script: devel-tools/compile-namd.sh
@@ -69,7 +51,7 @@ jobs:
       # Choice of license by UIUC prevents sharing the code, hence the secret
       private_key: ${{ secrets.PULL_NAMD_KEY }}
 
-  vmd:
+  vmd-cvs:
     name: VMD
     # Prevent running this job on PRs across different accounts, because
     # secrets wouldn't be shared
@@ -91,7 +73,7 @@ jobs:
       private_key_vmd_plugins: ${{ secrets.PULL_VMD_PLUGINS_KEY }}
 
   gromacs-2022:
-    name: GROMACS 2022
+    name: GROMACS (release-2022)
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2022
@@ -103,7 +85,7 @@ jobs:
       rpath_exe: install/bin/gmx_d
 
   gromacs-2023:
-    name: GROMACS 2023
+    name: GROMACS (release-2023)
     uses: ./.github/workflows/backend-template.yml
     with:
       backend_name: GROMACS-2023
@@ -114,11 +96,11 @@ jobs:
       test_lib_directory: gromacs/tests/library
       rpath_exe: install/bin/gmx_d
 
-  gromacs-devel:
-    name: GROMACS (MDModules)
+  gromacs-main:
+    name: GROMACS (main)
     uses: ./.github/workflows/backend-template.yml
     with:
-      backend_name: GROMACS-devel
+      backend_name: GROMACS-main
       backend_repo: gromacs/gromacs
       backend_repo_ref: main
       container_name: CentOS9-devel


### PR DESCRIPTION
The `master` branch of the NAMD repository (2.15 alpha release) is by now abandoned, and has been replaced by the `devel` branch (3.0 release candidate).  Removing the unmaintained version to avoid CI errors.

Also added more descriptive names for the backends CI jobs (i.e. using branches where these are applicable).