### PR TITLE
Backup files consistently with GROMACS standard

### DIFF
--- a/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.cpp
+++ b/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.cpp
@@ -42,6 +42,8 @@
 #include "colvarproxygromacs.h"
 #include "colvarproxy_gromacs_version.h"
 
+#include "gromacs/utility/futil.h"
+
 #include <sstream>
 
 
@@ -159,6 +161,25 @@ void ColvarProxyGromacs::error(std::string const& message)
 {
     log(message);
     GMX_THROW(InternalError("Error in collective variables module.\n"));
+}
+
+
+int ColvarProxyGromacs::backup_file(char const* filename)
+{
+    std::string const filename_str(filename);
+    auto const        state_suffix_pos = filename_str.rfind(std::string(".colvars.state"));
+    if (state_suffix_pos != std::string::npos)
+    {
+        // For a state file, which is usually written together with the checkpoint, keep one backup
+        // copy but use a different suffix to minimize confusion in edge cases
+        gmx_file_copy(filename_str, filename_str + ".old", true);
+    }
+    else
+    {
+        // General GROMACS backup mechanism
+        make_backup(filename);
+    }
+    return COLVARS_OK;
 }
 
 

--- a/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.h
+++ b/gromacs/gromacs-mdmodules/applied_forces/colvars/colvarproxygromacs.h
@@ -124,8 +124,13 @@ public:
 
     //! Print a message to the main log
     void log(std::string const& message) override;
+
     //! Print a message to the main log and let GROMACS handle the error
     void error(std::string const& message) override;
+
+    //! Rename the given file, before overwriting it
+    int backup_file(char const* filename) override;
+
     //! Request to set the units used internally by Colvars
     int set_unit_system(std::string const& unitsIn, bool colvarsDefined) override;
 


### PR DESCRIPTION
This PR restores the overridden version of `backup_file()`, which existed in the patched releases but not in the MDModules version.

The scheme is simple:
1. If the filename ends with `.colvars.state`, keep a single backup copy ending with `.old` (consistent with current behavior), as this is the typical behavior for checkpoints. The extension differs from the CPT because the code that handles it is different and there will be some edge cases.
2. For all other files, call the relevant GROMACS function to handle multiple backup copies.

Fixes #669 