### PR TITLE
Add Intel oneAPI CI job

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -511,6 +511,89 @@ jobs:
           cmake3 -D CMAKE_CXX_STANDARD=11 -P devel-tools/build_test_library.cmake
 
 
+  build-linux-x86_64-intel:
+    name: Linux x86_64 (Intel oneAPI)
+    runs-on: ubuntu-latest
+    needs: basicchecks
+    env:
+      CCACHE: ccache
+      CMAKE_GENERATOR: Ninja
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load compiler ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os }}-build-oneapi-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-build-oneapi-
+
+      - name: Get small downloadable packages
+        uses: actions/checkout@v4
+        with:
+          repository: 'Colvars/build-tools-packages'
+          ref: 'master'
+          path: 'devel-tools/packages'
+
+      - name: Install Apptainer
+        shell: bash
+        run: |
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt update
+          sudo apt install -y apptainer-suid
+
+      - name: Get container images for build dependencies
+        shell: bash
+        working-directory: devel-tools
+        run: |
+          apptainer pull CentOS9-devel-oneAPI.sif oras://ghcr.io/colvars/devel-containers:CentOS9-devel-oneAPI
+
+      - name: Intel oneAPI 2024.2, C++11
+        shell: bash
+        env:
+          CC: icx
+          CXX: icpx
+          CXX_STANDARD: 11
+          BASH_ENV: "/etc/profile.d/oneapi.sh"
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel-oneAPI.sif \
+          bash -c "cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake"
+
+      - name: Intel oneAPI 2024.2, C++14
+        shell: bash
+        env:
+          CC: icx
+          CXX: icpx
+          CXX_STANDARD: 14
+          BASH_ENV: "/etc/profile.d/oneapi.sh"
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel-oneAPI.sif \
+          bash -c "cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake"
+
+      - name: Intel oneAPI 2024.2, C++17
+        shell: bash
+        env:
+          CC: icx
+          CXX: icpx
+          CXX_STANDARD: 17
+          BASH_ENV: "/etc/profile.d/oneapi.sh"
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel-oneAPI.sif \
+          bash -c "cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake"
+
+      - name: Intel oneAPI 2024.2, C++20
+        shell: bash
+        env:
+          CC: icx
+          CXX: icpx
+          CXX_STANDARD: 20
+          BASH_ENV: "/etc/profile.d/oneapi.sh"
+        run: |
+          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel-oneAPI.sif \
+          bash -c "cmake -D CMAKE_CXX_STANDARD=${CXX_STANDARD} -P devel-tools/build_test_library.cmake"
+
+
   build-windows-x86_64-msvc:
     name: Windows x86_64 (MSVC)
     runs-on: windows-latest

--- a/devel-tools/containers/CentOS9-devel-oneAPI.def
+++ b/devel-tools/containers/CentOS9-devel-oneAPI.def
@@ -1,0 +1,31 @@
+
+BootStrap: localimage
+From: CentOS9-devel.sif
+
+
+%help
+    Development environment for CentOS Stream Linux 9 with Intel oneAPI installed
+
+
+%setup
+    cat > ${APPTAINER_ROOTFS}/etc/yum.repos.d/oneAPI.repo << EOF
+[oneAPI]
+name=Intel® oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+EOF
+
+
+%post
+    dnf -y update
+    dnf -y install intel-basekit intel-hpckit
+    cat > /etc/profile.d/oneapi.sh << EOF
+if [ -z "${ONEAPI_ROOT}" ] ; then
+    echo "Usage of Intel oneAPI is subject to the license agreement at: https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html"
+    source /opt/intel/oneapi/setvars.sh > /dev/null
+fi
+EOF
+    chmod 644 /etc/profile.d/oneapi.sh


### PR DESCRIPTION
Adds an Intel oneAPI CI job to test that compiler for library builds.