### PR TITLE
Check that CPU platform matches Tcl precompiled builds

### DIFF
--- a/devel-tools/build_test_library.cmake
+++ b/devel-tools/build_test_library.cmake
@@ -25,31 +25,34 @@ if(NOT DEFINED COLVARS_TCL)
   set(COLVARS_TCL ON)
 endif()
 
-if(DEFINED CMAKE_SYSTEM_NAME AND COLVARS_TCL)
-
-  # If available, use pre-downloaded OS-specific TCL libraries
-
-  if(EXISTS "${COLVARS_SOURCE_DIR}/devel-tools/packages")
-    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-      set(TCL_DIR "${COLVARS_SOURCE_DIR}/devel-tools/packages/tcl8.6.13-linux-x86_64-threaded")
-      set(TCL_LIBRARY "libtcl8.6.a")
+# If available, use pre-downloaded TCL libraries
+if(EXISTS "${COLVARS_SOURCE_DIR}/devel-tools/packages")
+  if(DEFINED CMAKE_SYSTEM_NAME)
+    # On Linux and macOS, test if we are using Intel
+    if (DEFINED CMAKE_HOST_SYSTEM_PROCESSOR)
+      if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+        set(TCL_DIR "${COLVARS_SOURCE_DIR}/devel-tools/packages/tcl8.6.13-linux-x86_64-threaded")
+        set(TCL_LIBRARY "libtcl8.6.a")
+      endif()
+      if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+        set(TCL_DIR "${COLVARS_SOURCE_DIR}/devel-tools/packages/tcl8.5.9-macosx-x86_64-threaded")
+        set(TCL_LIBRARY "libtcl8.5.a")
+      endif()
     endif()
-
+    # Assume Intel when using Windows
     if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
       set(TCL_DIR "${COLVARS_SOURCE_DIR}/devel-tools/packages/tcl8.5.9-win64")
       set(TCL_LIBRARY "tcl85.lib")
     endif()
-
-    if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-      set(TCL_DIR "${COLVARS_SOURCE_DIR}/devel-tools/packages/tcl8.5.9-macosx-x86_64-threaded")
-      set(TCL_LIBRARY "libtcl8.5.a")
-    endif()
-
-    set(DEFINE_TCL_DIR "-DTCL_DIR=${TCL_DIR}")
-    set(DEFINE_TCL_LIBRARY "-DTCL_LIBRARY=${TCL_DIR}/lib/${TCL_LIBRARY}")
   endif()
 
 endif()
+
+if(COLVARS_TCL AND DEFINED TCL_DIR)
+  set(DEFINE_TCL_DIR "-DTCL_DIR=${TCL_DIR}")
+  set(DEFINE_TCL_LIBRARY "-DTCL_LIBRARY=${TCL_DIR}/lib/${TCL_LIBRARY}")
+endif()
+
 
 if(COLVARS_LEPTON)
   if(NOT DEFINED LEPTON_DIR)


### PR DESCRIPTION
Fixes a current CI failure, due to GitHub Actions switching to ARM-based VMs for their macOS runners.

Their choice is definitely in line with how the underlying hardware for Macs has evolved. However, this means that we can no longer reuse [UIUC's precompiled libraries](https://www.ks.uiuc.edu/Research/namd/libraries/). Because building Tcl and Tk for macOS is outside the scope of this repository, the library is now built without Tcl on macOS.