### PR TITLE
Stop testing GROMACS 2022 patch release

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -72,18 +72,6 @@ jobs:
       private_key: ${{ secrets.PULL_VMD_KEY }}
       private_key_vmd_plugins: ${{ secrets.PULL_VMD_PLUGINS_KEY }}
 
-  gromacs-2022:
-    name: GROMACS (release-2022)
-    uses: ./.github/workflows/backend-template.yml
-    with:
-      backend_name: GROMACS-2022
-      backend_repo: gromacs/gromacs
-      backend_repo_ref: release-2022
-      container_name: CentOS9-devel
-      path_compile_script: devel-tools/compile-gromacs.sh
-      test_lib_directory: gromacs/tests/library
-      rpath_exe: install/bin/gmx_mpi_d
-
   gromacs-2023:
     name: GROMACS (release-2023)
     uses: ./.github/workflows/backend-template.yml


### PR DESCRIPTION
Stopped testing the 2022 patched release. I left the patch files for all old GROMACS versions in the repository as a conservative choice, but those could arguably be removed as well. The `master` branch of Colvars will now track the GROMACS `main` branch. 

GROMACS 2023 remains part of the tests, and is the last that will be supported as a Colvars patched release. 

GROMACS 2024 support will be for bugfixes only, and will be handled by pushing commits to the `gromacs-2024` branch, but not `master`.

Solves #647 
