### PR TITLE
Clarify purpose of functions that only handle PDB files anyway

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -907,11 +907,11 @@ e_pdb_field pdb_field_str2enum(std::string const &pdb_field_str)
 }
 
 
-int colvarproxy_namd::load_coords(char const *pdb_filename,
-                                  std::vector<cvm::atom_pos> &pos,
-                                  const std::vector<int> &indices,
-                                  std::string const &pdb_field_str,
-                                  double const pdb_field_value)
+int colvarproxy_namd::load_coords_pdb(char const *pdb_filename,
+                                      std::vector<cvm::atom_pos> &pos,
+                                      const std::vector<int> &indices,
+                                      std::string const &pdb_field_str,
+                                      double const pdb_field_value)
 {
   if (pdb_field_str.size() == 0 && indices.size() == 0) {
     cvm::error("Bug alert: either PDB field should be defined or list of "
@@ -1019,10 +1019,10 @@ int colvarproxy_namd::load_coords(char const *pdb_filename,
 }
 
 
-int colvarproxy_namd::load_atoms(char const *pdb_filename,
-                                 cvm::atom_group &atoms,
-                                 std::string const &pdb_field_str,
-                                 double const pdb_field_value)
+int colvarproxy_namd::load_atoms_pdb(char const *pdb_filename,
+                                     cvm::atom_group &atoms,
+                                     std::string const &pdb_field_str,
+                                     double const pdb_field_value)
 {
   if (pdb_field_str.size() == 0)
     cvm::error("Error: must define which PDB field to use "

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -190,16 +190,16 @@ public:
   cvm::rvector position_distance(cvm::atom_pos const &pos1,
                                  cvm::atom_pos const &pos2) const;
 
-  int load_atoms(char const *filename,
-                 cvm::atom_group &atoms,
-                 std::string const &pdb_field,
-                 double const pdb_field_value) override;
+  int load_atoms_pdb(char const *filename,
+                     cvm::atom_group &atoms,
+                     std::string const &pdb_field,
+                     double const pdb_field_value) override;
 
-  int load_coords(char const *filename,
-                  std::vector<cvm::atom_pos> &pos,
-                  const std::vector<int> &indices,
-                  std::string const &pdb_field,
-                  double const pdb_field_value) override;
+  int load_coords_pdb(char const *filename,
+                      std::vector<cvm::atom_pos> &pos,
+                      const std::vector<int> &indices,
+                      std::string const &pdb_field,
+                      double const pdb_field_value) override;
 
 
   int scalable_group_coms() override

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -532,8 +532,8 @@ int cvm::atom_group::parse(std::string const &group_conf)
         cvm::error("Error: atomsColValue, if provided, must be non-zero.\n", COLVARS_INPUT_ERROR);
       }
 
-      // NOTE: calls to add_atom() and/or add_atom_id() are in the proxy-implemented function
-      error_code |= cvm::load_atoms(atoms_file_name.c_str(), *this, atoms_col, atoms_col_value);
+      error_code |= cvm::main()->proxy->load_atoms_pdb(atoms_file_name.c_str(), *this, atoms_col,
+                                                       atoms_col_value);
     }
   }
 

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -2144,15 +2144,6 @@ int colvarmodule::reset_index_groups()
 }
 
 
-int cvm::load_atoms(char const *file_name,
-                    cvm::atom_group &atoms,
-                    std::string const &pdb_field,
-                    double pdb_field_value)
-{
-  return proxy->load_atoms(file_name, atoms, pdb_field, pdb_field_value);
-}
-
-
 int cvm::load_coords(char const *file_name,
                      std::vector<cvm::rvector> *pos,
                      cvm::atom_group *atoms,
@@ -2167,7 +2158,7 @@ int cvm::load_coords(char const *file_name,
 
   atoms->create_sorted_ids();
 
-  std::vector<cvm::rvector> sorted_pos(atoms->size(), cvm::rvector(0.0));
+  std::vector<cvm::atom_pos> sorted_pos(atoms->size(), cvm::rvector(0.0));
 
   // Differentiate between PDB and XYZ files
   if (colvarparse::to_lower_cppstr(ext) == std::string(".xyz")) {
@@ -2179,10 +2170,10 @@ int cvm::load_coords(char const *file_name,
     error_code |= cvm::main()->load_coords_xyz(file_name, &sorted_pos, atoms);
   } else {
     // Otherwise, call proxy function for PDB
-    error_code |= proxy->load_coords(file_name,
-                                     sorted_pos, atoms->sorted_ids(),
-                                     pdb_field, pdb_field_value);
+    error_code |= proxy->load_coords_pdb(file_name, sorted_pos, atoms->sorted_ids(), pdb_field,
+                                         pdb_field_value);
   }
+
   if (error_code != COLVARS_OK) return error_code;
 
   std::vector<int> const &map = atoms->sorted_ids_map();

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -746,17 +746,6 @@ public:
   /// Clear the index groups loaded so far
   int reset_index_groups();
 
-  /// \brief Select atom IDs from a file (usually PDB) \param filename name of
-  /// the file \param atoms array into which atoms read from "filename" will be
-  /// appended \param pdb_field (optional) if the file is a PDB and this
-  /// string is non-empty, select atoms for which this field is non-zero
-  /// \param pdb_field_value (optional) if non-zero, select only atoms whose
-  /// pdb_field equals this
-  static int load_atoms(char const *filename,
-                        atom_group &atoms,
-                        std::string const &pdb_field,
-                        double pdb_field_value = 0.0);
-
   /// \brief Load coordinates for a group of atoms from a file (PDB or XYZ);
   /// if "pos" is already allocated, the number of its elements must match the
   /// number of entries in "filename" \param filename name of the file \param

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -121,29 +121,6 @@ size_t colvarproxy_atoms::get_num_active_atoms() const
 }
 
 
-int colvarproxy_atoms::load_atoms(char const * /* filename */,
-                                  cvm::atom_group & /* atoms */,
-                                  std::string const & /* pdb_field */,
-                                  double)
-{
-  return cvm::error("Error: loading atom identifiers from a file "
-                    "is currently not implemented.\n",
-                    COLVARS_NOT_IMPLEMENTED);
-}
-
-
-int colvarproxy_atoms::load_coords(char const * /* filename */,
-                                   std::vector<cvm::atom_pos> & /* pos */,
-                                   std::vector<int> const & /* sorted_ids */,
-                                   std::string const & /* pdb_field */,
-                                   double)
-{
-  return cvm::error("Error: loading atomic coordinates from a file "
-                    "is currently not implemented.\n",
-                    COLVARS_NOT_IMPLEMENTED);
-}
-
-
 void colvarproxy_atoms::compute_rms_atoms_applied_force()
 {
   atoms_rms_applied_force_ =
@@ -552,6 +529,31 @@ int colvarproxy::parse_module_config()
     config_queue->pop_front();
   }
   return error_code;
+}
+
+
+int colvarproxy::load_atoms_pdb(char const * /* filename */,
+                                cvm::atom_group & /* atoms */,
+                                std::string const & /* pdb_field */,
+                                double /* pdb_field_value */)
+{
+  return cvm::error(
+      "Error: loading atom indices from a PDB file is currently not implemented in " +
+          engine_name() + ".\n",
+      COLVARS_NOT_IMPLEMENTED);
+}
+
+
+int colvarproxy::load_coords_pdb(char const * /* filename */,
+                                 std::vector<cvm::atom_pos> & /* pos */,
+                                 std::vector<int> const & /* sorted_ids */,
+                                 std::string const & /* pdb_field */,
+                                 double /* pdb_field_value */)
+{
+  return cvm::error(
+      "Error: loading atomic coordinates from a PDB file is currently not implemented in " +
+          engine_name() + ".\n",
+      COLVARS_NOT_IMPLEMENTED);
 }
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -74,27 +74,6 @@ public:
   /// (costly) set the corresponding atoms_refcount to zero
   virtual void clear_atom(int index);
 
-  /// \brief Read a selection of atom IDs from a coordinate file (only PDB is supported)
-  /// \param[in] filename name of the file
-  /// \param[in,out] atoms array into which atoms will be read from "filename"
-  /// \param[in] pdb_field if the file is a PDB and this string is non-empty,
-  /// select atoms for which this field is non-zero
-  /// \param[in] pdb_field_value if non-zero, select only atoms whose pdb_field equals this
-  virtual int load_atoms(char const *filename, cvm::atom_group &atoms, std::string const &pdb_field,
-                         double pdb_field_value);
-
-  /// \brief Load a set of coordinates from a file (PDB or XYZ)
-  /// \param[in] filename name of the file
-  /// \param[in,out] pos array of coordinates; if not empty, the number of its elements must match
-  /// the number of entries in "filename"
-  /// \param[in] sorted_ids array of sorted internal IDs, used to loop through the file only once
-  /// \param[in] pdb_field if the file is a PDB and this string is non-empty, only atoms for which
-  /// this field is non-zero will be processed
-  /// \param[in] pdb_field_value if non-zero, process only atoms whose pdb_field equals this
-  virtual int load_coords(char const *filename, std::vector<cvm::atom_pos> &pos,
-                          std::vector<int> const &sorted_ids, std::string const &pdb_field,
-                          double pdb_field_value);
-
   /// Clear atomic data
   int reset();
 
@@ -625,6 +604,26 @@ public:
 
   /// (Re)initialize the module
   virtual int parse_module_config();
+
+  /// \brief Read a selection of atom IDs from a PDB coordinate file
+  /// \param[in] filename name of the file
+  /// \param[in,out] atoms array into which atoms will be read from "filename"
+  /// \param[in] pdb_field if the file is a PDB and this string is non-empty,
+  /// select atoms for which this field is non-zero
+  /// \param[in] pdb_field_value if non-zero, select only atoms whose pdb_field equals this
+  virtual int load_atoms_pdb(char const *filename, cvm::atom_group &atoms,
+                             std::string const &pdb_field, double pdb_field_value);
+
+  /// \brief Load a set of coordinates from a PDB file
+  /// \param[in] filename name of the file
+  /// \param[in,out] pos array of coordinates to fill; if not empty, the number of its elements must match
+  /// the number of entries in "filename"
+  /// \param[in] sorted_ids array of sorted internal IDs, used to loop through the file only once
+  /// \param[in] pdb_field if non-empty, only atoms for which this field is non-zero will be processed
+  /// \param[in] pdb_field_value if non-zero, process only atoms whose pdb_field equals this
+  virtual int load_coords_pdb(char const *filename, std::vector<cvm::atom_pos> &pos,
+                              std::vector<int> const &sorted_ids, std::string const &pdb_field,
+                              double pdb_field_value);
 
   /// (Re)initialize required member data (called after the module)
   virtual int setup();

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -439,11 +439,11 @@ e_pdb_field pdb_field_str2enum(std::string const &pdb_field_str)
 }
 
 
-int colvarproxy_vmd::load_coords(char const *pdb_filename,
-                                 std::vector<cvm::atom_pos> &pos,
-                                 const std::vector<int> &indices,
-                                 std::string const &pdb_field_str,
-                                 double const pdb_field_value)
+int colvarproxy_vmd::load_coords_pdb(char const *pdb_filename,
+                                     std::vector<cvm::atom_pos> &pos,
+                                     const std::vector<int> &indices,
+                                     std::string const &pdb_field_str,
+                                     double const pdb_field_value)
 {
   if (pdb_field_str.size() == 0 && indices.size() == 0) {
     cvm::error("Bug alert: either PDB field should be defined or list of "
@@ -565,10 +565,10 @@ int colvarproxy_vmd::load_coords(char const *pdb_filename,
 }
 
 
-int colvarproxy_vmd::load_atoms(char const *pdb_filename,
-                                cvm::atom_group &atoms,
-                                std::string const &pdb_field_str,
-                                double const pdb_field_value)
+int colvarproxy_vmd::load_atoms_pdb(char const *pdb_filename,
+                                    cvm::atom_group &atoms,
+                                    std::string const &pdb_field_str,
+                                    double const pdb_field_value)
 {
   if (pdb_field_str.size() == 0) {
     cvm::log("Error: must define which PDB field to use "

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -80,16 +80,16 @@ public:
                                            std::vector<const colvarvalue *> const &cvc_values,
                                            std::vector<cvm::matrix2d<cvm::real> > &gradient);
 
-  virtual int load_atoms(char const *filename,
-                         cvm::atom_group &atoms,
-                         std::string const &pdb_field,
-                         double const pdb_field_value = 0.0);
+  virtual int load_atoms_pdb(char const *filename,
+                             cvm::atom_group &atoms,
+                             std::string const &pdb_field,
+                             double const pdb_field_value = 0.0);
 
-  virtual int load_coords(char const *filename,
-                          std::vector<cvm::atom_pos> &pos,
-                          const std::vector<int> &indices,
-                          std::string const &pdb_field,
-                          double const pdb_field_value = 0.0);
+  virtual int load_coords_pdb(char const *filename,
+                              std::vector<cvm::atom_pos> &pos,
+                              const std::vector<int> &indices,
+                              std::string const &pdb_field,
+                              double const pdb_field_value = 0.0);
 
 
   virtual int check_atom_name_selections_available();


### PR DESCRIPTION
Coordinate loading functions are renamed to reflect that they are specific to the PDB format.
