### PR TITLE
Fix restarting lambda-dynamics with NAMD

### DIFF
--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -2415,7 +2415,8 @@ int colvar::set_state_params(std::string const &conf)
     after_restart = true;
     // Externally driven cv (e.g. alchemical lambda) is imposed by restart value
     if (is_enabled(f_cv_external) && is_enabled(f_cv_extended_Lagrangian)) {
-      cvcs[0]->set_value(x);
+      // Request immediate sync of driven parameter to back-end code
+      cvcs[0]->set_value(x, true);
     }
   }
 

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -233,8 +233,14 @@ public:
 
   /// Forcibly set value of CVC - useful for driving an external coordinate,
   /// eg. lambda dynamics
-  inline void set_value(colvarvalue const &new_value) {
+  inline void set_value(colvarvalue const &new_value, bool now=false) {
     x = new_value;
+    // Cache value to be communicated to back-end between time steps
+    cvm::proxy->set_alch_lambda(x.real_value);
+    if (now) {
+      // If requested (e.g. upon restarting), sync to back-end
+      cvm::proxy->send_alch_lambda();
+    }
   }
 
 protected:

--- a/src/colvarcomp_alchlambda.cpp
+++ b/src/colvarcomp_alchlambda.cpp
@@ -81,8 +81,7 @@ void colvar::alch_lambda::calc_Jacobian_derivative()
 
 void colvar::alch_lambda::apply_force(colvarvalue const & /* force */)
 {
-  // new value will be cached and sent at end of timestep
-  cvm::proxy->set_alch_lambda(x.real_value);
+  // Forces, if any, are applied in colvar::update_extended_Lagrangian()
 }
 
 


### PR DESCRIPTION
Improved the logic of updating the alchemical parameter, separating two cases:
- upon restarting, the value of the parameter is communicated immediately to the back-end (necessary for the next force  calculation to be correct)
- during MD integration, it is cached to be communicated at the end of time-step to avoid race conditions when changing it during the force calculations.

Both cases are handled by the set_value() function of the alchemical CVC.

Note: This evaded testing because the dynamics was not long enough for the value to change significantly between runs. This means we need a negative test, loading an incompatible state and checking that we get an error.