### PR TITLE
Add patchversion scripting command

### DIFF
--- a/doc/cvscript-fix-modify.tex
+++ b/doc/cvscript-fix-modify.tex
@@ -305,6 +305,15 @@
 \-~~~~\texttt{values : string - The values}
 \end{mdexampleinput}
 \begin{mdexampleinput}{}
+\texttt{\textbf{fix\_modify Colvars patchversion}}
+\\
+\-~~~~\texttt{Get the Colvars patch version number (used for bugfixes only)}
+\\
+\-~~~~\texttt{\textbf{Returns}}
+\\
+\-~~~~\texttt{version : string - Colvars version}
+\end{mdexampleinput}
+\begin{mdexampleinput}{}
 \texttt{\textbf{fix\_modify Colvars printframelabels}}
 \\
 \-~~~~\texttt{Return the labels that would be written to colvars.traj}
@@ -388,7 +397,7 @@
 \begin{mdexampleinput}{}
 \texttt{\textbf{fix\_modify Colvars version}}
 \\
-\-~~~~\texttt{Get the Colvars Module version string}
+\-~~~~\texttt{Get the Colvars version string}
 \\
 \-~~~~\texttt{\textbf{Returns}}
 \\

--- a/doc/cvscript-tcl.tex
+++ b/doc/cvscript-tcl.tex
@@ -305,6 +305,15 @@
 \-~~~~\texttt{values : string - The values}
 \end{mdexampleinput}
 \begin{mdexampleinput}{}
+\texttt{\textbf{cv patchversion}}
+\\
+\-~~~~\texttt{Get the Colvars patch version number (used for bugfixes only)}
+\\
+\-~~~~\texttt{\textbf{Returns}}
+\\
+\-~~~~\texttt{version : string - Colvars version}
+\end{mdexampleinput}
+\begin{mdexampleinput}{}
 \texttt{\textbf{cv printframelabels}}
 \\
 \-~~~~\texttt{Return the labels that would be written to colvars.traj}
@@ -388,7 +397,7 @@
 \begin{mdexampleinput}{}
 \texttt{\textbf{cv version}}
 \\
-\-~~~~\texttt{Get the Colvars Module version string}
+\-~~~~\texttt{Get the Colvars version string}
 \\
 \-~~~~\texttt{\textbf{Returns}}
 \\

--- a/src/colvarscript_commands.h
+++ b/src/colvarscript_commands.h
@@ -541,6 +541,15 @@ CVSCRIPT(cv_printframe,
          return COLVARS_OK;
          )
 
+CVSCRIPT(cv_patchversion,
+         "Get the Colvars patch version number (used for bugfixes only)\n"
+         "version : string - Colvars version",
+         0, 0,
+         "",
+         script->set_result_int(cvm::main()->patch_version_number());
+         return COLVARS_OK;
+         )
+
 CVSCRIPT(cv_printframelabels,
          "Return the labels that would be written to colvars.traj\n"
          "Labels : string - The labels",
@@ -656,7 +665,7 @@ CVSCRIPT(cv_update,
          )
 
 CVSCRIPT(cv_version,
-         "Get the Colvars Module version string\n"
+         "Get the Colvars version string\n"
          "version : string - Colvars version",
          0, 0,
          "",


### PR DESCRIPTION
A NAMD patch release is upcoming, which may also contain bugfixes for Colvars. However, the Colvars version is **not** being updated in it, which makes it difficult to detect in script if a given bug has been fixed or not. The new command allows to retrieve the patch version in scripts.