### PR TITLE
fix: clamp the input values of asin and acos in case of fast math on aarch64

### DIFF
--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -18,6 +18,11 @@
 #define COLVARS_DEBUG false
 #endif
 
+#if defined(__FAST_MATH__) && defined(__aarch64__)
+// NOTE: This is used for fixing https://github.com/Colvars/colvars/issues/767
+#define COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
+#endif
+
 /*! \mainpage Main page
 This is the Developer's documentation for the Collective Variables module (Colvars).
 
@@ -150,13 +155,23 @@ public:
   /// Reimplemented to work around MS compiler issues
   static inline real asin(real const &x)
   {
+#ifdef COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
+    const double tmp = static_cast<double>(x);
+    return ::asin(tmp > 1.0 ? 1.0 : (tmp < -1.0 ? -1.0 : tmp));
+#else
     return ::asin(static_cast<double>(x));
+#endif
   }
 
   /// Reimplemented to work around MS compiler issues
   static inline real acos(real const &x)
   {
+#ifdef COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
+    const double tmp = static_cast<double>(x);
+    return ::acos(tmp > 1.0 ? 1.0 : (tmp < -1.0 ? -1.0 : tmp));
+#else
     return ::acos(static_cast<double>(x));
+#endif
   }
 
   /// Reimplemented to work around MS compiler issues

--- a/src/colvarvalue.cpp
+++ b/src/colvarvalue.cpp
@@ -674,7 +674,7 @@ colvarvalue colvarvalue::dist2_grad(colvarvalue const &x2) const
     cvm::rvector const &v1 = this->rvector_value;
     cvm::rvector const &v2 = x2.rvector_value;
     cvm::real const cos_t = v1 * v2;
-    return colvarvalue(2.0 * std::acos(cos_t) * -1.0 / cvm::sqrt(1.0 - cos_t * cos_t) * v2,
+    return colvarvalue(2.0 * cvm::acos(cos_t) * -1.0 / cvm::sqrt(1.0 - cos_t * cos_t) * v2,
                        colvarvalue::type_unit3vectorderiv);
   }
   case colvarvalue::type_quaternion:


### PR DESCRIPTION
This PR clamps the input values of `asin` and `acos` in case of `__FAST_MATH__` and `__aarch64__`, which fixes `NaNs in tests `000_distancedir-fitgroup_harmonic-ddir-fixed` and `000_distancedir-fitgroup_harmonic-ddir-fixed-fit-forces`.