### PR TITLE
Check that coordinate file exists before trying to read it

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -350,9 +350,9 @@ jobs:
           apptainer exec ${{github.workspace}}/devel-tools/CentOS7-devel.sif \
           cmake3 -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake
 
-      - name: Clang 7, C++17 (CentOS 7)
+      - name: Clang 7, C++14 (CentOS 7)
         env:
-          CXX_STANDARD: 17
+          CXX_STANDARD: 14
           CXX: clang++
           CXX_VERSION: 7
           CC: clang

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -11,6 +11,9 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#if __cplusplus >= 201703L
+#include <filesystem>
+#endif
 
 #include "colvarmodule.h"
 #include "colvarparse.h"
@@ -2160,6 +2163,14 @@ int cvm::load_coords(char const *file_name,
                      double pdb_field_value)
 {
   int error_code = COLVARS_OK;
+
+#if __cplusplus >= 201703L
+  std::string const file_name_str(file_name);
+  if (!std::filesystem::exists(file_name_str)) {
+    return cvm::error("Error: coordinate file \"" + file_name_str + "\" does not exist.\n",
+                      COLVARS_FILE_ERROR);
+  }
+#endif
 
   std::string const ext(strlen(file_name) > 4 ?
                         (file_name + (strlen(file_name) - 4)) :


### PR DESCRIPTION
Uses `std::filesystem::exists` from the C++17 standard library, which is supported in GROMACS, to print a more informative error message. VMD will most likely not support it in the near future, but at least doesn't raise a "not implemented" error.

Fixes #667.