### PR TITLE
Track patch version 

### DIFF
--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -100,8 +100,10 @@ colvarmodule::colvarmodule(colvarproxy *proxy_in)
   version_int = proxy->get_version_from_string(COLVARS_VERSION);
 
   cvm::log(cvm::line_marker);
-  cvm::log("Initializing the collective variables module, version "+
-           version()+".\n");
+  cvm::log(
+      "Initializing the collective variables module, version " + version() +
+      (patch_version_number() ? (" (patch " + cvm::to_str(patch_version_number()) + ")") : "") +
+      ".\n");
   cvm::log("Please cite Fiorin et al, Mol Phys 2013:\n"
            "  https://doi.org/10.1080/00268976.2013.813594\n"
            "as well as all other papers listed below for individual features used.\n");

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -88,8 +88,6 @@ private:
 
 public:
 
-  friend class colvarproxy;
-
   /// Use a 64-bit integer to store the step number
   typedef long long step_number;
 
@@ -204,8 +202,6 @@ public:
   // allow these classes to access protected data
   class atom;
   class atom_group;
-  friend class atom;
-  friend class atom_group;
   typedef std::vector<atom>::iterator       atom_iter;
   typedef std::vector<atom>::const_iterator atom_const_iter;
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -58,14 +58,6 @@ class colvarvalue;
 /// child objects
 class colvarmodule {
 
-private:
-
-  /// Impossible to initialize the main object without arguments
-  colvarmodule();
-
-  /// Integer representing the version string (allows comparisons)
-  int version_int;
-
 public:
 
   /// Get the version string (YYYY-MM-DD format)
@@ -79,6 +71,22 @@ public:
   {
     return version_int;
   }
+
+  /// Get the patch version number (non-zero in patch releases of other packages)
+  int patch_version_number() const
+  {
+    return patch_version_int;
+  }
+
+private:
+
+  /// Integer representing the version string (allows comparisons)
+  int version_int = 0;
+
+  /// Patch version number (non-zero in patch releases of other packages)
+  int patch_version_int = 0;
+
+public:
 
   friend class colvarproxy;
 
@@ -334,6 +342,13 @@ public:
   /// Constructor
   /// \param Pointer to instance of the proxy class (communicate with engine)
   colvarmodule(colvarproxy *proxy);
+
+private:
+
+  /// Cannot initialize the main object without a proxy
+  colvarmodule();
+
+public:
 
   /// Destructor
   ~colvarmodule();


### PR DESCRIPTION
Adds a patch version (which is zero in the `main` branch) to identify versions of the Colvars code where only bugfixes are added, for inclusion in patch releases of other packages. 

Solves #671 