### PR TITLE
Avoid error in acos and asin with fast-math

### DIFF
--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -18,7 +18,7 @@
 #define COLVARS_DEBUG false
 #endif
 
-#if defined(__FAST_MATH__) && defined(__aarch64__)
+#if defined(__FAST_MATH__)
 // NOTE: This is used for fixing https://github.com/Colvars/colvars/issues/767
 #define COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
 #endif
@@ -152,27 +152,44 @@ public:
     return ::cos(static_cast<double>(x));
   }
 
-  /// Reimplemented to work around MS compiler issues
-  static inline real asin(real const &x)
-  {
+#ifndef PI
+#define PI   3.14159265358979323846
+#endif
+#ifndef PI_2
+#define PI_2 1.57079632679489661923
+#endif
+
+/// Reimplemented to work around compiler issues; return hard-coded values for boundary conditions
+static inline real asin(real const &x)
+{
 #ifdef COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
-    const double tmp = static_cast<double>(x);
-    return ::asin(tmp > 1.0 ? 1.0 : (tmp < -1.0 ? -1.0 : tmp));
+    if (x <= -1.0) {
+        return -PI_2;
+    } else if (x >= 1.0) {
+        return PI_2;
+    } else {
+        return ::asin(static_cast<double>(x));
+    }
 #else
     return ::asin(static_cast<double>(x));
 #endif
-  }
+}
 
-  /// Reimplemented to work around MS compiler issues
-  static inline real acos(real const &x)
-  {
+/// Reimplemented to work around compiler issues; return hard-coded values for boundary conditions
+static inline real acos(real const &x)
+{
 #ifdef COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
-    const double tmp = static_cast<double>(x);
-    return ::acos(tmp > 1.0 ? 1.0 : (tmp < -1.0 ? -1.0 : tmp));
+    if (x <= -1.0) {
+        return PI;
+    } else if (x >= 1.0) {
+        return 0.0;
+    } else {
+        return ::acos(static_cast<double>(x));
+    }
 #else
     return ::acos(static_cast<double>(x));
 #endif
-  }
+}
 
   /// Reimplemented to work around MS compiler issues
   static inline real atan2(real const &x, real const &y)

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -20,10 +20,6 @@
 
 #include "colvarmodule.h"
 
-#ifndef PI
-#define PI 3.14159265358979323846
-#endif
-
 // ----------------------------------------------------------------------
 /// Linear algebra functions and data types used in the collective
 /// variables implemented so far


### PR DESCRIPTION
by returning hardcoded values on boundaries -1 and 1

Compared with previous fix #768 this is more radical:
- triggers when fast-math is enabled regardless of architecture (following remarks by @HanatoK https://github.com/Colvars/colvars/pull/768#issuecomment-2672473081)
- does not call the library functions when the argument is "equal" to -1 or 1, but returns hard-coded values.