### PR TITLE
fix: fix the use of Charm++ locks and CkLoop

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -46,7 +46,7 @@
 colvarproxy_namd::colvarproxy_namd()
 {
   engine_name_ = "NAMD";
-#if defined(CMK_SMP)
+#if CMK_SMP && USE_CKLOOP
   charm_lock_state = CmiCreateLock();
 #endif
 
@@ -154,7 +154,7 @@ colvarproxy_namd::colvarproxy_namd()
 
 colvarproxy_namd::~colvarproxy_namd()
 {
-#if defined(CMK_SMP)
+#if CMK_SMP && USE_CKLOOP
   CmiDestroyLock(charm_lock_state);
 #endif
   delete reduction;

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -154,18 +154,20 @@ public:
 
   int smp_lock()
   {
-    charm_lock_state = CmiCreateLock();
+    CmiLock(charm_lock_state);
     return COLVARS_OK;
   }
 
   int smp_trylock()
   {
-    return COLVARS_NOT_IMPLEMENTED;
+    const int ret = CmiTryLock(charm_lock_state);
+    if (ret == 0) return COLVARS_OK;
+    else return COLVARS_ERROR;
   }
 
   int smp_unlock()
   {
-    CmiDestroyLock(charm_lock_state);
+    CmiUnlock(charm_lock_state);
     return COLVARS_OK;
   }
 


### PR DESCRIPTION
This PR picks the fix of `smp_lock()` and `smp_unlock()` implementations in https://github.com/Colvars/colvars/pull/700/commits/ac82aa91e6f620050452e2211c1d752ffc65a1be , and uses `smp_num_threads()` for the number of chunks `CkLoop_Parallelize` to avoid potential oversubscription.