### PR TITLE
Allow NumPy-format output for plot_colvars_traj.py

### DIFF
--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -417,7 +417,7 @@ if (__name__ == '__main__'):
         if numpy_format:
             np.savez(output_file, **columns)
         else:
-            np.savetxt(fname=output_file, X=np.c_[*columns], fmt=str(text_fmt_string))
+            np.savetxt(fname=output_file, X=np.column_stack(columns), fmt=str(text_fmt_string))
 
     else:
 


### PR DESCRIPTION
As described in the title, allows converting segments of a Colvars traj into a more efficient binary format supported by the quintessential Python numerical analysis library.