### PR TITLE
Fix harmless memory error in standalone tool

### DIFF
--- a/colvartools/poisson_integrator.cpp
+++ b/colvartools/poisson_integrator.cpp
@@ -16,13 +16,13 @@ int main (int argc, char *argv[]) {
   colvarmodule *colvars = new colvarmodule(proxy);
 
   std::string gradfile (argv[1]);
-  colvar_grid_gradient grad(gradfile);
+  std::shared_ptr<colvar_grid_gradient> grad_ptr = std::make_shared<colvar_grid_gradient>(gradfile);
 
   int itmax = 1000;
   cvm::real err;
   cvm::real tol = 1e-6;
 
-  integrate_potential potential(&grad);
+  integrate_potential potential(grad_ptr);
   potential.set_div();
   potential.integrate(itmax, tol, err);
   potential.set_zero_minimum();

--- a/src/colvargrid.cpp
+++ b/src/colvargrid.cpp
@@ -617,7 +617,7 @@ integrate_potential::integrate_potential(std::vector<colvar *> &colvars, std::sh
 }
 
 
-integrate_potential::integrate_potential(colvar_grid_gradient * gradients)
+integrate_potential::integrate_potential(std::shared_ptr<colvar_grid_gradient> gradients)
   : b_smoothed(false),
     gradients(gradients)
 {

--- a/src/colvargrid.h
+++ b/src/colvargrid.h
@@ -1832,7 +1832,7 @@ class integrate_potential : public colvar_grid_scalar
   integrate_potential(std::vector<colvar *> &colvars, std::shared_ptr<colvar_grid_gradient> gradients);
 
   /// Constructor from a gradient grid (for processing grid files without a Colvars config)
-  integrate_potential(colvar_grid_gradient * gradients);
+  integrate_potential(std::shared_ptr<colvar_grid_gradient> gradients);
 
   /// \brief Calculate potential from divergence (in 2D); return number of steps
   int integrate(const int itmax, const cvm::real & tol, cvm::real & err, bool verbose = true);


### PR DESCRIPTION
Mix of shared and raw pointers caused double deallocation upon exit. This only affected the poisson_integrator standalone tool.