### PR TITLE
Stop initializing cvs after atom group init fail

### DIFF
--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -109,7 +109,7 @@ int colvar::coordnum::init(std::string const &conf)
   group2 = parse_group(conf, "group2");
 
   if (!group1 || !group2) {
-    return cvm::error("Error: failed to initialize atom groups.\n", COLVARS_INPUT_ERROR);
+    return error_code | COLVARS_INPUT_ERROR;
   }
 
   if (int atom_number = cvm::atom_group::overlap(*group1, *group2)) {
@@ -394,6 +394,10 @@ int colvar::selfcoordnum::init(std::string const &conf)
   int error_code = cvc::init(conf);
 
   group1 = parse_group(conf, "group1");
+
+  if (!group1 || group1->size() == 0) {
+    return error_code | COLVARS_INPUT_ERROR;
+  }
 
   get_keyval(conf, "cutoff", r0, r0);
   get_keyval(conf, "expNumer", en, en);

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -34,6 +34,10 @@ int colvar::distance::init(std::string const &conf)
   group1 = parse_group(conf, "group1");
   group2 = parse_group(conf, "group2");
 
+  if (!group1 || !group2) {
+    return error_code | COLVARS_INPUT_ERROR;
+  }
+
   error_code |= init_total_force_params(conf);
 
   return error_code;

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -39,6 +39,9 @@ int colvar::orientation::init(std::string const &conf)
   int error_code = cvc::init(conf);
 
   atoms = parse_group(conf, "atoms");
+  if (!atoms || atoms->size() == 0) {
+    return error_code | COLVARS_INPUT_ERROR;
+  }
   ref_pos.reserve(atoms->size());
 
   if (get_keyval(conf, "refPositions", ref_pos, ref_pos)) {


### PR DESCRIPTION
Done only to CVs where it is critical because followed by memory allocation assuming that the atom groups were parsed successfully. This fixes segfaults upon trying to load non-existent atomFiles.