### PR TITLE
Prepare for the change of the NAMD reduction interface

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -25,7 +25,6 @@
 #include "NamdState.h"
 #include "Controller.h"
 #include "PatchData.h"
-#include "ConfigList.h"
 
 #ifdef NAMD_TCL
 #include <tcl.h>
@@ -139,7 +138,7 @@ colvarproxy_namd::colvarproxy_namd()
 
   reduction = ReductionMgr::Object()->willSubmit(REDUCTIONS_BASIC);
 
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+  #ifdef NODEGROUP_FORCE_REGISTER
   CProxy_PatchData cpdata(CkpvAccess(BOCclass_group).patchData);
   PatchData *patchData = cpdata.ckLocalBranch();
   nodeReduction = patchData->reduction;
@@ -591,7 +590,7 @@ void colvarproxy_namd::calculate()
 #endif
 
   // send MISC energy
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+  #ifdef NODEGROUP_FORCE_REGISTER
   if(!simparams->CUDASOAintegrate) {
     reduction->submit();
   }
@@ -649,7 +648,7 @@ int colvarproxy_namd::run_colvar_gradient_callback(
 
 void colvarproxy_namd::add_energy(cvm::real energy)
 {
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+  #ifdef NODEGROUP_FORCE_REGISTER
   if (simparams->CUDASOAintegrate) {
     nodeReduction->item(REDUCTION_MISC_ENERGY) += energy;
   } else {

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -139,7 +139,7 @@ colvarproxy_namd::colvarproxy_namd()
 
   reduction = ReductionMgr::Object()->willSubmit(REDUCTIONS_BASIC);
 
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 50396675 )
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   CProxy_PatchData cpdata(CkpvAccess(BOCclass_group).patchData);
   PatchData *patchData = cpdata.ckLocalBranch();
   nodeReduction = patchData->reduction;
@@ -591,7 +591,7 @@ void colvarproxy_namd::calculate()
 #endif
 
   // send MISC energy
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 50396675 )
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   if(!simparams->CUDASOAintegrate) {
     reduction->submit();
   }
@@ -649,7 +649,7 @@ int colvarproxy_namd::run_colvar_gradient_callback(
 
 void colvarproxy_namd::add_energy(cvm::real energy)
 {
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 50396675 )
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   if (simparams->CUDASOAintegrate) {
     nodeReduction->item(REDUCTION_MISC_ENERGY) += energy;
   } else {

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -139,7 +139,7 @@ colvarproxy_namd::colvarproxy_namd()
 
   reduction = ReductionMgr::Object()->willSubmit(REDUCTIONS_BASIC);
 
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 50396675 )
   CProxy_PatchData cpdata(CkpvAccess(BOCclass_group).patchData);
   PatchData *patchData = cpdata.ckLocalBranch();
   nodeReduction = patchData->reduction;
@@ -591,7 +591,7 @@ void colvarproxy_namd::calculate()
 #endif
 
   // send MISC energy
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 50396675 )
   if(!simparams->CUDASOAintegrate) {
     reduction->submit();
   }
@@ -649,7 +649,7 @@ int colvarproxy_namd::run_colvar_gradient_callback(
 
 void colvarproxy_namd::add_energy(cvm::real energy)
 {
-  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 50396675 )
   if (simparams->CUDASOAintegrate) {
     nodeReduction->item(REDUCTION_MISC_ENERGY) += energy;
   } else {

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -138,7 +138,7 @@ colvarproxy_namd::colvarproxy_namd()
 
   reduction = ReductionMgr::Object()->willSubmit(REDUCTIONS_BASIC);
 
-  #ifdef NODEGROUP_FORCE_REGISTER
+  #if defined(NODEGROUP_FORCE_REGISTER) && !defined(NAMD_UNIFIED_REDUCTION)
   CProxy_PatchData cpdata(CkpvAccess(BOCclass_group).patchData);
   PatchData *patchData = cpdata.ckLocalBranch();
   nodeReduction = patchData->reduction;
@@ -590,7 +590,7 @@ void colvarproxy_namd::calculate()
 #endif
 
   // send MISC energy
-  #ifdef NODEGROUP_FORCE_REGISTER
+  #if defined(NODEGROUP_FORCE_REGISTER) && !defined(NAMD_UNIFIED_REDUCTION)
   if(!simparams->CUDASOAintegrate) {
     reduction->submit();
   }
@@ -648,7 +648,7 @@ int colvarproxy_namd::run_colvar_gradient_callback(
 
 void colvarproxy_namd::add_energy(cvm::real energy)
 {
-  #ifdef NODEGROUP_FORCE_REGISTER
+  #if defined(NODEGROUP_FORCE_REGISTER) && !defined(NAMD_UNIFIED_REDUCTION)
   if (simparams->CUDASOAintegrate) {
     nodeReduction->item(REDUCTION_MISC_ENERGY) += energy;
   } else {

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -139,7 +139,7 @@ colvarproxy_namd::colvarproxy_namd()
 
   reduction = ReductionMgr::Object()->willSubmit(REDUCTIONS_BASIC);
 
-  #ifdef NODEGROUP_FORCE_REGISTER
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   CProxy_PatchData cpdata(CkpvAccess(BOCclass_group).patchData);
   PatchData *patchData = cpdata.ckLocalBranch();
   nodeReduction = patchData->reduction;
@@ -591,7 +591,7 @@ void colvarproxy_namd::calculate()
 #endif
 
   // send MISC energy
-  #ifdef NODEGROUP_FORCE_REGISTER
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   if(!simparams->CUDASOAintegrate) {
     reduction->submit();
   }
@@ -649,7 +649,7 @@ int colvarproxy_namd::run_colvar_gradient_callback(
 
 void colvarproxy_namd::add_energy(cvm::real energy)
 {
-  #ifdef NODEGROUP_FORCE_REGISTER
+  #if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   if (simparams->CUDASOAintegrate) {
     nodeReduction->item(REDUCTION_MISC_ENERGY) += energy;
   } else {

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -24,6 +24,7 @@
 #include "Lattice.h"
 #include "GlobalMaster.h"
 #include "Random.h"
+#include "ConfigList.h"
 
 #include "colvarmodule.h"
 #include "colvarproxy.h"
@@ -57,7 +58,7 @@ protected:
 
   /// Used to submit restraint energy as MISC
   SubmitReduction *reduction;
-#ifdef NODEGROUP_FORCE_REGISTER
+#if defined(NODEGROUP_FORCE_REGISTER) && !defined(NAMD_UNIFIED_REDUCTION)
   NodeReduction *nodeReduction;
 #endif
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -12,7 +12,7 @@
 
 #ifndef NAMD_VERSION_NUMBER
 // Assume 2.14b1 for now until the NAMD macro is merged
-#define NAMD_VERSION_NUMBER 34471681L
+#define NAMD_VERSION_NUMBER 34471681
 #endif
 
 #include "colvarproxy_namd_version.h"
@@ -57,7 +57,7 @@ protected:
 
   /// Used to submit restraint energy as MISC
   SubmitReduction *reduction;
-#if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
+#ifdef NODEGROUP_FORCE_REGISTER
   NodeReduction *nodeReduction;
 #endif
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -12,7 +12,7 @@
 
 #ifndef NAMD_VERSION_NUMBER
 // Assume 2.14b1 for now until the NAMD macro is merged
-#define NAMD_VERSION_NUMBER 34471681
+#define NAMD_VERSION_NUMBER 34471681L
 #endif
 
 #include "colvarproxy_namd_version.h"
@@ -57,7 +57,7 @@ protected:
 
   /// Used to submit restraint energy as MISC
   SubmitReduction *reduction;
-#ifdef NODEGROUP_FORCE_REGISTER
+#if defined(NODEGROUP_FORCE_REGISTER) && ( NAMD_VERSION_NUMBER < 34471682L )
   NodeReduction *nodeReduction;
 #endif
 


### PR DESCRIPTION
David Clark from NVIDIA is working on extending the GPU-resident code to multiple nodes. He has proposed to refactor and unify the reductions of energies and virials in NAMD, as the old `NodeReduction` class only works for the single-node code path. I have proposed to change `NAMD_VERSION_NUMBER` to `34471682L` after David Clark's MR (see https://gitlab.com/tcbgUIUC/namd/-/commit/e81f36cc733d884f2aa2699449a61fa4c68483dc on a hackathon branch). This PR changes the `colvarproxy_namd.*` to check the `NAMD_VERSION_NUMBER` to determine whether `NodeReduction` should be used.