### PR TITLE
[RFC] Add an option to parallelize the inner loops instead of CVCs

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1497,9 +1497,9 @@ int colvarproxy_namd::compute_volmap(int flags,
 
 #if CMK_SMP && USE_CKLOOP // SMP only
 
-int colvarproxy_namd::check_smp_enabled()
+int colvarproxy_namd::check_smp_enabled(smp_mode_t mode)
 {
-  if (b_smp_active) {
+  if (smp_mode == mode) {
     return COLVARS_OK;
   }
   return COLVARS_ERROR;

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -1497,14 +1497,14 @@ int colvarproxy_namd::compute_volmap(int flags,
 
 #if CMK_SMP && USE_CKLOOP // SMP only
 
-int colvarproxy_namd::check_smp_enabled(smp_mode_t mode)
-{
-  if (smp_mode == mode) {
-    return COLVARS_OK;
-  }
-  return COLVARS_ERROR;
+colvarproxy::smp_mode_t colvarproxy_namd::get_smp_mode() const {
+  return smp_mode;
 }
 
+int colvarproxy_namd::set_smp_mode(smp_mode_t mode) {
+  smp_mode = mode;
+  return COLVARS_OK;
+}
 
 void calc_colvars_items_smp(int first, int last, void *result, int paramNum, void *param)
 {

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -124,13 +124,15 @@ public:
   }
 
 #if CMK_SMP && USE_CKLOOP
-  int check_smp_enabled(smp_mode_t mode) override;
+  colvarproxy::smp_mode_t get_smp_mode() const override;
+
+  int set_smp_mode(smp_mode_t mode) override;
 
   int smp_colvars_loop() override;
 
-  int smp_biases_loop();
+  int smp_biases_loop() override;
 
-  int smp_biases_script_loop();
+  int smp_biases_script_loop() override;
 
   friend void calc_colvars_items_smp(int first, int last, void *result, int paramNum, void *param);
   friend void calc_cv_biases_smp(int first, int last, void *result, int paramNum, void *param);

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -124,7 +124,7 @@ public:
   }
 
 #if CMK_SMP && USE_CKLOOP
-  int check_smp_enabled() override;
+  int check_smp_enabled(smp_mode_t mode) override;
 
   int smp_colvars_loop() override;
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -128,7 +128,7 @@ public:
 
   int set_smp_mode(smp_mode_t mode) override;
 
-  int smp_colvars_loop() override;
+  int smp_loop(int n_items, std::function<int (int)> const &worker) override;
 
   int smp_biases_loop() override;
 

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -224,6 +224,9 @@ int colvarbias::init_dependencies() {
   // (initially, harmonicWalls)
   feature_states[f_cvb_bypass_ext_lagrangian].available = false;
 
+  // Most biases cannot currently be processed in parallel over threads
+  feature_states[f_cvb_smp].available = false;
+
   return COLVARS_OK;
 }
 

--- a/src/colvarbias.cpp
+++ b/src/colvarbias.cpp
@@ -201,6 +201,8 @@ int colvarbias::init_dependencies() {
 
     init_feature(f_cvb_extended, "Bias on extended-Lagrangian variables", f_type_static);
 
+    init_feature(f_cvb_smp, "smp_computation", f_type_user);
+
     // check that everything is initialized
     for (i = 0; i < colvardeps::f_cvb_ntot; i++) {
       if (is_not_set(i)) {

--- a/src/colvarbias_opes.cpp
+++ b/src/colvarbias_opes.cpp
@@ -201,7 +201,7 @@ int colvarbias_opes::init(const std::string& conf) {
   get_keyval(conf, "calcWork", m_calc_work, false);
   bool b_replicas = false;
   get_keyval(conf, "multipleReplicas", b_replicas, false);
-  if (!cvm::proxy->b_smp_active) m_num_threads = 1;
+  if (cvm::proxy->check_smp_enabled(colvarproxy::smp_mode_t::cvcs) != COLVARS_OK) m_num_threads = 1;
   else m_num_threads = cvm::proxy->smp_num_threads();
 #ifdef OPES_THREADING
   if (m_num_threads == -1) {

--- a/src/colvarbias_opes.cpp
+++ b/src/colvarbias_opes.cpp
@@ -201,7 +201,8 @@ int colvarbias_opes::init(const std::string& conf) {
   get_keyval(conf, "calcWork", m_calc_work, false);
   bool b_replicas = false;
   get_keyval(conf, "multipleReplicas", b_replicas, false);
-  if (cvm::proxy->check_smp_enabled(colvarproxy::smp_mode_t::cvcs) != COLVARS_OK) m_num_threads = 1;
+  if (cvm::proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::none ||
+      cvm::proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::cvcs) m_num_threads = 1;
   else m_num_threads = cvm::proxy->smp_num_threads();
 #ifdef OPES_THREADING
   if (m_num_threads == -1) {

--- a/src/colvardeps.h
+++ b/src/colvardeps.h
@@ -257,6 +257,8 @@ public:
     f_cvb_scale_biasing_force,
     /// \brief whether this bias is applied to one or more ext-Lagrangian colvars
     f_cvb_extended,
+    /// Process this bias's data in parallel over multiple CPU threads
+    f_cvb_smp,
     f_cvb_ntot
   };
 

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -339,6 +339,9 @@ public:
   /// Indexes of the items to calculate for each colvar
   std::vector<int> *variables_active_smp_items();
 
+  /// Calculate the value of the specified component (to be called in a SMP loop)
+  int calc_component_smp(int i);
+
   /// Array of collective variable biases
   std::vector<colvarbias *> biases;
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -265,16 +265,25 @@ colvarproxy_smp::~colvarproxy_smp()
 #endif
 }
 
-
-int colvarproxy_smp::check_smp_enabled(smp_mode_t mode)
-{
+colvarproxy::smp_mode_t colvarproxy_smp::get_smp_mode() const {
 #if defined(_OPENMP)
-  if (smp_mode == mode) {
-    return COLVARS_OK;
-  }
-  return COLVARS_ERROR;
+  return smp_mode;
 #else
-  return COLVARS_NOT_IMPLEMENTED;
+  return colvarproxy::smp_mode_t::none;
+#endif
+}
+
+int colvarproxy_smp::set_smp_mode(smp_mode_t mode) {
+#if defined(_OPENMP)
+  smp_mode = mode;
+  return COLVARS_OK;
+#else
+  if (mode != colvarproxy::smp_mode_t::none) {
+    return COLVARS_NOT_IMPLEMENTED;
+  } else {
+    smp_mode = colvarproxy::smp_mode_t::none;
+  }
+  return COLVARS_OK;
 #endif
 }
 
@@ -470,8 +479,8 @@ colvarproxy::~colvarproxy()
 
 bool colvarproxy::io_available()
 {
-  return (check_smp_enabled(smp_mode_t::cvcs) == COLVARS_OK && smp_thread_id() == 0) ||
-    (check_smp_enabled(smp_mode_t::cvcs) != COLVARS_OK);
+  return ((get_smp_mode() != smp_mode_t::none) && smp_thread_id() == 0) ||
+    (get_smp_mode() == smp_mode_t::none);
 }
 
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -243,7 +243,7 @@ void colvarproxy_atom_groups::compute_max_atom_groups_applied_force()
 
 colvarproxy_smp::colvarproxy_smp()
 {
-  b_smp_active = true; // May be disabled by user option
+  smp_mode = smp_mode_t::cvcs; // May be disabled by user option
   omp_lock_state = NULL;
 #if defined(_OPENMP)
   if (omp_get_thread_num() == 0) {
@@ -266,10 +266,10 @@ colvarproxy_smp::~colvarproxy_smp()
 }
 
 
-int colvarproxy_smp::check_smp_enabled()
+int colvarproxy_smp::check_smp_enabled(smp_mode_t mode)
 {
 #if defined(_OPENMP)
-  if (b_smp_active) {
+  if (smp_mode == mode) {
     return COLVARS_OK;
   }
   return COLVARS_ERROR;
@@ -470,8 +470,8 @@ colvarproxy::~colvarproxy()
 
 bool colvarproxy::io_available()
 {
-  return (check_smp_enabled() == COLVARS_OK && smp_thread_id() == 0) ||
-    (check_smp_enabled() != COLVARS_OK);
+  return (check_smp_enabled(smp_mode_t::cvcs) == COLVARS_OK && smp_thread_id() == 0) ||
+    (check_smp_enabled(smp_mode_t::cvcs) != COLVARS_OK);
 }
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -456,12 +456,11 @@ public:
   /// Destructor
   virtual ~colvarproxy_smp();
 
-  /// Whether threaded parallelization should be used (TODO: make this a
-  /// cvm::deps feature)
-  smp_mode_t smp_mode;
+  /// Get the current SMP mode
+  virtual smp_mode_t get_smp_mode() const;
 
-  /// Whether threaded parallelization is available (TODO: make this a cvm::deps feature)
-  virtual int check_smp_enabled(smp_mode_t mode);
+  /// Set the current SMP mode
+  virtual int set_smp_mode(smp_mode_t mode);
 
   /// Distribute calculation of colvars (and their components) across threads
   virtual int smp_colvars_loop();
@@ -491,6 +490,10 @@ protected:
 
   /// Lock state for OpenMP
   omp_lock_t *omp_lock_state;
+
+  /// Whether threaded parallelization should be used (TODO: make this a
+  /// cvm::deps feature)
+  smp_mode_t smp_mode;
 };
 
 

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -448,6 +448,8 @@ class colvarproxy_smp {
 
 public:
 
+  enum class smp_mode_t {cvcs, inner_loop, none};
+
   /// Constructor
   colvarproxy_smp();
 
@@ -456,10 +458,10 @@ public:
 
   /// Whether threaded parallelization should be used (TODO: make this a
   /// cvm::deps feature)
-  bool b_smp_active;
+  smp_mode_t smp_mode;
 
   /// Whether threaded parallelization is available (TODO: make this a cvm::deps feature)
-  virtual int check_smp_enabled();
+  virtual int check_smp_enabled(smp_mode_t mode);
 
   /// Distribute calculation of colvars (and their components) across threads
   virtual int smp_colvars_loop();

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -10,6 +10,8 @@
 #ifndef COLVARPROXY_H
 #define COLVARPROXY_H
 
+#include <functional>
+
 #include "colvarmodule.h"
 #include "colvartypes.h"
 #include "colvarproxy_io.h"
@@ -462,8 +464,8 @@ public:
   /// Set the current SMP mode
   virtual int set_smp_mode(smp_mode_t mode);
 
-  /// Distribute calculation of colvars (and their components) across threads
-  virtual int smp_colvars_loop();
+  /// Distribute computation over threads using OpenMP, unless overridden in the backend (e.g. NAMD)
+  virtual int smp_loop(int n_items, std::function<int (int)> const &worker);
 
   /// Distribute calculation of biases across threads
   virtual int smp_biases_loop();


### PR DESCRIPTION
As discussed in https://github.com/Colvars/colvars/pull/700, this PR aims to provide the users an option (`smp inner_loop`) to parallelize the inner loops.

Currently this is only in early stage so I mark it as a draft PR.