### PR TITLE
Improve detection of hard/mathematical boundaries

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -2211,12 +2211,10 @@ int colvar::set_cvc_param(std::string const &param_name, void const *new_value)
 bool colvar::periodic_boundaries(colvarvalue const &lb, colvarvalue const &ub) const
 {
   if (period > 0.0) {
-    if ( ((cvm::sqrt(this->dist2(lb, ub))) / this->width)
-         < 1.0E-10 ) {
+    if (((cvm::sqrt(this->dist2(lb, ub))) / this->width) < colvar_boundaries_tol) {
       return true;
     }
   }
-
   return false;
 }
 

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -262,6 +262,12 @@ public:
 
   /// Init defaults for grid options
   int init_grid_parameters(std::string const &conf);
+  
+  /// Consistency check for the grid paramaters
+  int check_grid_parameters();
+
+  /// Read legacy wall keyword (these are biases now)
+  int parse_legacy_wall_params(std::string const &conf);
 
   /// Init extended Lagrangian parameters
   int init_extended_Lagrangian(std::string const &conf);

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -262,7 +262,7 @@ public:
 
   /// Init defaults for grid options
   int init_grid_parameters(std::string const &conf);
-  
+
   /// Consistency check for the grid paramaters
   int check_grid_parameters();
 
@@ -782,6 +782,12 @@ inline void colvar::reset_bias_force() {
   fb.reset();
   fb_actual.type(value());
   fb_actual.reset();
+}
+
+
+namespace {
+  // Tolerance parameter to decide when two boundaries coincide
+  constexpr cvm::real colvar_boundaries_tol = 1.0e-10;
 }
 
 #endif


### PR DESCRIPTION
Implements the ability to auto-detect when user-defined boundaries are also "hard" mathematical boundaries.

See https://github.com/Colvars/colvars/pull/710#issuecomment-2379363975

Related to #476 and  #710 