### PR TITLE
Add newest CMake to container

### DIFF
--- a/devel-tools/compile-gromacs.sh
+++ b/devel-tools/compile-gromacs.sh
@@ -16,14 +16,9 @@ compile_gromacs_target() {
     fi
 
     local CMAKE=cmake CTEST=ctest
-    if hash cmake3 >& /dev/null ; then
-        CMAKE=cmake3
-        CTEST=ctest3
-    fi
-    if hash ${CMAKE} >& /dev/null ; then
-        CMAKE_VERSION=$(${CMAKE} --version | head -1 | cut -d' ' -f3)
-    else
-        echo "Error: no CMake found." >& 2
+    if [ -e /opt/cmake/bin/cmake ] ; then
+        CMAKE=/opt/cmake/bin/cmake
+        CTEST=/opt/cmake/bin/ctest
     fi
 
     local GMX_SRC_DIR=""

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -46,7 +46,7 @@ From: quay.io/centos/centos:stream9
     source /etc/profile
     module load mpi
     if [ ! -d /opt/charm ] ; then
-        git clone --single-branch --depth=1 -b v7.0.0 https://github.com/UIUC-PPL/charm.git /opt/charm
+        git clone --single-branch --depth=1 -b v8.0.1 https://github.com/UIUC-PPL/charm.git /opt/charm
         cd /opt/charm
         export CCACHE_DIR=/tmp
         ./build charm++ mpi-linux-x86_64 -j16 --with-production && \
@@ -57,9 +57,10 @@ From: quay.io/centos/centos:stream9
     if [ ! -f /usr/local/bin/spiff ] ; then
         # Build and install spiff
         rm -fr /tmp/spiff
-        git clone https://github.com/jhenin/spiff /tmp/spiff && \
+        git clone https://github.com/HanatoK/spiff /tmp/spiff && \
             make -C /tmp/spiff && \
             install /tmp/spiff/spiff /usr/local/bin/
     fi
 
-
+    curl -o /tmp/libtorch.zip https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcpu.zip
+    unzip /tmp/libtorch.zip -d /opt

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -62,5 +62,17 @@ From: quay.io/centos/centos:stream9
             install /tmp/spiff/spiff /usr/local/bin/
     fi
 
+    # Download pre-built libTorch
+    rm -fr /opt/torch
     curl -o /tmp/libtorch.zip https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcpu.zip
     unzip /tmp/libtorch.zip -d /opt
+
+    # Install GitHub CLI
+    dnf -y config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+    dnf -y install gh --repo gh-cli
+
+    # Download pre-built recent CMake (mostly for GROMACS)
+    rm -fr /opt/cmake
+    mkdir -p /opt/cmake
+    gh release download v3.30.5 --repo https://github.com/Kitware/CMake --clobber --pattern '*linux-x86_64.sh'
+    bash cmake-3.30.5-linux-x86_64.sh  --skip-license --prefix=/opt/cmake

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -74,5 +74,6 @@ From: quay.io/centos/centos:stream9
     # Download pre-built recent CMake (mostly for GROMACS)
     rm -fr /opt/cmake
     mkdir -p /opt/cmake
+    # export GH_TOKEN=xxxxx (will needs this to run gh even on public repos)
     gh release download v3.30.5 --repo https://github.com/Kitware/CMake --clobber --pattern '*linux-x86_64.sh'
     bash cmake-3.30.5-linux-x86_64.sh  --skip-license --prefix=/opt/cmake

--- a/devel-tools/containers/CentOS9-devel.def
+++ b/devel-tools/containers/CentOS9-devel.def
@@ -57,7 +57,7 @@ From: quay.io/centos/centos:stream9
     if [ ! -f /usr/local/bin/spiff ] ; then
         # Build and install spiff
         rm -fr /tmp/spiff
-        git clone https://github.com/HanatoK/spiff /tmp/spiff && \
+        git clone https://github.com/Colvars/spiff /tmp/spiff && \
             make -C /tmp/spiff && \
             install /tmp/spiff/spiff /usr/local/bin/
     fi

--- a/devel-tools/containers/README.md
+++ b/devel-tools/containers/README.md
@@ -10,3 +10,13 @@ apptainer build container.sif container.def
 ```
 apptainer run container.sif
 ```
+
+4. (Optional) Push the container to the GitHub repository's "Packages"
+   section; currently we only have one package, called `devel-containers`,
+   which comes in different versions depending on the OS and software
+   contained.  For example, to update the most commonly used container
+   version:
+```
+apptainer push CentOS9-devel.sif oras://ghcr.io/colvars/devel-containers:CentOS9-devel
+```
+(note that the above requires having set up an access token for apptainer)


### PR DESCRIPTION
GROMACS main now requres a newer CMake (which appears to track the latest Ubuntu version):

https://gitlab.com/gromacs/gromacs/-/commit/812d99f18f5aefd209c1364a0443276e2c360f28
