### PR TITLE
Don't strip input state file in GROMACS (pre-2024)

### DIFF
--- a/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2020.x/colvarproxy_gromacs.cpp
@@ -88,8 +88,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
   {
     colvars_restart = true;
     input_prefix_str = filename_restart;
-    input_prefix_str.erase(input_prefix_str.rfind(".dat"));
-    input_prefix_str.erase(input_prefix_str.rfind(".colvars.state"));
+    // Don't strip the input_prefix_str because colvarmodule.cpp doesn't know that restart file from GROMACS needs the .dat extension.
   }
 
   // Retrieve masses and charges from input file

--- a/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2021.x/colvarproxy_gromacs.cpp
@@ -87,8 +87,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step,gmx_mtop_t *mtop,
   {
     colvars_restart = true;
     input_prefix_str = filename_restart;
-    input_prefix_str.erase(input_prefix_str.rfind(".dat"));
-    input_prefix_str.erase(input_prefix_str.rfind(".colvars.state"));
+    // Don't strip the input_prefix_str because colvarmodule.cpp doesn't know that restart file from GROMACS needs the .dat extension.
   }
 
   // Retrieve masses and charges from input file

--- a/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2022.x/colvarproxy_gromacs.cpp
@@ -87,8 +87,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step, const gmx_mtop_t &m
   {
     colvars_restart = true;
     input_prefix_str = filename_restart;
-    input_prefix_str.erase(input_prefix_str.rfind(".dat"));
-    input_prefix_str.erase(input_prefix_str.rfind(".colvars.state"));
+    // Don't strip the input_prefix_str because colvarmodule.cpp doesn't know that restart file from GROMACS needs the .dat extension.
   }
 
   // Retrieve masses and charges from input file

--- a/gromacs/gromacs-2023.x/colvarproxy_gromacs.cpp
+++ b/gromacs/gromacs-2023.x/colvarproxy_gromacs.cpp
@@ -87,8 +87,7 @@ void colvarproxy_gromacs::init(t_inputrec *ir, int64_t step, const gmx_mtop_t &m
   {
     colvars_restart = true;
     input_prefix_str = filename_restart;
-    input_prefix_str.erase(input_prefix_str.rfind(".dat"));
-    input_prefix_str.erase(input_prefix_str.rfind(".colvars.state"));
+    // Don't strip the input_prefix_str because colvarmodule.cpp doesn't know that restart file from GROMACS needs the .dat extension.
   }
 
   // Retrieve masses and charges from input file


### PR DESCRIPTION
This follows the bug report in GROMACS forum [here](https://gromacs.bioexcel.eu/t/standard-library-logic-error-when-restarting-colvars-run/7747).

The bug lied in the name of the colvars restart file or (colvars input state file) which was `abf_dihedral_state.dat` so the line `input_prefix_str.erase(input_prefix_str.rfind(".colvars.state"));` crashed.
Furthermore, the function `colvarmodule::setup_input()`:
https://github.com/Colvars/colvars/blob/351bfd2677186f2e0f1ad21050098c08d6db60c6/src/colvarmodule.cpp#L1346-L1351
doesn't handle the case when the suffix is `.dat`. (suffix `.dat` was introduced due to a limitation in file extension in `mdrun`).

So the most forward bugfix is to not strip the extension and let `setup_input()` takes the whole string as a filename.
The downside is the variable `input_prefix_str` is also called in `colvarmodule::print_total_forces_errning()` but according to @jhenin it's only called for code older than 2016 https://github.com/Colvars/colvars/blob/351bfd2677186f2e0f1ad21050098c08d6db60c6/src/colvarmodule.cpp#L1535

(it's basically a revert of commit efac865ce0ce1cd070)