### PR TITLE
Do not try accessing LAMMPS proxy object before allocating it

### DIFF
--- a/lammps/src/COLVARS/fix_colvars.h
+++ b/lammps/src/COLVARS/fix_colvars.h
@@ -73,6 +73,7 @@ class FixColvars : public Fix {
   char *out_name;               // prefix string for all output files
   char *tfix_name;              // name of thermostat fix.
   int rng_seed;                 // seed to initialize random number generator
+  double t_target = 0.0;        // thermostat target temperature
   double energy;                // biasing energy of the fix
 
   int me;             // my MPI rank in this "world".

--- a/lammps/tests/library/common/test.lmp.in
+++ b/lammps/tests/library/common/test.lmp.in
@@ -15,7 +15,7 @@ include ../common/fixes.lmp.in
 
 log test.out
 
-fix Colvars all colvars ${colvars_config} output test
+fix Colvars all colvars ${colvars_config} output test seed 54321
 
 include ../common/md.lmp.in
 

--- a/lammps/tests/library/run_tests.sh
+++ b/lammps/tests/library/run_tests.sh
@@ -273,7 +273,7 @@ for dir in ${DIRLIST} ; do
     if [ "x${gen_ref_output}" == 'xyes' ]; then
       echo "Reference files copied successfully."
     else
-      echo " $(${TPUT_GREEN})Success!$(${TPUT_CLEAR})"
+      echo " "$(${TPUT_GREEN})"Success!"$(${TPUT_CLEAR})
     fi
     cleanup_files
   fi


### PR DESCRIPTION
Fixes a bug reported up by @vineetbansal (see https://github.com/Colvars/colvars/pull/570#issuecomment-2200805494) when the `seed` argument is given to fix_colvars .

Also fixing the handling of the parameter `tstat`, which has a similar (so far undetected) bug.

