### PR TITLE
min_image fix; Saves long runs from crashes;

### DIFF
--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -191,7 +191,7 @@ cvm::rvector colvarproxy_lammps::position_distance(cvm::atom_pos const &pos1,
   double xtmp = pos2.x - pos1.x;
   double ytmp = pos2.y - pos1.y;
   double ztmp = pos2.z - pos1.z;
-  _lmp->domain->minimum_image(xtmp,ytmp,ztmp);
+  _lmp->domain->minimum_image_big(xtmp,ytmp,ztmp);
   return {xtmp, ytmp, ztmp};
 }
 


### PR DESCRIPTION
This addresses [this](https://matsci.org/t/fix-rigid-atoms-have-moved-too-far-apart/53926/14) recent issue solution