### PR TITLE
[RFC] Change the atom group to SOA

### DIFF
--- a/lammps/lib/colvars/Makefile.common
+++ b/lammps/lib/colvars/Makefile.common
@@ -24,6 +24,7 @@ COLVARS_INCFLAGS = -DCOLVARS_LAMMPS $(COLVARS_DEBUG_INCFLAGS) $(COLVARS_PYTHON_I
 
 COLVARS_SRCS = \
         colvaratoms.cpp \
+        colvaratoms_soa.cpp \
         colvarbias_abf.cpp \
         colvarbias_abmd.cpp \
         colvarbias_alb.cpp \

--- a/namd/colvars/Make.depends
+++ b/namd/colvars/Make.depends
@@ -8,18 +8,21 @@ obj/colvar.o: \
 	colvars/src/colvarparse.h \
 	colvars/src/colvarparams.h \
 	colvars/src/colvarcomp.h \
-	colvars/src/colvarcomp_torchann.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvardeps.h \
 	colvars/src/colvar.h \
 	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h \
 	colvars/src/colvarbias.h \
-	colvars/src/colvars_memstream.h
+	colvars/src/colvars_memstream.h \
+	colvars/src/colvarcomp_torchann.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvar.o $(COPTC) colvars/src/colvar.cpp
 obj/colvaratoms.o: \
 	obj/.exists \
@@ -33,12 +36,32 @@ obj/colvaratoms.o: \
 	colvars/src/colvarparams.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvaratoms.o $(COPTC) colvars/src/colvaratoms.cpp
+obj/colvaratoms_soa.o: \
+	obj/.exists \
+	colvars/src/colvaratoms_soa.cpp \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparams.h \
+	colvars/src/colvar_rotation_derivative.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
+	colvars/src/colvarproxy_system.h \
+	colvars/src/colvarproxy_tcl.h \
+	colvars/src/colvarproxy_volmaps.h
+	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvaratoms_soa.o $(COPTC) colvars/src/colvaratoms_soa.cpp
 obj/colvarbias.o: \
 	obj/.exists \
 	colvars/src/colvarbias.cpp \
@@ -47,6 +70,7 @@ obj/colvarbias.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -73,6 +97,7 @@ obj/colvarbias_abf.o: \
 	colvars/src/colvarbias_abf.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -97,6 +122,7 @@ obj/colvarbias_abmd.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h
@@ -109,6 +135,7 @@ obj/colvarbias_alb.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -128,6 +155,7 @@ obj/colvarbias_histogram.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -158,6 +186,7 @@ obj/colvarbias_histogram_reweight_amd.o: \
 	colvars/src/colvargrid.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -171,6 +200,7 @@ obj/colvarbias_meta.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -192,6 +222,7 @@ obj/colvarbias_restraint.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -218,9 +249,12 @@ obj/colvarbias_opes.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
-	colvars/src/colvarproxy_volmaps.h
+	colvars/src/colvarproxy_volmaps.h \
+	colvars/src/colvars_memstream.h \
+	colvars/src/colvargrid.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarbias_opes.o $(COPTC) colvars/src/colvarbias_opes.cpp
 obj/colvarcomp.o: \
 	obj/.exists \
@@ -237,10 +271,13 @@ obj/colvarcomp.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp.o $(COPTC) colvars/src/colvarcomp.cpp
 obj/colvarcomp_angles.o: \
 	obj/.exists \
@@ -257,10 +294,13 @@ obj/colvarcomp_angles.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_angles.o $(COPTC) colvars/src/colvarcomp_angles.cpp
 obj/colvarcomp_alchlambda.o: \
 	obj/.exists \
@@ -277,10 +317,13 @@ obj/colvarcomp_alchlambda.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_alchlambda.o $(COPTC) colvars/src/colvarcomp_alchlambda.cpp
 obj/colvarcomp_apath.o: \
 	obj/.exists \
@@ -297,10 +340,13 @@ obj/colvarcomp_apath.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h \
 	colvars/src/colvar_arithmeticpath.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_apath.o $(COPTC) colvars/src/colvarcomp_apath.cpp
 obj/colvarcomp_coordnums.o: \
@@ -312,6 +358,7 @@ obj/colvarcomp_coordnums.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -319,6 +366,8 @@ obj/colvarcomp_coordnums.o: \
 	colvars/src/colvarvalue.h \
 	colvars/src/colvarparams.h \
 	colvars/src/colvardeps.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h \
 	colvars/src/colvar.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvar_geometricpath.h
@@ -338,10 +387,12 @@ obj/colvarcomp_distances.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
 	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_distances.o $(COPTC) colvars/src/colvarcomp_distances.cpp
 obj/colvarcomp_gpath.o: \
@@ -359,10 +410,13 @@ obj/colvarcomp_gpath.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_gpath.o $(COPTC) colvars/src/colvarcomp_gpath.cpp
 obj/colvarcomp_protein.o: \
 	obj/.exists \
@@ -379,10 +433,13 @@ obj/colvarcomp_protein.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_protein.o $(COPTC) colvars/src/colvarcomp_protein.cpp
 obj/colvarcomp_rotations.o: \
 	obj/.exists \
@@ -399,10 +456,12 @@ obj/colvarcomp_rotations.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
 	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_rotations.o $(COPTC) colvars/src/colvarcomp_rotations.cpp
 obj/colvarcomp_volmaps.o: \
@@ -420,10 +479,13 @@ obj/colvarcomp_volmaps.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_volmaps.o $(COPTC) colvars/src/colvarcomp_volmaps.cpp
 obj/colvarcomp_combination.o: \
 	obj/.exists \
@@ -435,6 +497,7 @@ obj/colvarcomp_combination.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -443,7 +506,9 @@ obj/colvarcomp_combination.o: \
 	colvars/src/colvarparams.h \
 	colvars/src/colvardeps.h \
 	colvars/src/colvar.h \
-	colvars/src/colvar_geometricpath.h
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_combination.o $(COPTC) colvars/src/colvarcomp_combination.cpp
 obj/colvarcomp_neuralnetwork.o: \
 	obj/.exists \
@@ -460,16 +525,38 @@ obj/colvarcomp_neuralnetwork.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
 	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h \
 	colvars/src/colvar_neuralnetworkcompute.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_neuralnetwork.o $(COPTC) colvars/src/colvarcomp_neuralnetwork.cpp
 obj/colvarcomp_torchann.o: \
 	obj/.exists \
-	colvars/src/colvarcomp_torchann.h \
-	colvars/src/colvarcomp_torchann.cpp
+	colvars/src/colvarcomp_torchann.cpp \
+	colvars/src/colvar.h \
+	colvars/src/colvarmodule.h \
+	colvars/src/colvars_version.h \
+	colvars/src/colvarvalue.h \
+	colvars/src/colvartypes.h \
+	colvars/src/colvarparse.h \
+	colvars/src/colvarparams.h \
+	colvars/src/colvardeps.h \
+	colvars/src/colvarcomp.h \
+	colvars/src/colvaratoms.h \
+	colvars/src/colvarproxy.h \
+	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
+	colvars/src/colvarproxy_system.h \
+	colvars/src/colvarproxy_tcl.h \
+	colvars/src/colvarproxy_volmaps.h \
+	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h \
+	colvars/src/colvarcomp_torchann.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarcomp_torchann.o $(COPTC) colvars/src/colvarcomp_torchann.cpp
 obj/colvar_neuralnetworkcompute.o: \
 	obj/.exists \
@@ -483,6 +570,7 @@ obj/colvar_neuralnetworkcompute.o: \
 	colvars/src/colvarparams.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h
@@ -495,6 +583,7 @@ obj/colvardeps.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -518,6 +607,7 @@ obj/colvargrid.o: \
 	colvars/src/colvargrid_def.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -534,6 +624,7 @@ obj/colvarmodule.o: \
 	colvars/src/colvarparams.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -557,6 +648,8 @@ obj/colvarmodule.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarcomp.h \
 	colvars/src/colvar_geometricpath.h \
+	colvars/src/colvaratoms_soa.h \
+	colvars/src/colvar_rotation_derivative.h \
 	colvars/src/colvars_memstream.h \
 	colvars/src/colvarmodule_refs.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarmodule.o $(COPTC) colvars/src/colvarmodule.cpp
@@ -588,6 +681,7 @@ obj/colvarproxy.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -615,12 +709,7 @@ obj/colvarproxy_replicas.o: \
 	colvars/src/colvarproxy_replicas.cpp \
 	colvars/src/colvarmodule.h \
 	colvars/src/colvars_version.h \
-	colvars/src/colvarproxy.h \
-	colvars/src/colvartypes.h \
-	colvars/src/colvarproxy_io.h \
-	colvars/src/colvarproxy_system.h \
-	colvars/src/colvarproxy_tcl.h \
-	colvars/src/colvarproxy_volmaps.h
+	colvars/src/colvarproxy_replicas.h
 	$(CXX) $(COLVARSCXXFLAGS) $(COPTO)obj/colvarproxy_replicas.o $(COPTC) colvars/src/colvarproxy_replicas.cpp
 obj/colvarproxy_system.o: \
 	obj/.exists \
@@ -638,6 +727,7 @@ obj/colvarproxy_tcl.o: \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -663,6 +753,7 @@ obj/colvarscript.o: \
 	colvars/src/colvars_version.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -689,6 +780,7 @@ obj/colvarscript_commands.o: \
 	colvars/src/colvarbias.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -705,6 +797,7 @@ obj/colvarscript_commands_bias.o: \
 	colvars/src/colvars_version.h \
 	colvars/src/colvartypes.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -732,6 +825,7 @@ obj/colvarscript_commands_colvar.o: \
 	colvars/src/colvardeps.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \
@@ -758,6 +852,7 @@ obj/colvartypes.o: \
 	colvars/src/colvaratoms.h \
 	colvars/src/colvarproxy.h \
 	colvars/src/colvarproxy_io.h \
+	colvars/src/colvarproxy_replicas.h \
 	colvars/src/colvarproxy_system.h \
 	colvars/src/colvarproxy_tcl.h \
 	colvars/src/colvarproxy_volmaps.h \

--- a/namd/colvars/src/Makefile.namd
+++ b/namd/colvars/src/Makefile.namd
@@ -1,6 +1,7 @@
 COLVARSLIB = \
 	$(DSTDIR)/colvar.o \
 	$(DSTDIR)/colvaratoms.o \
+	$(DSTDIR)/colvaratoms_soa.o \
 	$(DSTDIR)/colvarbias.o \
 	$(DSTDIR)/colvarbias_abf.o \
 	$(DSTDIR)/colvarbias_abmd.o \

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -204,6 +204,10 @@ public:
                      cvm::atom_group &atoms,
                      std::string const &pdb_field,
                      double const pdb_field_value) override;
+  int load_atoms_pdb(char const *filename,
+                     cvm::atom_group_soa &atoms,
+                     std::string const &pdb_field,
+                     double pdb_field_value) override;
 
   int load_coords_pdb(char const *filename,
                       std::vector<cvm::atom_pos> &pos,
@@ -237,27 +241,43 @@ public:
 
   void clear_volmap(int index) override;
 
+#ifdef COLVARS_USE_SOA
   int compute_volmap(int flags,
-                             int volmap_id,
-                             cvm::atom_iter atom_begin,
-                             cvm::atom_iter atom_end,
-                             cvm::real *value,
-                             cvm::real *atom_field) override;
+                     int volmap_id,
+                     cvm::atom_group_soa* ag,
+                     cvm::real *value,
+                     cvm::real *atom_field) override;
+#else
+  int compute_volmap(int flags,
+                     int volmap_id,
+                     cvm::atom_iter atom_begin,
+                     cvm::atom_iter atom_end,
+                     cvm::real *value,
+                     cvm::real *atom_field) override;
+#endif // COLVARS_USE_SOA
 
   /// Abstraction of the two types of NAMD volumetric maps
   template<class T>
   void getGridForceGridValue(int flags,
                              T const *grid,
+#ifdef COLVARS_USE_SOA
+                             cvm::atom_group_soa* ag,
+#else
                              cvm::atom_iter atom_begin,
                              cvm::atom_iter atom_end,
+#endif // COLVARS_USE_SOA
                              cvm::real *value,
                              cvm::real *atom_field);
 
   /// Implementation of inner loop; allows for atom list computation and use
   template<class T, int flags>
   void GridForceGridLoop(T const *g,
+#ifdef COLVARS_USE_SOA
+                         cvm::atom_group_soa* ag,
+#else
                          cvm::atom_iter atom_begin,
                          cvm::atom_iter atom_end,
+#endif // COLVARS_USE_SOA
                          cvm::real *value,
                          cvm::real *atom_field);
 

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -199,15 +199,18 @@ public:
 
   cvm::rvector position_distance(cvm::atom_pos const &pos1,
                                  cvm::atom_pos const &pos2) const;
-
-  int load_atoms_pdb(char const *filename,
-                     cvm::atom_group &atoms,
-                     std::string const &pdb_field,
-                     double const pdb_field_value) override;
+#ifdef COLVARS_USE_SOA
   int load_atoms_pdb(char const *filename,
                      cvm::atom_group_soa &atoms,
                      std::string const &pdb_field,
                      double pdb_field_value) override;
+#else
+  int load_atoms_pdb(char const *filename,
+                     cvm::atom_group &atoms,
+                     std::string const &pdb_field,
+                     double const pdb_field_value) override;
+#endif // COLVARS_USE_SOA
+
 
   int load_coords_pdb(char const *filename,
                       std::vector<cvm::atom_pos> &pos,

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1024,14 +1024,22 @@ void colvar::build_atom_list(void)
 
   for (size_t i = 0; i < cvcs.size(); i++) {
     for (size_t j = 0; j < cvcs[i]->atom_groups.size(); j++) {
-      cvm::atom_group const &ag = *(cvcs[i]->atom_groups[j]);
+      auto const &ag = *(cvcs[i]->atom_groups[j]);
       for (size_t k = 0; k < ag.size(); k++) {
+#ifdef COLVARS_USE_SOA
+        temp_id_list.push_back(ag.id(k));
+#else
         temp_id_list.push_back(ag[k].id);
+#endif // COLVARS_USE_SOA
       }
       if (ag.is_enabled(f_ag_fitting_group) && ag.is_enabled(f_ag_fit_gradients)) {
-        cvm::atom_group const &fg = *(ag.fitting_group);
+        auto const &fg = *(ag.fitting_group);
         for (size_t k = 0; k < fg.size(); k++) {
+#ifdef COLVARS_USE_SOA
+          temp_id_list.push_back(fg.id(k));
+#else
           temp_id_list.push_back(fg[k].id);
+#endif // COLVARS_USE_SOA
         }
       }
     }
@@ -1294,7 +1302,7 @@ void colvar::setup()
   // loop over all components to update masses and charges of all groups
   for (size_t i = 0; i < cvcs.size(); i++) {
     for (size_t ig = 0; ig < cvcs[i]->atom_groups.size(); ig++) {
-      cvm::atom_group *atoms = cvcs[i]->atom_groups[ig];
+      auto *atoms = cvcs[i]->atom_groups[ig];
       atoms->setup();
       atoms->print_properties(name, i, ig);
       atoms->read_positions();

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -20,7 +20,7 @@
 #include "colvaratoms.h"
 #include "colvar_rotation_derivative.h"
 
-
+#ifndef COLVARS_USE_SOA
 cvm::atom::atom()
 {
   index = -1;
@@ -1559,5 +1559,5 @@ void cvm::atom_group::group_force_object::apply_force_with_fitting_group() {
 // Static members
 
 std::vector<colvardeps::feature *> cvm::atom_group::ag_features;
-
+#endif
 

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -15,10 +15,10 @@
 #include "colvarparse.h"
 #include "colvardeps.h"
 
-template <typename T1, typename T2>
+template <typename T1, typename T2, bool soa>
 struct rotation_derivative;
 
-
+#ifndef COLVARS_USE_SOA
 /// \brief Stores numeric id, mass and all mutable data for an atom,
 /// mostly used by a \link colvar::cvc \endlink
 ///
@@ -386,7 +386,7 @@ public:
   cvm::rotation rot;
 
   /// Rotation derivative;
-  rotation_derivative<cvm::atom, cvm::atom_pos>* rot_deriv;
+  rotation_derivative<cvm::atom, cvm::atom_pos, false>* rot_deriv;
 
   /// \brief Indicates that the user has explicitly set centerToReference or
   /// rotateReference, and the corresponding reference:
@@ -645,6 +645,6 @@ public:
   /// This overloads the base function in colvardeps
   void do_feature_side_effects(int id) override;
 };
-
+#endif
 
 #endif

--- a/src/colvaratoms_soa.cpp
+++ b/src/colvaratoms_soa.cpp
@@ -233,8 +233,8 @@ int cvm::atom_group_soa::setup() {
     atoms_charge.resize(size());
     atoms_mass.resize(size());
     for (size_t i = 0; i < num_atoms; ++i) {
-      atoms_charge[i] = static_cast<float>(p->get_atom_charge(atoms_index[i]));
-      atoms_mass[i] = static_cast<float>(p->get_atom_mass(atoms_index[i]));
+      atoms_charge[i] = p->get_atom_charge(atoms_index[i]);
+      atoms_mass[i] = p->get_atom_mass(atoms_index[i]);
     }
   }
   update_total_charge();
@@ -247,28 +247,7 @@ void cvm::atom_group_soa::atom_modifier::update_from_soa() {
   if (!m_ag->is_enabled(f_ag_scalable)) {
     m_atoms.resize(m_ag->size());
     for (size_t i = 0; i < m_atoms.size(); ++i) {
-      m_atoms[i] = simple_atom{
-        .proxy_index = m_ag->atoms_index[i],
-        .id = m_ag->atoms_ids[i],
-        .mass = m_ag->atoms_mass[i],
-        .charge = m_ag->atoms_charge[i],
-        .pos = cvm::atom_pos{
-          m_ag->pos_x(i),
-          m_ag->pos_y(i),
-          m_ag->pos_z(i)},
-        .vel = cvm::rvector{
-          m_ag->vel_x(i),
-          m_ag->vel_y(i),
-          m_ag->vel_z(i)},
-        .total_force = cvm::rvector{
-          m_ag->total_force_x(i),
-          m_ag->total_force_y(i),
-          m_ag->total_force_z(i)},
-        .grad = cvm::rvector{
-          m_ag->grad_x(i),
-          m_ag->grad_y(i),
-          m_ag->grad_z(i)
-        }};
+      m_atoms[i] = (*m_ag)[i];
       m_atoms_ids_count[m_ag->atoms_ids[i]] = 1;
     }
   }

--- a/src/colvaratoms_soa.cpp
+++ b/src/colvaratoms_soa.cpp
@@ -1,0 +1,1862 @@
+#include "colvaratoms_soa.h"
+// #include "colvaratoms.h"
+#include "colvar_rotation_derivative.h"
+#include "colvardeps.h"
+#include "colvarproxy.h"
+#include "colvarmodule.h"
+
+#include <numeric>
+#include <algorithm>
+#include <list>
+#include <iomanip>
+
+#ifdef COLVARS_USE_SOA
+
+std::vector<cvm::real> cvm::atom_group_soa::pos_aos_to_soa(const std::vector<cvm::atom_pos>& aos_in) {
+  static_assert(sizeof(cvm::atom_pos) == 3 * sizeof(cvm::real));
+  std::vector<cvm::real> pos_soa(aos_in.size() * 3);
+  const size_t offset_x = 0;
+  const size_t offset_y = offset_x + aos_in.size();
+  const size_t offset_z = offset_y + aos_in.size();
+  for (size_t i = 0; i < aos_in.size(); ++i) {
+    pos_soa[i + offset_x] = aos_in[i].x;
+    pos_soa[i + offset_y] = aos_in[i].y;
+    pos_soa[i + offset_z] = aos_in[i].z;
+  }
+  return pos_soa;
+}
+
+cvm::atom_group_soa::simple_atom cvm::atom_group_soa::init_atom_from_proxy(
+  colvarproxy* const    p,
+  cvm::residue_id const &residue,
+  std::string const     &atom_name,
+  std::string const     &segment_id) {
+  const int atom_proxy_index = p->init_atom(residue, atom_name, segment_id);
+  const int atom_id = p->get_atom_id(atom_proxy_index);
+  const cvm::real atom_mass = p->get_atom_mass(atom_proxy_index);
+  const cvm::real atom_charge = p->get_atom_charge(atom_proxy_index);
+  return cvm::atom_group_soa::simple_atom{
+    /*.proxy_index = */atom_proxy_index,
+    /*.id = */atom_id,
+    /*.mass = */atom_mass,
+    /*.charge = */atom_charge,
+    /*.pos = */{0, 0, 0},
+    /*.vel = */{0, 0, 0},
+    /*.total_force = */{0, 0, 0},
+    /*.grad = */{0, 0, 0}};
+}
+
+cvm::atom_group_soa::simple_atom cvm::atom_group_soa::init_atom_from_proxy(
+  colvarproxy* const    p,
+  int atom_number) {
+  const int atom_proxy_index = p->init_atom(atom_number);
+  const int atom_id = p->get_atom_id(atom_proxy_index);
+  const cvm::real atom_mass = p->get_atom_mass(atom_proxy_index);
+  const cvm::real atom_charge = p->get_atom_charge(atom_proxy_index);
+  return cvm::atom_group_soa::simple_atom{
+    /*.proxy_index = */atom_proxy_index,
+    /*.id = */atom_id,
+    /*.mass = */atom_mass,
+    /*.charge = */atom_charge,
+    /*.pos = */{0, 0, 0},
+    /*.vel = */{0, 0, 0},
+    /*.total_force = */{0, 0, 0},
+    /*.grad = */{0, 0, 0}};
+}
+
+cvm::atom_group_soa::simple_atom cvm::atom_group_soa::init_atom_from_proxy(
+  colvarproxy* const    p,
+  const simple_atom& atom_in) {
+  const int atom_proxy_index = atom_in.proxy_index;
+  const int atom_id = p->get_atom_id(atom_proxy_index);
+  p->increase_refcount(atom_proxy_index);
+  const cvm::real atom_mass = p->get_atom_mass(atom_proxy_index);
+  const cvm::real atom_charge = p->get_atom_charge(atom_proxy_index);
+  return cvm::atom_group_soa::simple_atom{
+    /*.proxy_index = */atom_proxy_index,
+    /*.id = */atom_id,
+    /*.mass = */atom_mass,
+    /*.charge = */atom_charge,
+    /*.pos = */{0, 0, 0},
+    /*.vel = */{0, 0, 0},
+    /*.total_force = */{0, 0, 0},
+    /*.grad = */{0, 0, 0}};
+}
+
+cvm::atom_group_soa::atom_group_soa():
+  b_dummy(false),
+  fitting_group(nullptr),
+  noforce(false), b_user_defined_fit(false),
+  rot_deriv(nullptr), num_atoms(0), index(-1),
+  num_ref_pos(0)
+{
+  key = "unnamed";
+  init();
+}
+
+cvm::atom_group_soa::atom_group_soa(char const *key_in): atom_group_soa() {
+  key = std::string(key_in);
+  init();
+}
+
+cvm::atom_group_soa::~atom_group_soa() {
+  clear_soa();
+  if (is_enabled(f_ag_scalable) && !b_dummy) {
+    (cvm::main()->proxy)->clear_atom_group(index);
+    index = -1;
+  }
+
+  if (fitting_group) {
+    delete fitting_group;
+    fitting_group = NULL;
+  }
+
+  if (rot_deriv != nullptr) {
+    delete rot_deriv;
+    rot_deriv = nullptr;
+  }
+}
+
+cvm::atom_group_soa::atom_modifier::atom_modifier(cvm::atom_group_soa* ag): m_ag(ag)
+{
+  if (m_ag->modify_lock.try_lock()) {
+    update_from_soa();
+  } else {
+    throw cvm::error(
+      "You are trying to modify the SOA atom group more than once at the same time",
+      COLVARS_BUG_ERROR);
+  }
+}
+
+cvm::atom_group_soa::atom_modifier::~atom_modifier() {
+  m_ag->modify_lock.unlock();
+  if (cvm::get_error() == COLVARS_OK) {
+    sync_to_soa();
+  }
+}
+
+int cvm::atom_group_soa::init()
+{
+  if (!key.size()) key = "unnamed";
+  description = "atom group " + key;
+  // These may be overwritten by parse(), if a name is provided
+
+  // atoms.clear();
+  this->clear_soa();
+  atom_group_soa::init_dependencies();
+  index = -1;
+
+  b_dummy = false;
+  b_user_defined_fit = false;
+  fitting_group = NULL;
+  rot_deriv = nullptr;
+
+  noforce = false;
+
+  total_mass = 0.0;
+  total_charge = 0.0;
+
+  cog.reset();
+  com.reset();
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::init_dependencies() {
+  size_t i;
+  // Initialize static array once and for all
+  if (features().size() == 0) {
+    for (i = 0; i < f_ag_ntot; i++) {
+      modify_features().push_back(new feature);
+    }
+
+    init_feature(f_ag_active, "active", f_type_dynamic);
+    init_feature(f_ag_center, "center_to_reference", f_type_user);
+    init_feature(f_ag_center_origin, "center_to_origin", f_type_user);
+    init_feature(f_ag_rotate, "rotate_to_origin", f_type_user);
+    init_feature(f_ag_fitting_group, "fitting_group", f_type_static);
+    init_feature(f_ag_explicit_gradient, "explicit_atom_gradient", f_type_dynamic);
+    init_feature(f_ag_fit_gradients, "fit_gradients", f_type_user);
+    require_feature_self(f_ag_fit_gradients, f_ag_explicit_gradient);
+
+    init_feature(f_ag_atom_forces, "atomic_forces", f_type_dynamic);
+
+    // parallel calculation implies that we have at least a scalable center of mass,
+    // but f_ag_scalable is kept as a separate feature to deal with future dependencies
+    init_feature(f_ag_scalable, "scalable_group", f_type_dynamic);
+    init_feature(f_ag_scalable_com, "scalable_group_center_of_mass", f_type_static);
+    require_feature_self(f_ag_scalable_com, f_ag_scalable);
+
+    init_feature(f_ag_collect_atom_ids, "collect_atom_ids", f_type_dynamic);
+    exclude_feature_self(f_ag_collect_atom_ids, f_ag_scalable);
+
+    // check that everything is initialized
+    for (i = 0; i < colvardeps::f_ag_ntot; i++) {
+      if (is_not_set(i)) {
+        cvm::error("Uninitialized feature " + cvm::to_str(i) + " in " + description);
+      }
+    }
+  }
+
+  // Initialize feature_states for each instance
+  // default as unavailable, not enabled
+  feature_states.reserve(f_ag_ntot);
+  for (i = feature_states.size(); i < colvardeps::f_ag_ntot; i++) {
+    feature_states.push_back(feature_state(false, false));
+  }
+
+  // Features that are implemented (or not) by all atom groups
+  feature_states[f_ag_active].available = true;
+  feature_states[f_ag_center].available = true;
+  feature_states[f_ag_center_origin].available = true;
+  feature_states[f_ag_rotate].available = true;
+
+  // f_ag_scalable_com is provided by the CVC iff it is COM-based
+  feature_states[f_ag_scalable_com].available = false;
+  feature_states[f_ag_scalable].available = true;
+  feature_states[f_ag_fit_gradients].available = true;
+  feature_states[f_ag_fitting_group].available = true;
+  feature_states[f_ag_explicit_gradient].available = true;
+  feature_states[f_ag_collect_atom_ids].available = true;
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::setup() {
+  // TODO: What should I do?
+  // if (atoms_ids.size() == 0) {
+  //   cvm::error("Bug: atoms_ids is empty!", COLVARS_BUG_ERROR);
+  // }
+  // Update masses and charges
+  const colvarproxy *p = cvm::proxy;
+  if (!b_dummy && !is_enabled(f_ag_scalable)) {
+    atoms_charge.resize(size());
+    atoms_mass.resize(size());
+    for (size_t i = 0; i < num_atoms; ++i) {
+      atoms_charge[i] = static_cast<float>(p->get_atom_charge(atoms_index[i]));
+      atoms_mass[i] = static_cast<float>(p->get_atom_mass(atoms_index[i]));
+    }
+  }
+  update_total_charge();
+  update_total_mass();
+  return COLVARS_OK;
+}
+
+void cvm::atom_group_soa::atom_modifier::update_from_soa() {
+  m_atoms_ids = m_ag->atoms_ids;
+  if (!m_ag->is_enabled(f_ag_scalable)) {
+    m_atoms.resize(m_ag->size());
+    for (size_t i = 0; i < m_atoms.size(); ++i) {
+      m_atoms[i] = simple_atom{
+        .proxy_index = m_ag->atoms_index[i],
+        .id = m_ag->atoms_ids[i],
+        .mass = m_ag->atoms_mass[i],
+        .charge = m_ag->atoms_charge[i],
+        .pos = cvm::atom_pos{
+          m_ag->pos_x(i),
+          m_ag->pos_y(i),
+          m_ag->pos_z(i)},
+        .vel = cvm::rvector{
+          m_ag->vel_x(i),
+          m_ag->vel_y(i),
+          m_ag->vel_z(i)},
+        .total_force = cvm::rvector{
+          m_ag->total_force_x(i),
+          m_ag->total_force_y(i),
+          m_ag->total_force_z(i)},
+        .grad = cvm::rvector{
+          m_ag->grad_x(i),
+          m_ag->grad_y(i),
+          m_ag->grad_z(i)
+        }};
+      m_atoms_ids_count[m_ag->atoms_ids[i]] = 1;
+    }
+  }
+  m_total_mass = m_ag->total_mass;
+  m_total_charge = m_ag->total_charge;
+}
+
+void cvm::atom_group_soa::atom_modifier::sync_to_soa() const {
+  m_ag->num_atoms = m_atoms.size();
+  m_ag->atoms_ids = m_atoms_ids;
+  if (!m_ag->is_enabled(f_ag_scalable)) {
+    m_ag->atoms_index.resize(m_ag->num_atoms);
+    m_ag->atoms_pos.resize(3 * m_ag->num_atoms);
+    m_ag->atoms_charge.resize(m_ag->num_atoms);
+    m_ag->atoms_vel.resize(3 * m_ag->num_atoms);
+    m_ag->atoms_mass.resize(m_ag->num_atoms);
+    m_ag->atoms_grad.resize(3 * m_ag->num_atoms);
+    m_ag->atoms_total_force.resize(3 * m_ag->num_atoms);
+    // colvarproxy *p = cvm::main()->proxy;
+    if (m_ag->atoms_ids.size() != m_atoms.size()) {
+      cvm::error("Number of atom IDs does not match the number of atoms!\n",
+                COLVARS_BUG_ERROR);
+    }
+    // for (size_t i = 0; i < m_ag->atoms_ids.size(); ++i) {
+    //   m_atoms[i].proxy_index = p->init_atom(m_ag->atoms_ids[i]);
+    // }
+    for (size_t i = 0; i < m_ag->num_atoms; ++i) {
+      m_ag->atoms_index[i] = m_atoms[i].proxy_index;
+      m_ag->pos_x(i) = m_atoms[i].pos.x;
+      m_ag->pos_y(i) = m_atoms[i].pos.y;
+      m_ag->pos_z(i) = m_atoms[i].pos.z;
+      m_ag->vel_x(i) = m_atoms[i].vel.x;
+      m_ag->vel_y(i) = m_atoms[i].vel.y;
+      m_ag->vel_z(i) = m_atoms[i].vel.z;
+      m_ag->grad_x(i) = m_atoms[i].grad.x;
+      m_ag->grad_y(i) = m_atoms[i].grad.y;
+      m_ag->grad_z(i) = m_atoms[i].grad.z;
+      m_ag->total_force_x(i) = m_atoms[i].total_force.x;
+      m_ag->total_force_y(i) = m_atoms[i].total_force.y;
+      m_ag->total_force_z(i) = m_atoms[i].total_force.z;
+      m_ag->atoms_mass[i] = m_atoms[i].mass;
+      m_ag->atoms_charge[i] = m_atoms[i].charge;
+    }
+  }
+  // m_ag->total_charge = m_total_charge;
+  // m_ag->total_mass = m_total_mass;
+  // m_ag->update_total_charge();
+  // m_ag->update_total_mass();
+}
+
+int cvm::atom_group_soa::atom_modifier::add_atom(const simple_atom& a) {
+  if (a.id < 0) {
+    return cvm::error("Error: invalid atom number " + cvm::to_str(a.id), COLVARS_INPUT_ERROR);
+  }
+  // for (size_t i = 0; i < m_atoms_ids.size(); i++) {
+  //   if (m_atoms_ids[i] == a.id) {
+  //     if (cvm::debug())
+  //       cvm::log("Discarding doubly counted atom with number "+
+  //                cvm::to_str(a.id+1)+".\n");
+  //     return COLVARS_OK;
+  //   }
+  // }
+  auto map_it = m_atoms_ids_count.find(a.id);
+  if (map_it != m_atoms_ids_count.end()) {
+    if (cvm::debug()) {
+      cvm::log("Discarding doubly counted atom with number "+
+              cvm::to_str(a.id+1)+".\n");
+    }
+    map_it->second++;
+    return COLVARS_OK;
+  } else {
+    m_atoms_ids_count[a.id] = 1;
+  }
+  // for consistency with add_atom_id(), we update the list as well
+  m_atoms_ids.push_back(a.id);
+  m_atoms.push_back(a);
+  m_total_mass += a.mass;
+  m_total_charge += a.charge;
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::remove_atom(atom_modifier::atom_iter ai)
+{
+  if (m_ag->is_enabled(f_ag_scalable)) {
+    cvm::error("Error: cannot remove atoms from a scalable group.\n", COLVARS_INPUT_ERROR);
+    return COLVARS_ERROR;
+  }
+
+  if (!this->size()) {
+    cvm::error("Error: trying to remove an atom from an empty group.\n", COLVARS_INPUT_ERROR);
+    return COLVARS_ERROR;
+  } else {
+    if (ai->proxy_index > 0) {
+      colvarproxy *p = cvm::main()->proxy;
+      p->clear_atom(ai->proxy_index);
+    }
+    m_total_mass -= ai->mass;
+    m_total_charge -= ai->charge;
+    const int id_to_remove = *(m_atoms_ids.begin() + (ai - m_atoms.begin()));
+    auto map_it = m_atoms_ids_count.find(id_to_remove);
+    if (map_it != m_atoms_ids_count.end()) {
+      m_atoms_ids_count.erase(map_it);
+    }
+    m_atoms_ids.erase(m_atoms_ids.begin() + (ai - m_atoms.begin()));
+    m_atoms.erase(ai);
+  }
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::add_atom_numbers(std::string const &numbers_conf)
+{
+  std::vector<int> atom_indexes;
+
+  if (numbers_conf.size()) {
+    std::istringstream is(numbers_conf);
+    int ia;
+    while (is >> ia) {
+      atom_indexes.push_back(ia);
+    }
+  }
+
+  if (atom_indexes.size()) {
+    m_atoms_ids.reserve(m_atoms_ids.size()+atom_indexes.size());
+
+    if (m_ag->is_enabled(f_ag_scalable)) {
+      for (size_t i = 0; i < atom_indexes.size(); i++) {
+        add_atom_id((cvm::proxy)->check_atom_id(atom_indexes[i]));
+      }
+    } else {
+      // if we are handling the group on rank 0, better allocate the vector in one shot
+      m_atoms.reserve(m_atoms.size()+atom_indexes.size());
+      colvarproxy* const p = cvm::main()->proxy;
+      for (size_t i = 0; i < atom_indexes.size(); i++) {
+        add_atom(init_atom_from_proxy(p, atom_indexes[i]));
+        // add_atom(cvm::atom(atom_indexes[i]));
+      }
+    }
+    if (cvm::get_error()) return COLVARS_ERROR;
+  } else {
+    return cvm::error("Error: no numbers provided for \""
+               "atomNumbers\".\n", COLVARS_INPUT_ERROR);
+  }
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::add_atoms_of_group(atom_group_soa const *ag) {
+  // TODO: should I check if ag == this??
+  std::vector<int> const &source_ids = ag->atoms_ids;
+  if (source_ids.size()) {
+    m_atoms_ids.reserve(m_atoms_ids.size()+source_ids.size());
+
+    if (m_ag->is_enabled(f_ag_scalable)) {
+      for (size_t i = 0; i < source_ids.size(); i++) {
+        add_atom_id(source_ids[i]);
+      }
+    } else {
+      m_atoms.reserve(m_atoms.size()+source_ids.size());
+      colvarproxy* const p = cvm::main()->proxy;
+      for (size_t i = 0; i < source_ids.size(); i++) {
+        // We could use the atom copy constructor, but only if the source
+        // group is not scalable - whereas this works in both cases
+        // atom constructor expects 1-based atom number
+        // add_atom(cvm::atom(source_ids[i] + 1));
+        add_atom(init_atom_from_proxy(p, source_ids[i] + 1));
+      }
+    }
+
+    if (cvm::get_error()) return COLVARS_ERROR;
+  } else {
+    cvm::error("Error: source atom group contains no atoms\".\n", COLVARS_INPUT_ERROR);
+    return COLVARS_ERROR;
+  }
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::add_index_group(std::string const &index_group_name, bool silent) {
+  std::vector<std::string> const &index_group_names =
+    cvm::main()->index_group_names;
+  std::vector<std::vector<int> *> const &index_groups =
+    cvm::main()->index_groups;
+  size_t i_group = 0;
+  for ( ; i_group < index_groups.size(); i_group++) {
+    if (index_group_names[i_group] == index_group_name)
+      break;
+  }
+  if (i_group >= index_group_names.size()) {
+    if (silent)
+      return COLVARS_INPUT_ERROR;
+    else
+      return cvm::error("Error: could not find index group "+
+                      index_group_name+" among those already provided.\n",
+                      COLVARS_INPUT_ERROR);
+  }
+
+  int error_code = COLVARS_OK;
+
+  std::vector<int> const &index_group = *(index_groups[i_group]);
+
+  m_atoms_ids.reserve(m_atoms_ids.size()+index_group.size());
+
+  if (m_ag->is_enabled(f_ag_scalable)) {
+    for (size_t i = 0; i < index_group.size(); i++) {
+      error_code |= add_atom_id((cvm::proxy)->check_atom_id(index_group[i]));
+    }
+  } else {
+    m_atoms.reserve(m_atoms.size()+index_group.size());
+    colvarproxy* const p = cvm::main()->proxy;
+    for (size_t i = 0; i < index_group.size(); i++) {
+      // error_code |= add_atom(cvm::atom(index_group[i]));
+      error_code |= add_atom(init_atom_from_proxy(p, index_group[i]));
+    }
+  }
+
+  return error_code;
+}
+
+int cvm::atom_group_soa::atom_modifier::add_atom_numbers_range(std::string const &range_conf) {
+  if (range_conf.size()) {
+    std::istringstream is(range_conf);
+    int initial, final;
+    char dash;
+    if ( (is >> initial) && (initial > 0) &&
+         (is >> dash) && (dash == '-') &&
+         (is >> final) && (final > 0) ) {
+
+      m_atoms_ids.reserve(m_atoms_ids.size() + (final - initial + 1));
+
+      if (m_ag->is_enabled(f_ag_scalable)) {
+        for (int anum = initial; anum <= final; anum++) {
+          add_atom_id((cvm::proxy)->check_atom_id(anum));
+        }
+      } else {
+        m_atoms.reserve(m_atoms.size() + (final - initial + 1));
+        colvarproxy* const p = cvm::main()->proxy;
+        for (int anum = initial; anum <= final; anum++) {
+          // add_atom(cvm::atom(anum));
+          add_atom(init_atom_from_proxy(p, anum));
+        }
+      }
+
+    }
+    if (cvm::get_error()) return COLVARS_ERROR;
+  } else {
+    cvm::error("Error: no valid definition for \"atomNumbersRange\", \""+
+               range_conf+"\".\n", COLVARS_INPUT_ERROR);
+    return COLVARS_ERROR;
+  }
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::add_atom_name_residue_range(
+  std::string const &psf_segid,
+  std::string const &range_conf) {
+  if (range_conf.size()) {
+    std::istringstream is(range_conf);
+    std::string atom_name;
+    int initial, final;
+    char dash;
+    if ( (is >> atom_name) && (atom_name.size())  &&
+         (is >> initial) && (initial > 0) &&
+         (is >> dash) && (dash == '-') &&
+         (is >> final) && (final > 0) ) {
+
+      m_atoms_ids.reserve(m_atoms_ids.size() + (final - initial + 1));
+
+      if (m_ag->is_enabled(f_ag_scalable)) {
+        for (int resid = initial; resid <= final; resid++) {
+          add_atom_id((cvm::proxy)->check_atom_id(resid, atom_name, psf_segid));
+        }
+      } else {
+        m_atoms.reserve(m_atoms.size() + (final - initial + 1));
+        colvarproxy* const p = cvm::main()->proxy;
+        for (int resid = initial; resid <= final; resid++) {
+          // add_atom(cvm::atom(resid, atom_name, psf_segid));
+          add_atom(init_atom_from_proxy(p, resid, atom_name, psf_segid));
+        }
+      }
+
+      if (cvm::get_error()) return COLVARS_ERROR;
+    } else {
+      cvm::error("Error: cannot parse definition for \""
+                 "atomNameResidueRange\", \""+
+                 range_conf+"\".\n");
+      return COLVARS_ERROR;
+    }
+  } else {
+    cvm::error("Error: atomNameResidueRange with empty definition.\n");
+    return COLVARS_ERROR;
+  }
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::from_aos(std::vector<simple_atom> const &atoms_in) {
+  colvarproxy* const p = cvm::main()->proxy;
+  m_atoms_ids.reserve(m_atoms_ids.size() + atoms_in.size());
+  m_atoms.reserve(m_atoms.size() + atoms_in.size());
+  int error_code = COLVARS_OK;
+  for (size_t i = 0; i < atoms_in.size(); ++i) {
+    // TODO: Is this correct?
+    p->increase_refcount(atoms_in[i].proxy_index);
+    error_code |= add_atom(atoms_in[i]);
+  }
+  return error_code;
+}
+
+void cvm::atom_group_soa::clear_soa() {
+  // Manually run cvm::atom::~atom()
+  for (size_t i = 0; i < atoms_index.size(); ++i) {
+    (cvm::main()->proxy)->clear_atom(atoms_index[i]);
+  }
+  // Then clear all arrays in SOA
+  std::fill(atoms_index.begin(), atoms_index.end(), 0);
+  std::fill(atoms_pos.begin(), atoms_pos.end(), 0);
+  std::fill(atoms_charge.begin(), atoms_charge.end(), 0);
+  std::fill(atoms_vel.begin(), atoms_vel.end(), 0);
+  std::fill(atoms_mass.begin(), atoms_mass.end(), 0);
+  std::fill(atoms_grad.begin(), atoms_grad.end(), 0);
+  std::fill(atoms_total_force.begin(), atoms_total_force.end(), 0);
+  // Reset the number of atoms
+  num_atoms = 0;
+  // Other fields should be untouched
+}
+
+int cvm::atom_group_soa::parse(std::string const &group_conf)
+{
+  cvm::log("Initializing atom group \""+key+"\".\n");
+
+  // whether or not to include messages in the log
+  // colvarparse::Parse_Mode mode = parse_silent;
+  // {
+  //   bool b_verbose;
+  //   get_keyval (group_conf, "verboseOutput", b_verbose, false, parse_silent);
+  //   if (b_verbose) mode = parse_normal;
+  // }
+  // colvarparse::Parse_Mode mode = parse_normal;
+
+  int error_code = COLVARS_OK;
+
+  // Optional group name will let other groups reuse atom definition
+  if (get_keyval(group_conf, "name", name)) {
+    if ((cvm::atom_group_soa_by_name(this->name) != NULL) &&
+        (cvm::atom_group_soa_by_name(this->name) != this)) {
+      cvm::error("Error: this atom group cannot have the same name, \""+this->name+
+                        "\", as another atom group.\n",
+                COLVARS_INPUT_ERROR);
+      return COLVARS_INPUT_ERROR;
+    }
+    cvm::main()->register_named_atom_group_soa(this);
+    description = "atom group " + name;
+  }
+
+  // We need to know about fitting to decide whether the group is scalable
+  // and we need to know about scalability before adding atoms
+  bool b_defined_center = get_keyval_feature(this, group_conf, "centerToOrigin", f_ag_center_origin, false);
+  // Legacy alias
+  b_defined_center |= get_keyval_feature(this, group_conf, "centerReference", f_ag_center, is_enabled(f_ag_center_origin), parse_deprecated);
+  b_defined_center |= get_keyval_feature(this, group_conf, "centerToReference", f_ag_center, is_enabled(f_ag_center));
+
+  if (is_enabled(f_ag_center_origin) && ! is_enabled(f_ag_center)) {
+    return cvm::error("centerToReference may not be disabled if centerToOrigin"
+                      "is enabled.\n", COLVARS_INPUT_ERROR);
+  }
+  // Legacy alias
+  bool b_defined_rotate = get_keyval_feature(this, group_conf, "rotateReference", f_ag_rotate, false, parse_deprecated);
+  b_defined_rotate |= get_keyval_feature(this, group_conf, "rotateToReference", f_ag_rotate, is_enabled(f_ag_rotate));
+
+  if (is_enabled(f_ag_rotate) || is_enabled(f_ag_center) ||
+      is_enabled(f_ag_center_origin)) {
+    cvm::main()->cite_feature("Moving frame of reference");
+  }
+
+  // is the user setting explicit options?
+  b_user_defined_fit = b_defined_center || b_defined_rotate;
+
+  if (is_available(f_ag_scalable_com) && !is_enabled(f_ag_rotate) && !is_enabled(f_ag_center)) {
+    enable(f_ag_scalable_com);
+  }
+
+  {
+    std::string atoms_of = "";
+    if (get_keyval(group_conf, "atomsOfGroup", atoms_of)) {
+      atom_group_soa * ag = atom_group_soa_by_name(atoms_of);
+      if (ag == NULL) {
+        cvm::error("Error: cannot find atom group with name " + atoms_of + ".\n");
+        return COLVARS_ERROR;
+      }
+      auto modify_atoms = get_atom_modifier();
+      error_code |= modify_atoms.add_atoms_of_group(ag);
+    }
+  }
+
+//   if (get_keyval(group_conf, "copyOfGroup", source)) {
+//     // Goal: Initialize this as a full copy
+//     // for this we'll need an atom_group copy constructor
+//     return COLVARS_OK;
+//   }
+
+  {
+    std::string numbers_conf = "";
+    size_t pos = 0;
+    while (key_lookup(group_conf, "atomNumbers", &numbers_conf, &pos)) {
+      auto modify_atoms = get_atom_modifier();
+      error_code |= modify_atoms.add_atom_numbers(numbers_conf);
+      numbers_conf = "";
+    }
+  }
+
+  {
+    std::string index_group_name;
+    if (get_keyval(group_conf, "indexGroup", index_group_name)) {
+      // use an index group from the index file read globally
+      auto modify_atoms = get_atom_modifier();
+      error_code |= modify_atoms.add_index_group(index_group_name);
+    }
+  }
+
+  {
+    std::string range_conf = "";
+    size_t pos = 0;
+    while (key_lookup(group_conf, "atomNumbersRange",
+                      &range_conf, &pos)) {
+      auto modify_atoms = get_atom_modifier();
+      error_code |= modify_atoms.add_atom_numbers_range(range_conf);
+      range_conf = "";
+    }
+  }
+
+  {
+    std::vector<std::string> psf_segids;
+    get_keyval(group_conf, "psfSegID", psf_segids, std::vector<std::string>());
+    std::vector<std::string>::iterator psii;
+    for (psii = psf_segids.begin(); psii < psf_segids.end(); ++psii) {
+      if ( (psii->size() == 0) || (psii->size() > 4) ) {
+        cvm::error("Error: invalid PSF segment identifier provided, \""+
+                   (*psii)+"\".\n", COLVARS_INPUT_ERROR);
+      }
+    }
+
+    std::string range_conf = "";
+    size_t pos = 0;
+    size_t range_count = 0;
+    psii = psf_segids.begin();
+    while (key_lookup(group_conf, "atomNameResidueRange",
+                      &range_conf, &pos)) {
+      range_count++;
+      if (psf_segids.size() && (range_count > psf_segids.size())) {
+        cvm::error("Error: more instances of \"atomNameResidueRange\" than "
+                   "values of \"psfSegID\".\n", COLVARS_INPUT_ERROR);
+      } else {
+        auto modify_atoms = get_atom_modifier();
+        error_code |= modify_atoms.add_atom_name_residue_range(psf_segids.size() ?
+          *psii : std::string(""), range_conf);
+        if (psf_segids.size()) psii++;
+      }
+      range_conf = "";
+    }
+  }
+
+  {
+    // read the atoms from a file
+    std::string atoms_file_name;
+    if (get_keyval(group_conf, "atomsFile", atoms_file_name, std::string(""))) {
+
+      std::string atoms_col;
+      if (!get_keyval(group_conf, "atomsCol", atoms_col, std::string(""))) {
+        cvm::error("Error: parameter atomsCol is required if atomsFile is set.\n",
+                   COLVARS_INPUT_ERROR);
+      }
+
+      double atoms_col_value;
+      bool const atoms_col_value_defined = get_keyval(group_conf, "atomsColValue", atoms_col_value, 0.0);
+      if (atoms_col_value_defined && (!atoms_col_value)) {
+        cvm::error("Error: atomsColValue, if provided, must be non-zero.\n", COLVARS_INPUT_ERROR);
+      }
+
+      error_code |= cvm::main()->proxy->load_atoms_pdb(atoms_file_name.c_str(), *this, atoms_col,
+                                                       atoms_col_value);
+    }
+  }
+
+  // Catch any errors from all the initialization steps above
+  if (error_code || cvm::get_error()) return (error_code || cvm::get_error());
+
+  // checks of doubly-counted atoms have been handled by add_atom() already
+
+  if (get_keyval(group_conf, "dummyAtom", dummy_atom_pos, cvm::atom_pos())) {
+
+    error_code |= set_dummy();
+    error_code |= set_dummy_pos(dummy_atom_pos);
+
+  } else {
+
+    if (!(atoms_ids.size())) {
+      error_code |= cvm::error("Error: no atoms defined for atom group \"" + key + "\".\n",
+                               COLVARS_INPUT_ERROR);
+    }
+
+    // whether these atoms will ever receive forces or not
+    bool enable_forces = true;
+    get_keyval(group_conf, "enableForces", enable_forces, true, colvarparse::parse_silent);
+    noforce = !enable_forces;
+  }
+
+  // Now that atoms are defined we can parse the detailed fitting options
+  error_code |= parse_fitting_options(group_conf);
+
+  if (is_enabled(f_ag_scalable) && !b_dummy) {
+    cvm::log("Enabling scalable calculation for group \""+this->key+"\".\n");
+    index = (cvm::proxy)->init_atom_group(atoms_ids);
+  }
+
+  bool b_print_atom_ids = false;
+  get_keyval(group_conf, "printAtomIDs", b_print_atom_ids, false);
+
+  // Calculate all required properties (such as total mass)
+  setup();
+
+  if (cvm::debug())
+    cvm::log("Done initializing atom group \""+key+"\".\n");
+
+  {
+    std::string init_msg;
+    init_msg.append("Atom group \""+key+"\" defined with "+
+                    cvm::to_str(atoms_ids.size())+" atoms requested");
+    if ((cvm::proxy)->updated_masses()) {
+      init_msg.append(": total mass = "+
+                      cvm::to_str(total_mass));
+      if ((cvm::proxy)->updated_charges()) {
+        init_msg.append(", total charge = "+
+                        cvm::to_str(total_charge));
+      }
+    }
+    init_msg.append(".\n");
+    cvm::log(init_msg);
+  }
+
+  if (b_print_atom_ids) {
+    cvm::log("Internal definition of the atom group:\n");
+    cvm::log(print_atom_ids());
+  }
+
+  if (is_enabled(f_ag_rotate)) setup_rotation_derivative();
+
+  return error_code;
+}
+
+int cvm::atom_group_soa::parse_fitting_options(std::string const &group_conf) {
+  if (is_enabled(f_ag_center) || is_enabled(f_ag_rotate)) {
+
+    if (b_dummy)
+      cvm::error("Error: centerToReference or rotateToReference "
+                 "cannot be defined for a dummy atom.\n");
+
+    bool b_ref_pos_group = false;
+    std::string fitting_group_conf;
+    if (key_lookup(group_conf, "refPositionsGroup", &fitting_group_conf)) {
+      b_ref_pos_group = true;
+      cvm::log("Warning: keyword \"refPositionsGroup\" is deprecated: please use \"fittingGroup\" instead.\n");
+    }
+
+    if (b_ref_pos_group || key_lookup(group_conf, "fittingGroup", &fitting_group_conf)) {
+      // instead of this group, define another group to compute the fit
+      if (fitting_group) {
+        cvm::error("Error: the atom group \""+
+                   key+"\" has already a reference group "
+                   "for the rototranslational fit, which was communicated by the "
+                   "colvar component.  You should not use fittingGroup "
+                   "in this case.\n", COLVARS_INPUT_ERROR);
+        return COLVARS_INPUT_ERROR;
+      }
+      cvm::log("Within atom group \""+key+"\":\n");
+      fitting_group = new atom_group_soa("fittingGroup");
+      if (fitting_group->parse(fitting_group_conf) == COLVARS_OK) {
+        fitting_group->check_keywords(fitting_group_conf, "fittingGroup");
+        if (cvm::get_error()) {
+          cvm::error("Error setting up atom group \"fittingGroup\".", COLVARS_INPUT_ERROR);
+          return COLVARS_INPUT_ERROR;
+        }
+      }
+      enable(f_ag_fitting_group);
+    }
+
+    atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+
+    std::vector<cvm::atom_pos> ref_pos_aos;
+    get_keyval(group_conf, "refPositions", ref_pos_aos, ref_pos_aos);
+
+    std::string ref_pos_file;
+    if (get_keyval(group_conf, "refPositionsFile", ref_pos_file, std::string(""))) {
+
+      if (ref_pos_aos.size()) {
+        cvm::error("Error: cannot specify \"refPositionsFile\" and "
+                   "\"refPositions\" at the same time.\n");
+      }
+
+      std::string ref_pos_col;
+      double ref_pos_col_value=0.0;
+
+      if (get_keyval(group_conf, "refPositionsCol", ref_pos_col, std::string(""))) {
+        // if provided, use PDB column to select coordinates
+        bool found = get_keyval(group_conf, "refPositionsColValue", ref_pos_col_value, 0.0);
+        if (found && ref_pos_col_value == 0.0) {
+          cvm::error("Error: refPositionsColValue, "
+                     "if provided, must be non-zero.\n", COLVARS_INPUT_ERROR);
+          return COLVARS_ERROR;
+        }
+      }
+
+      ref_pos_aos.resize(group_for_fit->size());
+      cvm::load_coords(ref_pos_file.c_str(), &ref_pos_aos, group_for_fit,
+                       ref_pos_col, ref_pos_col_value);
+    }
+
+    if (ref_pos_aos.size()) {
+
+      if (is_enabled(f_ag_rotate)) {
+        if (ref_pos_aos.size() != group_for_fit->size())
+          cvm::error("Error: the number of reference positions provided("+
+                     cvm::to_str(ref_pos_aos.size())+
+                     ") does not match the number of atoms within \""+
+                     key+
+                     "\" ("+cvm::to_str(group_for_fit->size())+
+                     "): to perform a rotational fit, "+
+                     "these numbers should be equal.\n", COLVARS_INPUT_ERROR);
+      }
+
+      // Convert ref_pos_aos to SOA
+      num_ref_pos = ref_pos_aos.size();
+      ref_pos.resize(3 * num_ref_pos);
+      for (size_t i = 0; i < num_ref_pos; ++i) {
+        ref_pos_x(i) = ref_pos_aos[i].x;
+        ref_pos_y(i) = ref_pos_aos[i].y;
+        ref_pos_z(i) = ref_pos_aos[i].z;
+      }
+      // save the center of geometry of ref_pos and subtract it
+      center_ref_pos();
+
+    } else {
+      cvm::error("Error: no reference positions provided.\n", COLVARS_INPUT_ERROR);
+      return COLVARS_ERROR;
+    }
+
+    if (is_enabled(f_ag_rotate) && !noforce) {
+      cvm::log("Warning: atom group \""+key+
+               "\" will be aligned to a fixed orientation given by the reference positions provided.  "
+               "If the internal structure of the group changes too much (i.e. its RMSD is comparable "
+               "to its radius of gyration), the optimal rotation and its gradients may become discontinuous.  "
+               "If that happens, use fittingGroup (or a different definition for it if already defined) "
+               "to align the coordinates.\n");
+    }
+  }
+
+  // Enable fit gradient calculation only if necessary, and not disabled by the user
+  // This must happen after fitting group is defined so that side-effects are performed
+  // properly (ie. allocating fitting group gradients)
+  {
+    bool b_fit_gradients;
+    get_keyval(group_conf, "enableFitGradients", b_fit_gradients, true);
+
+    if (b_fit_gradients && (is_enabled(f_ag_center) || is_enabled(f_ag_rotate))) {
+      enable(f_ag_fit_gradients);
+    }
+  }
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::atom_modifier::add_atom_id(int aid) {
+  if (aid < 0) {
+    return COLVARS_ERROR;
+  }
+
+  // for (size_t i = 0; i < m_atoms_ids.size(); i++) {
+  //   if (m_atoms_ids[i] == aid) {
+  //     if (cvm::debug())
+  //       cvm::log("Discarding doubly counted atom with number "+
+  //                cvm::to_str(aid+1)+".\n");
+  //     return COLVARS_OK;
+  //   }
+  // }
+  auto map_it = m_atoms_ids_count.find(aid);
+  if (map_it != m_atoms_ids_count.end()) {
+    if (cvm::debug()) {
+      cvm::log("Discarding doubly counted atom with number "+
+              cvm::to_str(aid+1)+".\n");
+    }
+    map_it->second++;
+    return COLVARS_OK;
+  } else {
+    m_atoms_ids_count[aid] = 1;
+  }
+
+  m_atoms_ids.push_back(aid);
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::set_dummy()
+{
+  if (atoms_ids.size() > 0) {
+    return cvm::error("Error: setting group with keyword \""+key+
+                      "\" and name \""+name+"\" as dummy, but it already "
+                      "contains atoms.\n", COLVARS_INPUT_ERROR);
+  }
+  b_dummy = true;
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::set_dummy_pos(cvm::atom_pos const &pos) {
+  if (b_dummy) {
+    dummy_atom_pos = pos;
+  } else {
+    return cvm::error("Error: setting dummy position for group with keyword \""+
+                      key+"\" and name \""+name+
+                      "\", but it is not dummy.\n", COLVARS_INPUT_ERROR);
+  }
+  return COLVARS_OK;
+}
+
+void cvm::atom_group_soa::update_total_mass() {
+  if (b_dummy) {
+    total_mass = 1.0;
+    return;
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    total_mass = (cvm::main()->proxy)->get_atom_group_mass(index);
+  } else {
+    // total_mass = 0.0
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   total_mass += ai->mass;
+    // }
+    total_mass = std::accumulate(atoms_mass.begin(), atoms_mass.end(), 0.0f);
+  }
+  if (total_mass < 1e-15) {
+    cvm::error("ERROR: " + description + " has zero total mass.\n");
+  }
+}
+
+void cvm::atom_group_soa::update_total_charge() {
+  if (b_dummy) {
+    total_charge = 0.0;
+    return;
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    total_charge = (cvm::main()->proxy)->get_atom_group_charge(index);
+  } else {
+    // total_charge = 0.0;
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   total_charge += ai->charge;
+    // }
+    total_charge = std::accumulate(atoms_charge.begin(), atoms_charge.end(), 0.0f);
+  }
+}
+
+void cvm::atom_group_soa::print_properties(std::string const &colvar_name, int i, int j) {
+  if (cvm::proxy->updated_masses() && cvm::proxy->updated_charges()) {
+    cvm::log("Re-initialized atom group for variable \""+colvar_name+"\":"+
+             cvm::to_str(i)+"/"+
+             cvm::to_str(j)+". "+ cvm::to_str(atoms_ids.size())+
+             " atoms: total mass = "+cvm::to_str(total_mass)+
+             ", total charge = "+cvm::to_str(total_charge)+".\n");
+  }
+}
+
+std::string const cvm::atom_group_soa::print_atom_ids() const {
+  size_t line_count = 0;
+  std::ostringstream os("");
+  for (size_t i = 0; i < atoms_ids.size(); i++) {
+    os << " " << std::setw(9) << atoms_ids[i];
+    if (++line_count == 7) {
+      os << "\n";
+      line_count = 0;
+    }
+  }
+  return os.str();
+}
+
+int cvm::atom_group_soa::create_sorted_ids()
+{
+  // Only do the work if the vector is not yet populated
+  if (sorted_atoms_ids.size())
+    return COLVARS_OK;
+
+  // Sort the internal IDs
+  std::list<int> sorted_atoms_ids_list(atoms_ids.begin(), atoms_ids.end());
+  // for (size_t i = 0; i < atoms_ids.size(); i++) {
+  //   sorted_atoms_ids_list.push_back(atoms_ids[i]);
+  // }
+  sorted_atoms_ids_list.sort();
+  sorted_atoms_ids_list.unique();
+  if (sorted_atoms_ids_list.size() != atoms_ids.size()) {
+    return cvm::error("Error: duplicate atom IDs in atom group? (found " +
+                      cvm::to_str(sorted_atoms_ids_list.size()) +
+                      " unique atom IDs instead of " +
+                      cvm::to_str(atoms_ids.size()) + ").\n", COLVARS_BUG_ERROR);
+  }
+
+  // Compute map between sorted and unsorted elements
+  sorted_atoms_ids.resize(atoms_ids.size());
+  sorted_atoms_ids_map.resize(atoms_ids.size());
+  std::list<int>::iterator lsii = sorted_atoms_ids_list.begin();
+  size_t ii = 0;
+  for ( ; ii < atoms_ids.size(); lsii++, ii++) {
+    sorted_atoms_ids[ii] = *lsii;
+    size_t const pos = std::find(atoms_ids.begin(), atoms_ids.end(), *lsii) -
+      atoms_ids.begin();
+    sorted_atoms_ids_map[ii] = pos;
+  }
+
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::overlap(const atom_group_soa &g1, const atom_group_soa &g2) {
+  // for (cvm::atom_const_iter ai1 = g1.begin(); ai1 != g1.end(); ai1++) {
+  //   for (cvm::atom_const_iter ai2 = g2.begin(); ai2 != g2.end(); ai2++) {
+  //     if (ai1->id == ai2->id) {
+  //       return (ai1->id + 1); // 1-based index to allow boolean usage
+  //     }
+  //   }
+  // }
+  for (auto ai1 = g1.atoms_ids.cbegin(); ai1 != g1.atoms_ids.cend(); ++ai1) {
+    for (auto ai2 = g2.atoms_ids.cbegin(); ai2 != g2.atoms_ids.cend(); ++ai2) {
+      if ((*ai1) == (*ai2)) {
+        return (*ai1) + 1; // 1-based index to allow boolean usage
+      }
+    }
+  }
+  return 0;
+}
+
+void cvm::atom_group_soa::read_positions()
+{
+  if (b_dummy) return;
+
+  // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+  //   ai->read_position();
+  // }
+  // TODO: Should I check if this group is scalable?
+  if (!is_enabled(f_ag_scalable)) {
+    colvarproxy *p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      const cvm::rvector pos = p->get_atom_position(proxy_index);
+      pos_x(i) = pos.x;
+      pos_y(i) = pos.y;
+      pos_z(i) = pos.z;
+    }
+  }
+
+  if (fitting_group)
+    fitting_group->read_positions();
+}
+
+void cvm::atom_group_soa::calc_apply_roto_translation()
+{
+  // store the laborarory-frame COGs for when they are needed later
+  cog_orig = this->center_of_geometry();
+  if (fitting_group) {
+    fitting_group->cog_orig = fitting_group->center_of_geometry();
+  }
+
+  if (is_enabled(f_ag_center)) {
+    // center on the origin first
+    cvm::atom_pos const rpg_cog = fitting_group ?
+      fitting_group->center_of_geometry() : this->center_of_geometry();
+    apply_translation(-1.0 * rpg_cog);
+    if (fitting_group) {
+      fitting_group->apply_translation(-1.0 * rpg_cog);
+    }
+  }
+
+  if (is_enabled(f_ag_fit_gradients) && !b_dummy) {
+    // Save the unrotated frame for fit gradients
+    // pos_unrotated.resize(size());
+    // for (size_t i = 0; i < size(); ++i) {
+    //   pos_unrotated[i] = atoms[i].pos;
+    // }
+    atoms_pos_unrotated = atoms_pos;
+  }
+
+  if (is_enabled(f_ag_rotate)) {
+    // rotate the group (around the center of geometry if f_ag_center is
+    // enabled, around the origin otherwise)
+    auto* group_for_fit = fitting_group ? fitting_group : this;
+    rot.calc_optimal_rotation_soa(
+      group_for_fit->atoms_pos, ref_pos,
+      group_for_fit->size(), num_ref_pos);
+    const auto rot_mat = rot.matrix();
+
+    // cvm::atom_iter ai;
+    // for (ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->pos = rot_mat * ai->pos;
+    // }
+    // if (fitting_group) {
+    //   for (ai = fitting_group->begin(); ai != fitting_group->end(); ai++) {
+    //     ai->pos = rot_mat * ai->pos;
+    //   }
+    // }
+    this->rotate(rot_mat);
+    if (fitting_group/* && (fitting_group != this)*/) {
+      // TODO: Should I check if fitting_group != this
+      fitting_group->rotate(rot_mat);
+    }
+  }
+
+  if (is_enabled(f_ag_center) && !is_enabled(f_ag_center_origin)) {
+    // align with the center of geometry of ref_pos
+    apply_translation(ref_pos_cog);
+    if (fitting_group) {
+      fitting_group->apply_translation(ref_pos_cog);
+    }
+  }
+  // update of COM and COG is done from the calling routine
+}
+
+void cvm::atom_group_soa::setup_rotation_derivative() {
+  if (rot_deriv != nullptr) delete rot_deriv;
+  auto* group_for_fit = fitting_group ? fitting_group : this;
+  rot_deriv = new rotation_derivative<cvm::real, cvm::real, true>(
+    rot, group_for_fit->atoms_pos, ref_pos,
+    group_for_fit->size(), num_ref_pos
+  );
+}
+
+void cvm::atom_group_soa::center_ref_pos()
+{
+  ref_pos_cog = cvm::atom_pos(0.0, 0.0, 0.0);
+  // std::vector<cvm::atom_pos>::iterator pi;
+  // for (pi = ref_pos.begin(); pi != ref_pos.end(); ++pi) {
+  //   ref_pos_cog += *pi;
+  // }
+  // ref_pos_cog /= (cvm::real) ref_pos.size();
+  // for (pi = ref_pos.begin(); pi != ref_pos.end(); ++pi) {
+  //   (*pi) -= ref_pos_cog;
+  // }
+  for (size_t i = 0; i < num_ref_pos; ++i) {
+    ref_pos_cog.x += ref_pos_x(i);
+    ref_pos_cog.y += ref_pos_y(i);
+    ref_pos_cog.z += ref_pos_z(i);
+  }
+  ref_pos_cog /= num_ref_pos;
+  for (size_t i = 0; i < num_ref_pos; ++i) {
+    ref_pos_x(i) -= ref_pos_cog.x;
+    ref_pos_y(i) -= ref_pos_cog.y;
+    ref_pos_z(i) -= ref_pos_cog.z;
+  }
+}
+
+void cvm::atom_group_soa::rotate(const cvm::rmatrix& rot_mat) {
+  for (size_t i = 0; i < num_atoms; ++i) {
+    const cvm::real new_x = rot_mat.xx * pos_x(i) + rot_mat.xy * pos_y(i) + rot_mat.xz * pos_z(i);
+    const cvm::real new_y = rot_mat.yx * pos_x(i) + rot_mat.yy * pos_y(i) + rot_mat.yz * pos_z(i);
+    const cvm::real new_z = rot_mat.zx * pos_x(i) + rot_mat.zy * pos_y(i) + rot_mat.zz * pos_z(i);
+    pos_x(i) = new_x;
+    pos_y(i) = new_y;
+    pos_z(i) = new_z;
+  }
+}
+
+void cvm::atom_group_soa::apply_translation(cvm::rvector const &t)
+{
+  if (b_dummy) {
+    cvm::error("Error: cannot translate the coordinates of a dummy atom group.\n", COLVARS_INPUT_ERROR);
+    return;
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    cvm::error("Error: cannot translate the coordinates of a scalable atom group.\n", COLVARS_INPUT_ERROR);
+    return;
+  }
+
+  // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+  //   ai->pos += t;
+  // }
+  for (size_t i = 0; i < num_atoms; ++i) {
+    pos_x(i) += t.x;
+    pos_y(i) += t.y;
+    pos_z(i) += t.z;
+  }
+}
+
+void cvm::atom_group_soa::read_velocities()
+{
+  if (b_dummy) return;
+
+  if (is_enabled(f_ag_rotate)) {
+
+    const auto rot_mat = rot.matrix();
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->read_velocity();
+    //   ai->vel = rot_mat * ai->vel;
+    // }
+    colvarproxy *p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      const cvm::rvector vel = p->get_atom_velocity(proxy_index);
+      vel_x(i) = rot_mat.xx * vel.x + rot_mat.xy * vel.y + rot_mat.xz * vel.z;
+      vel_y(i) = rot_mat.yx * vel.x + rot_mat.yy * vel.y + rot_mat.yz * vel.z;
+      vel_z(i) = rot_mat.zx * vel.x + rot_mat.zy * vel.y + rot_mat.zz * vel.z;
+    }
+
+  } else {
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->read_velocity();
+    // }
+    colvarproxy *p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      const cvm::rvector vel = p->get_atom_velocity(proxy_index);
+      vel_x(i) = vel.x;
+      vel_y(i) = vel.y;
+      vel_z(i) = vel.z;
+    }
+  }
+}
+
+void cvm::atom_group_soa::read_total_forces()
+{
+  if (b_dummy) return;
+
+  if (is_enabled(f_ag_rotate)) {
+
+    const auto rot_mat = rot.matrix();
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->read_total_force();
+    //   ai->total_force = rot_mat * ai->total_force;
+    // }
+    colvarproxy *p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      const cvm::rvector total_force = p->get_atom_total_force(proxy_index);
+      total_force_x(i) = rot_mat.xx * total_force.x +
+                         rot_mat.xy * total_force.y +
+                         rot_mat.xz * total_force.z;
+      total_force_y(i) = rot_mat.yx * total_force.x +
+                         rot_mat.yy * total_force.y +
+                         rot_mat.yz * total_force.z;
+      total_force_z(i) = rot_mat.zx * total_force.x +
+                         rot_mat.zy * total_force.y +
+                         rot_mat.zz * total_force.z;
+    }
+
+  } else {
+
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->read_total_force();
+    // }
+    colvarproxy *p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      const cvm::rvector total_force = p->get_atom_total_force(proxy_index);
+      total_force_x(i) = total_force.x;
+      total_force_y(i) = total_force.y;
+      total_force_z(i) = total_force.z;
+    }
+  }
+}
+
+int cvm::atom_group_soa::calc_required_properties()
+{
+  // TODO check if the com is needed?
+  calc_center_of_mass();
+  calc_center_of_geometry();
+
+  if (!is_enabled(f_ag_scalable)) {
+    if (is_enabled(f_ag_center) || is_enabled(f_ag_rotate)) {
+      if (fitting_group) {
+        fitting_group->calc_center_of_geometry();
+      }
+
+      calc_apply_roto_translation();
+
+      // update COM and COG after fitting
+      calc_center_of_geometry();
+      calc_center_of_mass();
+      if (fitting_group) {
+        fitting_group->calc_center_of_geometry();
+      }
+    }
+  }
+
+  // TODO calculate elements of scalable cvc's here before reduction
+
+  return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);
+}
+
+int cvm::atom_group_soa::calc_center_of_geometry()
+{
+  if (b_dummy) {
+    cog = dummy_atom_pos;
+  } else {
+    cog.reset();
+    // for (cvm::atom_const_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   cog += ai->pos;
+    // }
+    for (size_t i = 0; i < num_atoms; ++i) {
+      cog.x += pos_x(i);
+      cog.y += pos_y(i);
+      cog.z += pos_z(i);
+    }
+    cog /= cvm::real(this->size());
+  }
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::calc_center_of_mass()
+{
+  if (b_dummy) {
+    com = dummy_atom_pos;
+    if (cvm::debug()) {
+      cvm::log("Dummy atom center of mass = "+cvm::to_str(com)+"\n");
+    }
+  } else if (is_enabled(f_ag_scalable)) {
+    com = (cvm::proxy)->get_atom_group_com(index);
+  } else {
+    com.reset();
+    // for (cvm::atom_const_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   com += ai->mass * ai->pos;
+    // }
+    for (size_t i = 0; i < num_atoms; ++i) {
+      com.x += atoms_mass[i] * pos_x(i);
+      com.y += atoms_mass[i] * pos_y(i);
+      com.z += atoms_mass[i] * pos_z(i);
+    }
+    com /= total_mass;
+  }
+  return COLVARS_OK;
+}
+
+int cvm::atom_group_soa::calc_dipole(cvm::atom_pos const &dipole_center)
+{
+  if (b_dummy) {
+    return cvm::error("Error: trying to compute the dipole "
+                      "of a dummy group.\n", COLVARS_INPUT_ERROR);
+  }
+  dip.reset();
+  // for (cvm::atom_const_iter ai = this->begin(); ai != this->end(); ai++) {
+  //   dip += ai->charge * (ai->pos - dipole_center);
+  // }
+  for (size_t i = 0; i < num_atoms; ++i) {
+    dip.x += atoms_charge[i] * (pos_x(i) - dipole_center.x);
+    dip.y += atoms_charge[i] * (pos_y(i) - dipole_center.y);
+    dip.z += atoms_charge[i] * (pos_z(i) - dipole_center.z);
+  }
+  return COLVARS_OK;
+}
+
+void cvm::atom_group_soa::set_weighted_gradient(cvm::rvector const &grad)
+{
+  if (b_dummy) return;
+
+  scalar_com_gradient = grad;
+
+  if (!is_enabled(f_ag_scalable)) {
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->grad = (ai->mass/total_mass) * grad;
+    // }
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const double factor = atoms_mass[i]/total_mass;
+      grad_x(i) = factor * grad.x;
+      grad_y(i) = factor * grad.y;
+      grad_z(i) = factor * grad.z;
+    }
+  }
+}
+
+void cvm::atom_group_soa::calc_fit_gradients()
+{
+  if (b_dummy || ! is_enabled(f_ag_fit_gradients)) return;
+
+  if (cvm::debug())
+    cvm::log("Calculating fit gradients.\n");
+
+  cvm::atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+
+  auto accessor_main = [this](size_t i){
+    // return atoms[i].grad;
+    return cvm::rvector{grad_x(i), grad_y(i), grad_z(i)};
+  };
+  auto accessor_fitting = [&group_for_fit](size_t j, const cvm::rvector& grad){
+    // group_for_fit->fit_gradients[j] = grad;
+    group_for_fit->fit_gradients_x(j) = grad.x;
+    group_for_fit->fit_gradients_y(j) = grad.y;
+    group_for_fit->fit_gradients_z(j) = grad.z;
+  };
+  if (is_enabled(f_ag_center) && is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<true, true>(accessor_main, accessor_fitting);
+  if (is_enabled(f_ag_center) && !is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<true, false>(accessor_main, accessor_fitting);
+  if (!is_enabled(f_ag_center) && is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<false, true>(accessor_main, accessor_fitting);
+  if (!is_enabled(f_ag_center) && !is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<false, false>(accessor_main, accessor_fitting);
+
+  if (cvm::debug())
+    cvm::log("Done calculating fit gradients.\n");
+}
+
+template <bool B_ag_center, bool B_ag_rotate,
+          typename main_force_accessor_T, typename fitting_force_accessor_T>
+void cvm::atom_group_soa::calc_fit_forces_impl(
+  main_force_accessor_T accessor_main,
+  fitting_force_accessor_T accessor_fitting) const {
+  const cvm::atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+  // the center of geometry contribution to the gradients
+  cvm::rvector atom_grad;
+  // the rotation matrix contribution to the gradients
+  const auto rot_inv = rot.inverse().matrix();
+  // temporary variables for computing and summing derivatives
+  cvm::real sum_dxdq[4] = {0, 0, 0, 0};
+  cvm::vector1d<cvm::rvector> dq0_1(4);
+  // loop 1: iterate over the current atom group
+  for (size_t i = 0; i < size(); i++) {
+    if (B_ag_center) {
+      atom_grad += accessor_main(i);
+    }
+    if (B_ag_rotate) {
+      // calculate \partial(R(q) \vec{x}_i)/\partial q) \cdot \partial\xi/\partial\vec{x}_i
+      cvm::quaternion const dxdq =
+        rot.q.position_derivative_inner(
+          cvm::rvector{pos_unrotated_x(i),
+                       pos_unrotated_y(i),
+                       pos_unrotated_z(i)},
+          accessor_main(i));
+      sum_dxdq[0] += dxdq[0];
+      sum_dxdq[1] += dxdq[1];
+      sum_dxdq[2] += dxdq[2];
+      sum_dxdq[3] += dxdq[3];
+    }
+  }
+  if (B_ag_center) {
+    if (B_ag_rotate) atom_grad = rot_inv * atom_grad;
+    atom_grad *= (-1.0)/(cvm::real(group_for_fit->size()));
+  }
+  // loop 2: iterate over the fitting group
+  if (B_ag_rotate) rot_deriv->prepare_derivative(rotation_derivative_dldq::use_dq);
+  for (size_t j = 0; j < group_for_fit->size(); j++) {
+    cvm::rvector fitting_force_grad{0, 0, 0};
+    if (B_ag_center) {
+      fitting_force_grad += atom_grad;
+    }
+    if (B_ag_rotate) {
+      rot_deriv->calc_derivative_wrt_group1<false, true, false>(j, nullptr, &dq0_1);
+      // multiply by {\partial q}/\partial\vec{x}_j and add it to the fit gradients
+      fitting_force_grad += sum_dxdq[0] * dq0_1[0] +
+                            sum_dxdq[1] * dq0_1[1] +
+                            sum_dxdq[2] * dq0_1[2] +
+                            sum_dxdq[3] * dq0_1[3];
+    }
+    if (cvm::debug()) {
+      cvm::log(cvm::to_str(fitting_force_grad));
+    }
+    accessor_fitting(j, fitting_force_grad);
+  }
+}
+
+template <typename main_force_accessor_T, typename fitting_force_accessor_T>
+void cvm::atom_group_soa::calc_fit_forces(
+  main_force_accessor_T accessor_main,
+  fitting_force_accessor_T accessor_fitting) const {
+  if (is_enabled(f_ag_center) && is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<true, true, main_force_accessor_T, fitting_force_accessor_T>(accessor_main, accessor_fitting);
+  if (is_enabled(f_ag_center) && !is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<true, false, main_force_accessor_T, fitting_force_accessor_T>(accessor_main, accessor_fitting);
+  if (!is_enabled(f_ag_center) && is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<false, true, main_force_accessor_T, fitting_force_accessor_T>(accessor_main, accessor_fitting);
+  if (!is_enabled(f_ag_center) && !is_enabled(f_ag_rotate))
+    calc_fit_forces_impl<false, false, main_force_accessor_T, fitting_force_accessor_T>(accessor_main, accessor_fitting);
+}
+
+std::vector<cvm::real> cvm::atom_group_soa::positions() const
+{
+  if (b_dummy) {
+    cvm::error("Error: positions are not available "
+               "from a dummy atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    cvm::error("Error: atomic positions are not available "
+               "from a scalable atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  // std::vector<cvm::atom_pos> x(this->size(), 0.0);
+  // cvm::atom_const_iter ai = this->begin();
+  // std::vector<cvm::atom_pos>::iterator xi = x.begin();
+  // for ( ; ai != this->end(); ++xi, ++ai) {
+  //   *xi = ai->pos;
+  // }
+  return atoms_pos;
+}
+
+std::vector<cvm::real> cvm::atom_group_soa::positions_shifted(cvm::rvector const &shift) const
+{
+  if (b_dummy) {
+    cvm::error("Error: positions are not available "
+               "from a dummy atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    cvm::error("Error: atomic positions are not available "
+               "from a scalable atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  // std::vector<cvm::atom_pos> x(this->size(), 0.0);
+  // cvm::atom_const_iter ai = this->begin();
+  // std::vector<cvm::atom_pos>::iterator xi = x.begin();
+  // for ( ; ai != this->end(); ++xi, ++ai) {
+  //   *xi = (ai->pos + shift);
+  // }
+  // return x;
+  std::vector<cvm::real> shifted = atoms_pos;
+  for (size_t i = 0; i < num_atoms; ++i) {
+    shifted[i]             += shift.x;
+    shifted[i+num_atoms]   += shift.y;
+    shifted[i+2*num_atoms] += shift.z;
+  }
+  return shifted;
+}
+
+std::vector<cvm::real> cvm::atom_group_soa::velocities() const {
+  if (b_dummy) {
+    cvm::error("Error: velocities are not available "
+               "from a dummy atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    cvm::error("Error: atomic velocities are not available "
+               "from a scalable atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  return atoms_vel;
+}
+
+std::vector<cvm::real> cvm::atom_group_soa::total_forces() const {
+  if (b_dummy) {
+    cvm::error("Error: velocities are not available "
+               "from a dummy atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    cvm::error("Error: atomic velocities are not available "
+               "from a scalable atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  return atoms_total_force;
+}
+
+cvm::rvector cvm::atom_group_soa::total_force() const {
+  if (b_dummy) {
+    cvm::error("Error: total total forces are not available "
+               "from a dummy atom group.\n", COLVARS_INPUT_ERROR);
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    return (cvm::proxy)->get_atom_group_total_force(index);
+  }
+  cvm::rvector f(0, 0, 0);
+  for (size_t i = 0; i < num_atoms; ++i) {
+    f.x += total_force_x(i);
+    f.y += total_force_y(i);
+    f.z += total_force_z(i);
+  }
+  return f;
+}
+
+void cvm::atom_group_soa::apply_colvar_force(cvm::real const &force)
+{
+  if (cvm::debug()) {
+    log("Communicating a colvar force from atom group to the MD engine.\n");
+  }
+
+  if (b_dummy) return;
+
+  if (noforce) {
+    cvm::error("Error: sending a force to a group that has "
+               "\"enableForces\" set to off.\n");
+    return;
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    (cvm::proxy)->apply_atom_group_force(index, force * scalar_com_gradient);
+    return;
+  }
+
+  if (is_enabled(f_ag_rotate)) {
+
+    // rotate forces back to the original frame
+    const auto rot_inv = rot.inverse().matrix();
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->apply_force(rot_inv * (force * ai->grad));
+    // }
+    colvarproxy* const p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      // The calculation is reordered since A(λ*f) = λ*(Af)
+      // where λ is a scalar, f is a vector and A is a matrix.
+      const cvm::rvector f{
+        force * (rot_inv.xx * grad_x(i) + rot_inv.xy * grad_y(i) + rot_inv.xz * grad_z(i)),
+        force * (rot_inv.yx * grad_x(i) + rot_inv.yy * grad_y(i) + rot_inv.yz * grad_z(i)),
+        force * (rot_inv.zx * grad_x(i) + rot_inv.zy * grad_y(i) + rot_inv.zz * grad_z(i))
+      };
+      p->apply_atom_force(proxy_index, f);
+    }
+
+  } else {
+
+    // for (cvm::atom_iter ai = this->begin(); ai != this->end(); ai++) {
+    //   ai->apply_force(force * ai->grad);
+    // }
+    colvarproxy* const p = cvm::main()->proxy;
+    for (size_t i = 0; i < num_atoms; ++i) {
+      const int proxy_index = atoms_index[i];
+      const cvm::rvector f{
+        force * grad_x(i),
+        force * grad_y(i),
+        force * grad_z(i)
+      };
+      p->apply_atom_force(proxy_index, f);
+    }
+  }
+
+  if ((is_enabled(f_ag_center) || is_enabled(f_ag_rotate)) && is_enabled(f_ag_fit_gradients)) {
+
+    atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    colvarproxy* const p = cvm::main()->proxy;
+    // Fit gradients are already calculated in "laboratory" frame
+    for (size_t j = 0; j < group_for_fit->size(); j++) {
+      // (*group_for_fit)[j].apply_force(force * group_for_fit->fit_gradients[j]);
+      const int proxy_index = group_for_fit->atoms_index[j];
+      const cvm::rvector f{
+        force * group_for_fit->fit_gradients_x(j),
+        force * group_for_fit->fit_gradients_y(j),
+        force * group_for_fit->fit_gradients_z(j)
+      };
+      p->apply_atom_force(proxy_index, f);
+    }
+  }
+}
+
+void cvm::atom_group_soa::apply_force(cvm::rvector const &force)
+{
+  if (cvm::debug()) {
+    log("Communicating a colvar force from atom group to the MD engine.\n");
+  }
+
+  if (b_dummy) return;
+
+  if (noforce) {
+    cvm::error("Error: sending a force to a group that has "
+               "\"enableForces\" set to off.\n");
+    return;
+  }
+
+  if (is_enabled(f_ag_scalable)) {
+    (cvm::proxy)->apply_atom_group_force(index, force);
+    return;
+  }
+
+  auto ag_force = get_group_force_object();
+  for (size_t i = 0; i < size(); ++i) {
+    ag_force.add_atom_force(i, atoms_mass[i] / total_mass * force);
+  }
+}
+
+void cvm::atom_group_soa::reset_atoms_data() {
+  std::fill(atoms_pos.begin(), atoms_pos.end(), 0);
+  std::fill(atoms_vel.begin(), atoms_vel.end(), 0);
+  std::fill(atoms_grad.begin(), atoms_grad.end(), 0);
+  std::fill(atoms_total_force.begin(), atoms_total_force.end(), 0);
+}
+
+void cvm::atom_group_soa::do_feature_side_effects(int id)
+{
+  // If enabled features are changed upstream, the features below should be refreshed
+  switch (id) {
+    case f_ag_fit_gradients:
+      if (is_enabled(f_ag_center) || is_enabled(f_ag_rotate)) {
+        atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+        // group_for_fit->fit_gradients.assign(group_for_fit->size(), cvm::atom_pos(0.0, 0.0, 0.0));
+        // num_fit_gradients = group_for_fit->size();
+        group_for_fit->fit_gradients.assign(3 * group_for_fit->size(), 0);
+      }
+      break;
+  }
+}
+
+void cvm::atom_group_soa::set_ref_pos_from_aos(const std::vector<cvm::atom_pos>& pos_aos) {
+  num_ref_pos = pos_aos.size();
+  ref_pos = cvm::atom_group_soa::pos_aos_to_soa(pos_aos);
+}
+
+cvm::atom_group_soa::group_force_object cvm::atom_group_soa::get_group_force_object() {
+  return cvm::atom_group_soa::group_force_object(this);
+}
+
+cvm::atom_group_soa::group_force_object::group_force_object(cvm::atom_group_soa* ag):
+m_ag(ag), m_group_for_fit(m_ag->fitting_group ? m_ag->fitting_group : m_ag),
+m_has_fitting_force(m_ag->is_enabled(f_ag_center) || m_ag->is_enabled(f_ag_rotate)) {
+  if (m_has_fitting_force) {
+    if (m_ag->group_forces.size() != 3 * m_ag->size()) {
+      m_ag->group_forces.assign(3 * m_ag->size(), 0);
+    } else {
+      std::fill(m_ag->group_forces.begin(),
+                m_ag->group_forces.end(), 0);
+    }
+  }
+}
+
+cvm::atom_group_soa::group_force_object::~group_force_object() {
+  if (m_has_fitting_force) {
+    apply_force_with_fitting_group();
+  }
+}
+
+void cvm::atom_group_soa::group_force_object::add_atom_force(
+  size_t i, const cvm::rvector& force) {
+  if (m_has_fitting_force) {
+    // m_ag->group_forces[i] += force;
+    m_ag->group_forces_x(i) += force.x;
+    m_ag->group_forces_y(i) += force.y;
+    m_ag->group_forces_z(i) += force.z;
+  } else {
+    // Apply the force directly if we don't use fitting
+    // (*m_ag)[i].apply_force(force);
+    colvarproxy* const p = cvm::main()->proxy;
+    const int proxy_index = m_ag->atoms_index[i];
+    p->apply_atom_force(proxy_index, force);
+  }
+}
+
+void cvm::atom_group_soa::group_force_object::apply_force_with_fitting_group() {
+  const cvm::rmatrix rot_inv = m_ag->rot.inverse().matrix();
+  if (cvm::debug()) {
+    cvm::log("Applying force on main group " + m_ag->name + ":\n");
+  }
+  colvarproxy* const p = cvm::main()->proxy;
+  for (size_t ia = 0; ia < m_ag->size(); ++ia) {
+    // const cvm::rvector f_ia = rot_inv * m_ag->group_forces[ia];
+    // (*m_ag)[ia].apply_force(f_ia);
+    const int proxy_index = m_ag->atoms_index[ia];
+    const cvm::rvector f_ia{
+      rot_inv.xx * m_ag->group_forces_x(ia) +
+      rot_inv.xy * m_ag->group_forces_y(ia) +
+      rot_inv.xz * m_ag->group_forces_z(ia),
+      rot_inv.yx * m_ag->group_forces_x(ia) +
+      rot_inv.yy * m_ag->group_forces_y(ia) +
+      rot_inv.yz * m_ag->group_forces_z(ia),
+      rot_inv.zx * m_ag->group_forces_x(ia) +
+      rot_inv.zy * m_ag->group_forces_y(ia) +
+      rot_inv.zz * m_ag->group_forces_z(ia),
+    };
+    p->apply_atom_force(proxy_index, f_ia);
+    if (cvm::debug()) {
+      cvm::log(cvm::to_str(f_ia));
+    }
+  }
+  // Gradients are only available with scalar components, so for a scalar component,
+  // if f_ag_fit_gradients is disabled, then the forces on the fitting group is not
+  // computed. For a vector component, we can only know the forces on the fitting
+  // group, but checking this flag can mimic results that the users expect (if
+  // "enableFitGradients no" then there is no force on the fitting group).
+  if (!m_ag->b_dummy && m_ag->is_enabled(f_ag_fit_gradients)) {
+    colvarproxy* const p = cvm::main()->proxy;
+    auto accessor_main = [this](size_t i){
+      return cvm::rvector(m_ag->group_forces_x(i),
+                          m_ag->group_forces_y(i),
+                          m_ag->group_forces_z(i));};
+    auto accessor_fitting = [this, p](size_t j, const cvm::rvector& fitting_force){
+      // (*(m_group_for_fit))[j].apply_force(fitting_force);
+      const int proxy_index = m_group_for_fit->atoms_index[j];
+      p->apply_atom_force(proxy_index, fitting_force);
+    };
+    if (cvm::debug()) {
+      cvm::log("Applying force on the fitting group of main group" + m_ag->name + ":\n");
+    }
+    m_ag->calc_fit_forces(accessor_main, accessor_fitting);
+    if (cvm::debug()) {
+      cvm::log("Done applying force on the fitting group of main group" + m_ag->name + ":\n");
+    }
+  }
+}
+
+std::vector<colvardeps::feature *> cvm::atom_group_soa::ag_features;
+
+#endif // COLVARS_USE_SOA

--- a/src/colvaratoms_soa.h
+++ b/src/colvaratoms_soa.h
@@ -1,0 +1,514 @@
+#ifndef COLVARATOMS_SOA_H
+#define COLVARATOMS_SOA_H
+
+#include "colvarmodule.h"
+#include "colvardeps.h"
+#include "colvar_rotation_derivative.h"
+#include <unordered_map>
+#include <mutex>
+
+#ifdef COLVARS_USE_SOA
+class cvm::atom_group_soa: public colvarparse, public colvardeps {
+public:
+  static std::vector<cvm::real> pos_aos_to_soa(const std::vector<cvm::atom_pos>& aos_in);
+  atom_group_soa();
+  /// \brief Create a group object, assign a name to it
+  atom_group_soa(char const *key_in);
+  ~atom_group_soa() override;
+  int init();
+  int setup();
+  /// \brief Initialize dependency tree
+  int init_dependencies() override;
+  /// \brief Implementation of the feature list accessor for atom group
+  const std::vector<feature *> &features() const override { return ag_features; }
+  std::vector<feature *> &modify_features() override { return ag_features; }
+  static void delete_features()
+  {
+    for (size_t i = 0; i < ag_features.size(); i++) {
+      delete ag_features[i];
+    }
+    ag_features.clear();
+  }
+  // AOS-compatible interfaces
+  struct simple_atom {
+    int proxy_index;
+    int id;
+    cvm::real mass;
+    cvm::real charge;
+    cvm::atom_pos pos;
+    cvm::rvector vel;
+    cvm::rvector total_force;
+    cvm::rvector grad;
+  };
+  static simple_atom init_atom_from_proxy(
+    colvarproxy* const p,
+    cvm::residue_id const &residue,
+    std::string const     &atom_name,
+    std::string const     &segment_id);
+  static simple_atom init_atom_from_proxy(
+    colvarproxy* const p,
+    int atom_number);
+  static simple_atom init_atom_from_proxy(
+    colvarproxy* const p,
+    const simple_atom& atom);
+  class atom_modifier {
+  private:
+    cvm::atom_group_soa* m_ag;
+    std::vector<int> m_atoms_ids;
+    std::vector<simple_atom> m_atoms;
+    // Use a map to avoid duplicate
+    std::unordered_map<int, int> m_atoms_ids_count;
+    cvm::real m_total_mass;
+    cvm::real m_total_charge;
+    void update_from_soa();
+    void sync_to_soa() const;
+  public:
+    using atom_iter = decltype(m_atoms)::iterator;
+    using const_atom_iter = decltype(m_atoms)::const_iterator;
+    atom_modifier(cvm::atom_group_soa* ag);
+    ~atom_modifier();
+    inline simple_atom & operator [] (size_t const i){return m_atoms[i];}
+    inline simple_atom const & operator [] (size_t const i) const {return m_atoms[i];}
+    inline atom_iter begin(){return m_atoms.begin();}
+    inline const_atom_iter begin() const {return m_atoms.begin();}
+    inline atom_iter end() {return m_atoms.end();}
+    inline const_atom_iter end() const {return m_atoms.end();}
+    inline size_t size() const {return m_atoms.size();}
+    int add_atom(simple_atom const &a);
+    int remove_atom(atom_iter ai);
+    int add_atom_numbers(std::string const &numbers_conf);
+    int add_atoms_of_group(const atom_group_soa *ag);
+    int add_index_group(std::string const &index_group_name, bool silent = false);
+    int add_atom_numbers_range(std::string const &range_conf);
+    int add_atom_name_residue_range(std::string const &psf_segid,
+                                    std::string const &range_conf);
+    /// \brief Add an atom ID to this group (the actual atomicdata will be not be handled by the group)
+    int add_atom_id(int aid);
+    int from_aos(std::vector<simple_atom> const &atoms_in);
+  };
+  atom_modifier get_atom_modifier() {
+    return atom_modifier(this);
+  }
+  /// \brief Initialize the group by looking up its configuration
+  /// string in conf and parsing it
+  void clear_soa();
+  int parse(std::string const &conf);
+  int parse_fitting_options(std::string const &group_conf);
+  /// Set this group as a dummy group (no actual atoms)
+  int set_dummy();
+  /// If this group is dummy, set the corresponding position
+  int set_dummy_pos(cvm::atom_pos const &pos);
+  /// Update the total mass of the atom group
+  void update_total_mass();
+  /// Update the total mass of the group
+  void update_total_charge();
+  /// \brief Print the updated the total mass and charge of a group.
+  /// This is needed in case the hosting MD code has an option to
+  /// change atom masses after their initialization.
+  void print_properties(std::string const &colvar_name, int i, int j);
+  /// Internal atom IDs (populated during initialization)
+  inline std::vector<int> const &ids() const
+  {
+    return atoms_ids;
+  }
+  std::string const print_atom_ids() const;
+  /// Allocates and populates sorted_ids and sorted_ids_map
+  int create_sorted_ids();
+  /// Sorted internal atom IDs (populated on-demand by create_sorted_ids);
+  /// used to read coordinate files
+  inline std::vector<int> const &sorted_ids() const
+  {
+    return sorted_atoms_ids;
+  }
+  /// Map entries of sorted_atoms_ids onto the original positions in the group
+  inline std::vector<int> const &sorted_ids_map() const
+  {
+    return sorted_atoms_ids_map;
+  }
+  /// Detect whether two groups share atoms
+  /// If yes, returns 1-based number of a common atom; else, returns 0
+  static int overlap(const atom_group_soa &g1, const atom_group_soa &g2);
+  /// \brief Get the current positions
+  void read_positions();
+  /// \brief (Re)calculate the optimal roto-translation
+  void calc_apply_roto_translation();
+  void setup_rotation_derivative();
+  /// \brief Save aside the center of geometry of the reference positions,
+  /// then subtract it from them
+  ///
+  /// In this way it will be possible to use ref_pos also for the
+  /// rotational fit.
+  /// This is called either by atom_group::parse or by CVCs that assign
+  /// reference positions (eg. RMSD, eigenvector).
+  void center_ref_pos();
+  /// \brief Rotate all atoms by a rotation matrix
+  void rotate(const cvm::rmatrix& rot_mat);
+  /// \brief Move all positions
+  void apply_translation(cvm::rvector const &t);
+  /// \brief Get the current velocities; this must be called always
+  /// *after* read_positions(); if f_ag_rotate is defined, the same
+  /// rotation applied to the coordinates will be used
+  void read_velocities();
+  /// \brief Get the current total_forces; this must be called always
+  /// *after* read_positions(); if f_ag_rotate is defined, the same
+  /// rotation applied to the coordinates will be used
+  void read_total_forces();
+  /// \brief Recompute all mutable quantities that are required to compute CVCs
+  int calc_required_properties();
+  /// \brief Calculate the center of geometry of the atomic positions, assuming
+  /// that they are already pbc-wrapped
+  int calc_center_of_geometry();
+  /// \brief Return a copy of the current atom positions
+  std::vector<cvm::real> positions() const;
+  /// \brief Return the center of geometry of the atomic positions
+  inline cvm::atom_pos center_of_geometry() const
+  {
+    return cog;
+  }
+  /// \brief Calculate the center of mass of the atomic positions, assuming that
+  /// they are already pbc-wrapped
+  int calc_center_of_mass();
+  /// \brief Return the center of mass (COM) of the atomic positions
+  inline cvm::atom_pos center_of_mass() const
+  {
+    return com;
+  }
+  /// \brief Return previously gradient of scalar variable with respect to the
+  /// COM
+  inline cvm::rvector center_of_mass_scalar_gradient() const
+  {
+    return scalar_com_gradient;
+  }
+  /// \brief Return a copy of the current atom positions, shifted by a constant vector
+  std::vector<cvm::real> positions_shifted(cvm::rvector const &shift) const;
+  /// \brief Return a copy of the current atom velocities
+  std::vector<cvm::real> velocities() const;
+  ///\brief Calculate the dipole of the atom group around the specified center
+  int calc_dipole(cvm::atom_pos const &dipole_center);
+  ///\brief Return the (previously calculated) dipole of the atom group
+  inline cvm::rvector dipole() const
+  {
+    return dip;
+  }
+  /// \brief Return a copy of the total forces
+  std::vector<cvm::real> total_forces() const;
+  /// \brief Return a copy of the aggregated total force on the group
+  cvm::rvector total_force() const;
+  /// \brief Shorthand: save the specified gradient on each atom,
+  /// weighting with the atom mass (mostly used in combination with
+  /// \link center_of_mass() \endlink)
+  void set_weighted_gradient(cvm::rvector const &grad);
+  /// \brief Calculate the derivatives of the fitting transformation
+  void calc_fit_gradients();
+  /*! @brief  Actual implementation of `calc_fit_gradients` and
+ *          `calc_fit_forces`. The template is
+ *          used to avoid branching inside the loops in case that the CPU
+ *          branch prediction is broken (or further migration to GPU code).
+ *  @tparam B_ag_center Centered the reference to origin? This should follow
+ *          the value of `is_enabled(f_ag_center)`.
+ *  @tparam B_ag_rotate Calculate the optimal rotation? This should follow
+ *          the value of `is_enabled(f_ag_rotate)`.
+ *  @tparam main_force_accessor_T The type of accessor of the main
+ *          group forces or gradients acting on the rotated frame.
+ *  @tparam fitting_force_accessor_T The type of accessor of the fitting group
+ *          forces or gradients.
+ *  @param accessor_main The accessor of the main group forces or gradients.
+ *         accessor_main(i) should return the i-th force or gradient of the
+ *         rotated main group.
+ *  @param accessor_fitting The accessor of the fitting group forces or gradients.
+ *         accessor_fitting(j, v) should store/apply the j-th atom gradient or
+ *         force in the fitting group.
+ *
+ *  This function is used to (i) project the gradients of CV with respect to
+ *  rotated main group atoms to fitting group atoms, or (ii) project the forces
+ *  on rotated main group atoms to fitting group atoms, by the following two steps
+ *  (using the goal (ii) for example):
+ *  (1) Loop over the positions of main group atoms and call cvm::quaternion::position_derivative_inner
+ *      to project the forces on rotated main group atoms to the forces on quaternion.
+ *  (2) Loop over the positions of fitting group atoms, compute the gradients of
+ *      \f$\mathbf{q}\f$ with respect to the position of each atom, and then multiply
+ *      that with the force on \f$\mathbf{q}\f$ (chain rule).
+ */
+  template <bool B_ag_center, bool B_ag_rotate,
+            typename main_force_accessor_T,
+            typename fitting_force_accessor_T>
+  void calc_fit_forces_impl(
+    main_force_accessor_T accessor_main,
+    fitting_force_accessor_T accessor_fitting) const;
+
+/*! @brief  Calculate or apply the fitting group forces from the main group forces.
+ *  @tparam main_force_accessor_T The type of accessor of the main
+ *          group forces or gradients.
+ *  @tparam fitting_force_accessor_T The type of accessor of the fitting group
+ *          forces or gradients.
+ *  @param accessor_main The accessor of the main group forces or gradients.
+ *         accessor_main(i) should return the i-th force or gradient of the
+ *         main group.
+ *  @param accessor_fitting The accessor of the fitting group forces or gradients.
+ *         accessor_fitting(j, v) should store/apply the j-th atom gradient or
+ *         force in the fitting group.
+ *
+ *  This function just dispatches the parameters to calc_fit_forces_impl that really
+ *  performs the calculations.
+ */
+  template <typename main_force_accessor_T, typename fitting_force_accessor_T>
+  void calc_fit_forces(
+    main_force_accessor_T accessor_main,
+    fitting_force_accessor_T accessor_fitting) const;
+  /// \brief Used by a (scalar) colvar to apply its force on its \link
+  /// atom_group \endlink members
+  ///
+  /// The (scalar) force is multiplied by the colvar gradient for each
+  /// atom; this should be used when a colvar with scalar \link
+  /// colvarvalue \endlink type is used (this is the most frequent
+  /// case: for colvars with a non-scalar type, the most convenient
+  /// solution is to sum together the Cartesian forces from all the
+  /// colvar components, and use apply_force() or apply_forces()).  If
+  /// the group is being rotated to a reference frame (e.g. to express
+  /// the colvar independently from the solute rotation), the
+  /// gradients are temporarily rotated to the original frame.
+  void apply_colvar_force(cvm::real const &force);
+  /// \brief Apply a force "to the center of mass", i.e. the force is
+  /// distributed on each atom according to its mass
+  ///
+  /// If the group is being rotated to a reference frame (e.g. to
+  /// express the colvar independently from the solute rotation), the
+  /// force is rotated back to the original frame.  Colvar gradients
+  /// are not used, either because they were not defined (e.g because
+  /// the colvar has not a scalar value) or the biases require to
+  /// micromanage the force.
+  /// This function will be phased out eventually, in favor of
+  /// apply_colvar_force() once that is implemented for non-scalar values
+  void apply_force(cvm::rvector const &force);
+  /// Implements possible actions to be carried out
+  /// when a given feature is enabled
+  /// This overloads the base function in colvardeps
+  void do_feature_side_effects(int id) override;
+  size_t size() const {return num_atoms;}
+  /// Call reset_data() for each atom
+  void reset_atoms_data();
+  /// \brief Setup reference positions from AOS
+  void set_ref_pos_from_aos(const std::vector<cvm::atom_pos>& pos_aos);
+  /// \brief Accessors to atom IDs
+  inline int& id(size_t i) {return atoms_ids[i];}
+  inline const int& id(size_t i) const {return atoms_ids[i];}
+  /// \brief Accessors to positions
+  inline cvm::real& pos_x(size_t i) {return atoms_pos[i];}
+  inline cvm::real& pos_y(size_t i) {return atoms_pos[i + num_atoms];}
+  inline cvm::real& pos_z(size_t i) {return atoms_pos[i + 2 * num_atoms];}
+  inline const cvm::real& pos_x(size_t i) const {return atoms_pos[i];}
+  inline const cvm::real& pos_y(size_t i) const {return atoms_pos[i + num_atoms];}
+  inline const cvm::real& pos_z(size_t i) const {return atoms_pos[i + 2 * num_atoms];}
+  /// \brief Accessors to velocities
+  inline cvm::real& vel_x(size_t i) {return atoms_vel[i];}
+  inline cvm::real& vel_y(size_t i) {return atoms_vel[i + num_atoms];}
+  inline cvm::real& vel_z(size_t i) {return atoms_vel[i + 2 * num_atoms];}
+  inline const cvm::real& vel_x(size_t i) const {return atoms_vel[i];}
+  inline const cvm::real& vel_y(size_t i) const {return atoms_vel[i + num_atoms];}
+  inline const cvm::real& vel_z(size_t i) const {return atoms_vel[i + 2 * num_atoms];}
+  /// \brief Accessors to gradients
+  inline cvm::real& grad_x(size_t i) {return atoms_grad[i];}
+  inline cvm::real& grad_y(size_t i) {return atoms_grad[i + num_atoms];}
+  inline cvm::real& grad_z(size_t i) {return atoms_grad[i + 2 * num_atoms];}
+  inline const cvm::real& grad_x(size_t i) const {return atoms_grad[i];}
+  inline const cvm::real& grad_y(size_t i) const {return atoms_grad[i + num_atoms];}
+  inline const cvm::real& grad_z(size_t i) const {return atoms_grad[i + 2 * num_atoms];}
+  /// \brief Accessors to total forces
+  inline cvm::real& total_force_x(size_t i) {return atoms_total_force[i];}
+  inline cvm::real& total_force_y(size_t i) {return atoms_total_force[i + num_atoms];}
+  inline cvm::real& total_force_z(size_t i) {return atoms_total_force[i + 2 * num_atoms];}
+  inline const cvm::real& total_force_x(size_t i) const {return atoms_total_force[i];}
+  inline const cvm::real& total_force_y(size_t i) const {return atoms_total_force[i + num_atoms];}
+  inline const cvm::real& total_force_z(size_t i) const {return atoms_total_force[i + 2 * num_atoms];}
+  /// \brief Accessors to reference positions
+  inline cvm::real& ref_pos_x(size_t i) {return ref_pos[i];}
+  inline cvm::real& ref_pos_y(size_t i) {return ref_pos[i + num_ref_pos];}
+  inline cvm::real& ref_pos_z(size_t i) {return ref_pos[i + 2 * num_ref_pos];}
+  inline const cvm::real& ref_pos_x(size_t i) const {return ref_pos[i];}
+  inline const cvm::real& ref_pos_y(size_t i) const {return ref_pos[i + num_ref_pos];}
+  inline const cvm::real& ref_pos_z(size_t i) const {return ref_pos[i + 2 * num_ref_pos];}
+  /// \brief Accessors to positions before rotation
+  inline cvm::real& pos_unrotated_x(size_t i) {return atoms_pos_unrotated[i];}
+  inline cvm::real& pos_unrotated_y(size_t i) {return atoms_pos_unrotated[i + num_atoms];}
+  inline cvm::real& pos_unrotated_z(size_t i) {return atoms_pos_unrotated[i + 2 * num_atoms];}
+  inline const cvm::real& pos_unrotated_x(size_t i) const {return atoms_pos_unrotated[i];}
+  inline const cvm::real& pos_unrotated_y(size_t i) const {return atoms_pos_unrotated[i + num_atoms];}
+  inline const cvm::real& pos_unrotated_z(size_t i) const {return atoms_pos_unrotated[i + 2 * num_atoms];}
+  /// \brief Accessors to masses
+  inline cvm::real& mass(size_t i) {return atoms_mass[i];}
+  inline const cvm::real& mass(size_t i) const {return atoms_mass[i];}
+  /// \brief Accessors to charges
+  inline cvm::real& charge(size_t i) {return atoms_charge[i];}
+  inline const cvm::real& charge(size_t i) const {return atoms_charge[i];}
+  /// \brief Accessors to fit gradients
+  inline cvm::real& fit_gradients_x(size_t i) {
+    atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    return group_for_fit->fit_gradients[i];}
+  inline cvm::real& fit_gradients_y(size_t i) {
+    atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    return group_for_fit->fit_gradients[i + group_for_fit->size()];}
+  inline cvm::real& fit_gradients_z(size_t i) {
+    atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    return group_for_fit->fit_gradients[i + 2 * group_for_fit->size()];}
+  inline const cvm::real& fit_gradients_x(size_t i) const {
+    const atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    return group_for_fit->fit_gradients[i];}
+  inline const cvm::real& fit_gradients_y(size_t i) const {
+    const atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    return group_for_fit->fit_gradients[i + group_for_fit->size()];}
+  inline const cvm::real& fit_gradients_z(size_t i) const {
+    const atom_group_soa *group_for_fit = fitting_group ? fitting_group : this;
+    return group_for_fit->fit_gradients[i + 2 * group_for_fit->size()];}
+  /// \brief Accessors to group forces
+  inline cvm::real& group_forces_x(size_t i) {return group_forces[i];}
+  inline cvm::real& group_forces_y(size_t i) {return group_forces[i + num_atoms];}
+  inline cvm::real& group_forces_z(size_t i) {return group_forces[i + 2 * num_atoms];}
+  inline const cvm::real& group_forces_x(size_t i) const {return group_forces[i];}
+  inline const cvm::real& group_forces_y(size_t i) const {return group_forces[i + num_atoms];}
+  inline const cvm::real& group_forces_z(size_t i) const {return group_forces[i + 2 * num_atoms];}
+  /// \brief Read-only operator[]
+  inline simple_atom operator[](size_t i) const {
+    return simple_atom{
+      /*.proxy_index = */atoms_index[i],
+      /*.id = */atoms_ids[i],
+      /*.mass = */atoms_mass[i],
+      /*.charge = */atoms_charge[i],
+      /*.pos = */{pos_x(i), pos_y(i), pos_z(i)},
+      /*.vel = */{vel_x(i), vel_y(i), vel_z(i)},
+      /*.total_force = */{total_force_x(i), total_force_y(i), total_force_z(i)},
+      /*.grad = */{grad_x(i), grad_y(i), grad_z(i)}
+    };
+  }
+
+  /*! @class group_force_object
+   *  @brief A helper class for applying forces on an atom group in a way that
+   *         is aware of the fitting group. NOTE: you are encouraged to use
+   *         get_group_force_object() to get an instance of group_force_object
+   *         instead of constructing directly.
+   */
+  class group_force_object {
+  public:
+    /*! @brief Constructor of group_force_object
+     *  @param ag The pointer to the atom group that forces will be applied on.
+     */
+    group_force_object(cvm::atom_group_soa* ag);
+    /*! @brief Destructor of group_force_object
+     */
+    ~group_force_object();
+    /*! @brief Apply force to atom i
+     *  @param i The i-th of atom in the atom group.
+     *  @param force The force being added to atom i.
+     *
+     * The function can be used as follows,
+     * @code
+     *       // In your colvar::cvc::apply_force() loop of a component:
+     *       auto ag_force = atoms->get_group_force_object();
+     *       for (ia = 0; ia < atoms->size(); ia++) {
+     *         const cvm::rvector f = compute_force_on_atom_ia();
+     *         ag_force.add_atom_force(ia, f);
+     *       }
+     * @endcode
+     * There are actually two scenarios under the hood:
+     * (i) If the atom group does not have a fitting group, then the force is
+     *     added to atom i directly;
+     * (ii) If the atom group has a fitting group, the force on atom i will just
+     *      be temporary stashed into ag->group_forces. At the end of the loop
+     *      of apply_force(), the destructor ~group_force_object() will be called,
+     *      which then call apply_force_with_fitting_group(). The forces on the
+     *      main group will be rotated back by multiplying ag->group_forces with
+     *      the inverse rotation. The forces on the fitting group (if
+     *      enableFitGradients is on) will be calculated by calling
+     *      calc_fit_forces.
+     */
+    void add_atom_force(size_t i, const cvm::rvector& force);
+  private:
+    cvm::atom_group_soa* m_ag;
+    cvm::atom_group_soa* m_group_for_fit;
+    bool m_has_fitting_force;
+    void apply_force_with_fitting_group();
+  };
+  group_force_object get_group_force_object();
+public:
+  /// \brief Optional name to reuse properties of this in other groups
+  std::string name;
+  /// \brief If this option is on, this group merely acts as a wrapper
+  /// for a fixed position; any calls to atoms within or to
+  /// functions that return disaggregated data will fail
+  bool b_dummy;
+  /// \brief Keyword used to define the group
+  // TODO Make this field part of the data structures that link a group to a CVC
+  std::string key;
+  /// \brief If f_ag_center or f_ag_rotate is true, use this group to
+  /// define the transformation (default: this group itself)
+  cvm::atom_group_soa *fitting_group;
+  /// The rotation calculated automatically if f_ag_rotate is defined
+  cvm::rotation rot;
+  /// \brief Don't apply any force on this group (use its coordinates
+  /// only to calculate a colvar)
+  bool noforce;
+  /// \brief Indicates that the user has explicitly set centerToReference or
+  /// rotateReference, and the corresponding reference:
+  /// cvc's (eg rmsd, eigenvector) will not override the user's choice
+  bool b_user_defined_fit;
+  /// \brief Derivatives of the fitting transformation
+  std::vector<cvm::real> fit_gradients;
+  /// Total mass of the atom group
+  cvm::real total_mass;
+  /// Total charge of the atom group
+  cvm::real total_charge;
+  /// Rotation derivative;
+  rotation_derivative<cvm::real, cvm::real, true>* rot_deriv;
+  /// \brief Implementation of the feature list for atom group
+  static std::vector<feature *> ag_features;
+private:
+  /// \brief Number of atoms
+  size_t num_atoms;
+  /// \brief SOA positions
+  std::vector<int> atoms_index;
+  std::vector<cvm::real> atoms_pos;
+  std::vector<cvm::real> atoms_charge;
+  std::vector<cvm::real> atoms_vel;
+  std::vector<cvm::real> atoms_mass;
+  std::vector<cvm::real> atoms_grad;
+  std::vector<cvm::real> atoms_total_force;
+  /// \brief Internal atom IDs for host code
+  std::vector<int> atoms_ids;
+  /// Sorted list of internal atom IDs (populated on-demand by
+  /// create_sorted_ids); used to read coordinate files
+  std::vector<int> sorted_atoms_ids;
+  /// Map entries of sorted_atoms_ids onto the original positions in the group
+  std::vector<int> sorted_atoms_ids_map;
+  /// \brief Dummy atom position
+  cvm::atom_pos dummy_atom_pos;
+  /// \brief Index in the colvarproxy arrays (if the group is scalable)
+  int index;
+  /// \brief The temporary forces acting on the main group atoms.
+  ///        Currently this is only used for calculating the fitting group forces for
+  ///        non-scalar components.
+  std::vector<cvm::real> group_forces;
+  /// \brief use reference coordinates for f_ag_center or f_ag_rotate
+  std::vector<cvm::real> ref_pos;
+  size_t num_ref_pos; // TODO: Do I really need this?
+  /// \brief Center of geometry of the reference coordinates; regardless
+  /// of whether f_ag_center is true, ref_pos is centered to zero at
+  /// initialization, and ref_pos_cog serves to center the positions
+  cvm::atom_pos ref_pos_cog;
+  /// \brief Center of geometry
+  cvm::atom_pos cog;
+  /// \brief Center of geometry before any fitting
+  cvm::atom_pos cog_orig;
+  /// \brief Unrotated atom positions for fit gradients
+  std::vector<cvm::real> atoms_pos_unrotated;
+  /// \brief Center of mass
+  cvm::atom_pos com;
+  /// \brief The derivative of a scalar variable with respect to the COM
+  // TODO for scalable calculations of more complex variables (e.g. rotation),
+  // use a colvarvalue of vectors to hold the entire derivative
+  cvm::rvector scalar_com_gradient;
+  /// Dipole moment of the atom group
+  cvm::rvector dip;
+  /// \brief Lock for modifier
+  std::mutex modify_lock;
+};
+#endif // COLVARS_USE_SOA
+#endif // COLVARATOMS_SOA_H

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -150,7 +150,7 @@ int colvar::cvc::init_total_force_params(std::string const &conf)
 
   if (! is_enabled(f_cvc_one_site_total_force)) {
     // check whether any of the other atom groups is dummy
-    std::vector<cvm::atom_group *>::iterator agi = atom_groups.begin();
+    auto agi = atom_groups.begin();
     agi++;
     for ( ; agi != atom_groups.end(); agi++) {
       if ((*agi)->b_dummy) {
@@ -163,19 +163,30 @@ int colvar::cvc::init_total_force_params(std::string const &conf)
   return COLVARS_OK;
 }
 
-
+#ifdef COLVARS_USE_SOA
+cvm::atom_group_soa *colvar::cvc::parse_group(std::string const &conf,
+                                          char const *group_key,
+                                          bool optional)
+#else
 cvm::atom_group *colvar::cvc::parse_group(std::string const &conf,
                                           char const *group_key,
                                           bool optional)
+#endif // COLVARS_USE_SOA
 {
   int error_code = COLVARS_OK;
-
+#ifdef COLVARS_USE_SOA
+  cvm::atom_group_soa *group = nullptr;
+#else
   cvm::atom_group *group = nullptr;
+#endif // COLVARS_USE_SOA
   std::string group_conf;
 
   if (key_lookup(conf, group_key, &group_conf)) {
-
+#ifdef COLVARS_USE_SOA
+    group = new cvm::atom_group_soa(group_key);
+#else
     group = new cvm::atom_group(group_key);
+#endif // COLVARS_USE_SOA
 
     if (b_try_scalable) {
       if (is_available(f_cvc_scalable_com)
@@ -398,13 +409,21 @@ void colvar::cvc::init_scalar_boundaries(cvm::real lb, cvm::real ub)
 }
 
 
+#ifdef COLVARS_USE_SOA
+void colvar::cvc::register_atom_group(cvm::atom_group_soa *ag)
+{
+  atom_groups.push_back(ag);
+  add_child(ag);
+  enable(f_cvc_explicit_atom_groups);
+}
+#else
 void colvar::cvc::register_atom_group(cvm::atom_group *ag)
 {
   atom_groups.push_back(ag);
   add_child(ag);
   enable(f_cvc_explicit_atom_groups);
 }
-
+#endif // COLVARS_USE_SOA
 
 colvarvalue const *colvar::cvc::get_param_grad(std::string const &param_name)
 {
@@ -444,7 +463,7 @@ void colvar::cvc::read_data()
 {
   if (is_enabled(f_cvc_explicit_atom_groups)) {
     for (auto agi = atom_groups.begin(); agi != atom_groups.end(); agi++) {
-      cvm::atom_group &atoms = *(*agi);
+      auto &atoms = *(*agi);
       atoms.reset_atoms_data();
       atoms.read_positions();
       atoms.calc_required_properties();
@@ -458,12 +477,12 @@ std::vector<std::vector<int>> colvar::cvc::get_atom_lists()
 {
   std::vector<std::vector<int>> lists;
 
-  std::vector<cvm::atom_group *>::iterator agi = atom_groups.begin();
+  auto agi = atom_groups.begin();
   for ( ; agi != atom_groups.end(); ++agi) {
     (*agi)->create_sorted_ids();
     lists.push_back((*agi)->sorted_ids());
     if ((*agi)->is_enabled(f_ag_fitting_group) && (*agi)->is_enabled(f_ag_fit_gradients)) {
-      cvm::atom_group &fg = *((*agi)->fitting_group);
+      auto &fg = *((*agi)->fitting_group);
       fg.create_sorted_ids();
       lists.push_back(fg.sorted_ids());
     }
@@ -479,35 +498,57 @@ void colvar::cvc::collect_gradients(std::vector<int> const &atom_ids, std::vecto
     cvm::integer_power(value().real_value, sup_np-1);
 
   for (size_t j = 0; j < atom_groups.size(); j++) {
-
-    cvm::atom_group &ag = *(atom_groups[j]);
-
+    auto &ag = *(atom_groups[j]);
     // If necessary, apply inverse rotation to get atomic
     // gradient in the laboratory frame
     if (ag.is_enabled(f_ag_rotate)) {
       const auto rot_inv = ag.rot.inverse().matrix();
 
       for (size_t k = 0; k < ag.size(); k++) {
+#ifdef COLVARS_USE_SOA
+        size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
+                                    ag.id(k)) - atom_ids.begin();
+        atomic_gradients[a] += coeff * (rot_inv * cvm::rvector(ag.grad_x(k),
+                                                               ag.grad_y(k),
+                                                               ag.grad_z(k)));
+#else
         size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
                                     ag[k].id) - atom_ids.begin();
         atomic_gradients[a] += coeff * (rot_inv * ag[k].grad);
+#endif // COLVARS_USE_SOA
       }
 
     } else {
 
       for (size_t k = 0; k < ag.size(); k++) {
+#ifdef COLVARS_USE_SOA
+        size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
+                                    ag.id(k)) - atom_ids.begin();
+        atomic_gradients[a] += coeff * cvm::rvector(ag.grad_x(k),
+                                                    ag.grad_y(k),
+                                                    ag.grad_z(k));
+#else
         size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
                                     ag[k].id) - atom_ids.begin();
         atomic_gradients[a] += coeff * ag[k].grad;
+#endif // COLVARS_USE_SOA
       }
     }
     if (ag.is_enabled(f_ag_fitting_group) && ag.is_enabled(f_ag_fit_gradients)) {
-      cvm::atom_group const &fg = *(ag.fitting_group);
+      auto const &fg = *(ag.fitting_group);
       for (size_t k = 0; k < fg.size(); k++) {
+#ifdef COLVARS_USE_SOA
+        size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
+                                    fg.id(k)) - atom_ids.begin();
+        atomic_gradients[a] += coeff * cvm::rvector(fg.fit_gradients_x(k),
+                                                    fg.fit_gradients_y(k),
+                                                    fg.fit_gradients_z(k));
+#else
         size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
                                     fg[k].id) - atom_ids.begin();
         // fit gradients are in the unrotated (simulation) frame
         atomic_gradients[a] += coeff * fg.fit_gradients[k];
+#endif // COLVARS_USE_SOA
       }
     }
   }
@@ -562,7 +603,7 @@ void colvar::cvc::debug_gradients()
   cvm::log("Debugging gradients for " + description);
 
   for (size_t ig = 0; ig < atom_groups.size(); ig++) {
-    cvm::atom_group *group = atom_groups[ig];
+    auto *group = atom_groups[ig];
     if (group->b_dummy) continue;
 
     const auto rot_0 = group->rot.matrix();
@@ -573,7 +614,7 @@ void colvar::cvc::debug_gradients()
 
     // cvm::log("gradients     = "+cvm::to_str (gradients)+"\n");
 
-    cvm::atom_group *group_for_fit = group->fitting_group ? group->fitting_group : group;
+    auto *group_for_fit = group->fitting_group ? group->fitting_group : group;
     cvm::atom_pos fit_gradient_sum, gradient_sum;
 
     // print the values of the fit gradients
@@ -583,6 +624,19 @@ void colvar::cvc::debug_gradients()
 
         // fit_gradients are in the simulation frame: we should print them in the rotated frame
         cvm::log("Fit gradients:\n");
+#ifdef COLVARS_USE_SOA
+        for (j = 0; j < group_for_fit->size(); j++) {
+          const cvm::rvector fit_grad(
+            group_for_fit->fit_gradients_x(j),
+            group_for_fit->fit_gradients_y(j),
+            group_for_fit->fit_gradients_z(j));
+          cvm::log((group->fitting_group ? std::string("refPosGroup") : group->key) +
+                  "[" + cvm::to_str(j) + "] = " +
+                  (group->is_enabled(f_ag_rotate) ?
+                    cvm::to_str(rot_0 * (fit_grad)) :
+                    cvm::to_str(fit_grad)));
+        }
+#else
         for (j = 0; j < group_for_fit->fit_gradients.size(); j++) {
           cvm::log((group->fitting_group ? std::string("refPosGroup") : group->key) +
                   "[" + cvm::to_str(j) + "] = " +
@@ -590,23 +644,40 @@ void colvar::cvc::debug_gradients()
                     cvm::to_str(rot_0 * (group_for_fit->fit_gradients[j])) :
                     cvm::to_str(group_for_fit->fit_gradients[j])));
         }
+#endif // COLVARS_USE_SOA
       }
     }
 
     // debug the gradients
     for (size_t ia = 0; ia < group->size(); ia++) {
-
       // tests are best conducted in the unrotated (simulation) frame
+#ifdef COLVARS_USE_SOA
+      const cvm::rvector g(group->grad_x(ia),
+                           group->grad_y(ia),
+                           group->grad_z(ia));
+      cvm::rvector const atom_grad = (group->is_enabled(f_ag_rotate) ?
+                                      rot_inv * g :
+                                      g);
+#else
       cvm::rvector const atom_grad = (group->is_enabled(f_ag_rotate) ?
                                       rot_inv * ((*group)[ia].grad) :
                                       (*group)[ia].grad);
+#endif // COLVARS_USE_SOA
       gradient_sum += atom_grad;
 
       for (size_t id = 0; id < 3; id++) {
         // (re)read original positions
         group->read_positions();
         // change one coordinate
+#ifdef COLVARS_USE_SOA
+        switch (id) {
+          case 0: group->pos_x(ia) += cvm::debug_gradients_step_size; break;
+          case 1: group->pos_y(ia) += cvm::debug_gradients_step_size; break;
+          case 2: group->pos_z(ia) += cvm::debug_gradients_step_size; break;
+        }
+#else
         (*group)[ia].pos[id] += cvm::debug_gradients_step_size;
+#endif // COLVARS_USE_SOA
         group->calc_required_properties();
         calc_value();
         cvm::real x_1 = x.real_value;
@@ -614,9 +685,32 @@ void colvar::cvc::debug_gradients()
         cvm::log("Atom "+cvm::to_str(ia)+", component "+cvm::to_str(id)+":\n");
         cvm::log("dx(actual) = "+cvm::to_str(x_1 - x_0,
                               21, 14)+"\n");
+#ifdef COLVARS_USE_SOA
+        cvm::real dx_pred;
+        const size_t fit_gradients_size =
+          group->fitting_group ? group->fitting_group->size() : 0;
+        switch (id) {
+          case 0:
+            dx_pred = cvm::debug_gradients_step_size * (fit_gradients_size ?
+                      atom_grad[0] + group->fit_gradients_x(ia):
+                      atom_grad[0]);
+            break;
+          case 1:
+            dx_pred = cvm::debug_gradients_step_size * (fit_gradients_size ?
+                      atom_grad[1] + group->fit_gradients_y(ia):
+                      atom_grad[1]);
+            break;
+          case 2:
+            dx_pred = cvm::debug_gradients_step_size * (fit_gradients_size ?
+                      atom_grad[2] + group->fit_gradients_z(ia):
+                      atom_grad[2]);
+            break;
+        }
+#else
         cvm::real const dx_pred = (group->fit_gradients.size()) ?
           (cvm::debug_gradients_step_size * (atom_grad[id] + group->fit_gradients[ia][id])) :
           (cvm::debug_gradients_step_size * atom_grad[id]);
+#endif // COLVARS_USE_SOA
         cvm::log("dx(interp) = "+cvm::to_str(dx_pred,
                               21, 14)+"\n");
         cvm::log("|dx(actual) - dx(interp)|/|dx(actual)| = "+
@@ -626,14 +720,20 @@ void colvar::cvc::debug_gradients()
     }
 
     if ((group->is_enabled(f_ag_fit_gradients)) && (group->fitting_group != NULL)) {
-      cvm::atom_group *ref_group = group->fitting_group;
+      auto *ref_group = group->fitting_group;
       group->read_positions();
       group->calc_required_properties();
 
       for (size_t ia = 0; ia < ref_group->size(); ia++) {
 
         // fit gradients are in the unrotated (simulation) frame
+#ifdef COLVARS_USE_SOA
+        cvm::rvector const atom_grad(ref_group->fit_gradients_x(ia),
+                                     ref_group->fit_gradients_y(ia),
+                                     ref_group->fit_gradients_z(ia));
+#else
         cvm::rvector const atom_grad = ref_group->fit_gradients[ia];
+#endif // COLVARS_USE_SOA
         fit_gradient_sum += atom_grad;
 
         for (size_t id = 0; id < 3; id++) {
@@ -641,7 +741,15 @@ void colvar::cvc::debug_gradients()
           group->read_positions();
           ref_group->read_positions();
           // change one coordinate
+#ifdef COLVARS_USE_SOA
+          switch (id) {
+            case 0: ref_group->pos_x(ia) += cvm::debug_gradients_step_size; break;
+            case 1: ref_group->pos_y(ia) += cvm::debug_gradients_step_size; break;
+            case 2: ref_group->pos_z(ia) += cvm::debug_gradients_step_size; break;
+          }
+#else
           (*ref_group)[ia].pos[id] += cvm::debug_gradients_step_size;
+#endif // COLVARS_USE_SOA
           group->calc_required_properties();
           calc_value();
 

--- a/src/colvarcomp_apath.cpp
+++ b/src/colvarcomp_apath.cpp
@@ -178,7 +178,13 @@ void colvar::aspath::calc_gradients() {
     impl_->compute_s_derivatives();
     for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
         for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+#ifdef COLVARS_USE_SOA
+            comp_atoms[i_frame]->grad_x(i_atom) += impl_->dsdx[i_frame][i_atom][0];
+            comp_atoms[i_frame]->grad_y(i_atom) += impl_->dsdx[i_frame][i_atom][1];
+            comp_atoms[i_frame]->grad_z(i_atom) += impl_->dsdx[i_frame][i_atom][2];
+#else
             (*(comp_atoms[i_frame]))[i_atom].grad += impl_->dsdx[i_frame][i_atom];
+#endif
         }
     }
 }
@@ -233,7 +239,13 @@ void colvar::azpath::calc_gradients() {
     impl_->compute_z_derivatives();
     for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
         for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+#ifdef COLVARS_USE_SOA
+            comp_atoms[i_frame]->grad_x(i_atom) += impl_->dzdx[i_frame][i_atom][0];
+            comp_atoms[i_frame]->grad_y(i_atom) += impl_->dzdx[i_frame][i_atom][1];
+            comp_atoms[i_frame]->grad_z(i_atom) += impl_->dzdx[i_frame][i_atom][2];
+#else
             (*(comp_atoms[i_frame]))[i_atom].grad += impl_->dzdx[i_frame][i_atom];
+#endif // COLVARS_USE_SOA
         }
     }
 }
@@ -306,7 +318,13 @@ void colvar::aspathCV::calc_gradients() {
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                     for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+#ifdef COLVARS_USE_SOA
+                        cv[i_cv]->atom_groups[k_ag]->grad_x(l_atom) *= grad[j_elem] * factor_polynomial;
+                        cv[i_cv]->atom_groups[k_ag]->grad_y(l_atom) *= grad[j_elem] * factor_polynomial;
+                        cv[i_cv]->atom_groups[k_ag]->grad_z(l_atom) *= grad[j_elem] * factor_polynomial;
+#else
                         (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = grad[j_elem] * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+#endif // COLVARS_USE_SOA
                     }
                 }
             }
@@ -409,7 +427,13 @@ void colvar::azpathCV::calc_gradients() {
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                     for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+#ifdef COLVARS_USE_SOA
+                        cv[i_cv]->atom_groups[k_ag]->grad_x(l_atom) *= grad[j_elem] * factor_polynomial;
+                        cv[i_cv]->atom_groups[k_ag]->grad_y(l_atom) *= grad[j_elem] * factor_polynomial;
+                        cv[i_cv]->atom_groups[k_ag]->grad_z(l_atom) *= grad[j_elem] * factor_polynomial;
+#else
                         (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = grad[j_elem] * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+#endif // COLVARS_USE_SOA
                     }
                 }
             }

--- a/src/colvarcomp_combination.cpp
+++ b/src/colvarcomp_combination.cpp
@@ -111,7 +111,14 @@ void colvar::linearCombination::calc_gradients() {
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                     for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+#ifdef COLVARS_USE_SOA
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom) *= factor_polynomial;
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom) *= factor_polynomial;
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom) *= factor_polynomial;
+
+#else
                         (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+#endif // COLVARS_USE_SOA
                     }
                 }
             }
@@ -321,7 +328,13 @@ void colvar::customColvar::calc_gradients() {
                         const double expr_grad = gradient_evaluators[e++]->evaluate();
                         for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                             for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+#ifdef COLVARS_USE_SOA
+                                (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom) *= expr_grad * factor_polynomial;
+                                (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom) *= expr_grad * factor_polynomial;
+                                (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom) *= expr_grad * factor_polynomial;
+#else
                                 (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = expr_grad * factor_polynomial * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+#endif // COLVARS_USE_SOA
                             }
                         }
                     }

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -9,13 +9,24 @@
 
 #include "colvarmodule.h"
 #include "colvaratoms.h"
+#include "colvaratoms_soa.h"
 #include "colvarvalue.h"
 #include "colvar.h"
 #include "colvarcomp.h"
 
-
-
 template<int flags>
+#ifdef COLVARS_USE_SOA
+cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
+                                               cvm::rvector const &r0_vec,
+                                               int en,
+                                               int ed,
+                                               const cvm::atom_pos& A1,
+                                               const cvm::atom_pos& A2,
+                                               cvm::rvector& G1,
+                                               cvm::rvector& G2,
+                                               bool **pairlist_elem,
+                                               cvm::real pairlist_tol)
+#else
 cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
                                                cvm::rvector const &r0_vec,
                                                int en,
@@ -24,6 +35,7 @@ cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
                                                cvm::atom &A2,
                                                bool **pairlist_elem,
                                                cvm::real pairlist_tol)
+#endif // COLVARS_USE_SOA
 {
   if ((flags & ef_use_pairlist) && !(flags & ef_rebuild_pairlist)) {
     bool const within = **pairlist_elem;
@@ -36,8 +48,11 @@ cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
   cvm::rvector const r0sq_vec(r0_vec.x*r0_vec.x,
                               r0_vec.y*r0_vec.y,
                               r0_vec.z*r0_vec.z);
-
+#ifdef COLVARS_USE_SOA
+  cvm::rvector const diff = cvm::position_distance(A1, A2);
+#else
   cvm::rvector const diff = cvm::position_distance(A1.pos, A2.pos);
+#endif // COLVARS_USE_SOA
 
   cvm::rvector const scal_diff(diff.x/((flags & ef_anisotropic) ?
                                        r0_vec.x : r0),
@@ -81,8 +96,13 @@ cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
                                    r0*r0)) * diff.y,
                              (2.0/((flags & ef_anisotropic) ? r0sq_vec.z :
                                    r0*r0)) * diff.z);
+#ifdef COLVARS_USE_SOA
+    G1 += (-1.0)*dFdl2*dl2dx;
+    G2 +=        dFdl2*dl2dx;
+#else
     A1.grad += (-1.0)*dFdl2*dl2dx;
     A2.grad +=        dFdl2*dl2dx;
+#endif // COLVARS_USE_SOA
   }
 
   return func;
@@ -112,7 +132,11 @@ int colvar::coordnum::init(std::string const &conf)
     return error_code | COLVARS_INPUT_ERROR;
   }
 
+#ifdef COLVARS_USE_SOA
+  if (int atom_number = cvm::atom_group_soa::overlap(*group1, *group2)) {
+#else
   if (int atom_number = cvm::atom_group::overlap(*group1, *group2)) {
+#endif // COLVARS_USE_SOA
     error_code |= cvm::error(
         "Error: group1 and group2 share a common atom (number: " + cvm::to_str(atom_number) + ")\n",
         COLVARS_INPUT_ERROR);
@@ -195,6 +219,28 @@ colvar::coordnum::~coordnum()
 template<int flags> void colvar::coordnum::main_loop(bool **pairlist_elem)
 {
   if (b_group2_center_only) {
+#ifdef COLVARS_USE_SOA
+    const cvm::atom_pos group2_com = group2->center_of_mass();
+    cvm::rvector group2_com_grad(0, 0, 0);
+    for (size_t i = 0; i < group1->size(); ++i) {
+      // Cache the i-atom first in case of SOA
+      cvm::rvector G1(0, 0, 0);
+      const cvm::atom_pos A1{group1->pos_x(i), group1->pos_y(i), group1->pos_z(i)};
+      x.real_value += switching_function<flags>(r0, r0_vec, en, ed,
+                                                A1, group2_com,
+                                                G1, group2_com_grad,
+                                                pairlist_elem,
+                                                tolerance);
+      if (flags & ef_gradients) {
+        group1->grad_x(i) += G1.x;
+        group1->grad_y(i) += G1.y;
+        group1->grad_z(i) += G1.z;
+      }
+    }
+    if (b_group2_center_only) {
+      group2->set_weighted_gradient(group2_com_grad);
+    }
+#else
     cvm::atom group2_com_atom;
     group2_com_atom.pos = group2->center_of_mass();
     for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
@@ -206,7 +252,38 @@ template<int flags> void colvar::coordnum::main_loop(bool **pairlist_elem)
     if (b_group2_center_only) {
       group2->set_weighted_gradient(group2_com_atom.grad);
     }
+#endif // COLVARS_USE_SOA
   } else {
+#ifdef COLVARS_USE_SOA
+    for (size_t i = 0; i < group1->size(); ++i) {
+      // Cache the i-atom first in case of SOA
+      const cvm::atom_pos A1{group1->pos_x(i),
+                             group1->pos_y(i),
+                             group1->pos_z(i)};
+      cvm::rvector G1(0, 0, 0);
+      for (size_t j = 0; j < group2->size(); ++j) {
+        cvm::rvector G2(0, 0, 0);
+        const cvm::atom_pos A2{group2->pos_x(j),
+                               group2->pos_y(j),
+                               group2->pos_z(j)};
+        x.real_value += switching_function<flags>(r0, r0_vec, en, ed,
+                                                  A1, A2,
+                                                  G1, G2,
+                                                  pairlist_elem,
+                                                  tolerance);
+        if (flags & ef_gradients) {
+          group2->grad_x(j) += G2.x;
+          group2->grad_y(j) += G2.y;
+          group2->grad_z(j) += G2.z;
+        }
+      }
+      if (flags & ef_gradients) {
+        group1->grad_x(i) += G1.x;
+        group1->grad_y(i) += G1.y;
+        group1->grad_z(i) += G1.z;
+      }
+    }
+#else
     for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
       for (cvm::atom_iter ai2 = group2->begin(); ai2 != group2->end(); ai2++) {
         x.real_value += switching_function<flags>(r0, r0_vec, en, ed,
@@ -215,6 +292,7 @@ template<int flags> void colvar::coordnum::main_loop(bool **pairlist_elem)
                                                   tolerance);
       }
     }
+#endif // COLVARS_USE_SOA
   }
 }
 
@@ -317,11 +395,21 @@ int colvar::h_bond::init(std::string const &conf)
     error_code |= cvm::error("Error: either acceptor or donor undefined.\n", COLVARS_INPUT_ERROR);
   }
 
+#ifdef COLVARS_USE_SOA
+  register_atom_group(new cvm::atom_group_soa);
+  {
+    colvarproxy* const p = cvm::main()->proxy;
+    auto modify_atom = atom_groups[0]->get_atom_modifier();
+    modify_atom.add_atom(cvm::atom_group_soa::init_atom_from_proxy(p, a_num));
+    modify_atom.add_atom(cvm::atom_group_soa::init_atom_from_proxy(p, d_num));
+  }
+#else
   cvm::atom acceptor = cvm::atom(a_num);
   cvm::atom donor    = cvm::atom(d_num);
   register_atom_group(new cvm::atom_group);
   atom_groups[0]->add_atom(acceptor);
   atom_groups[0]->add_atom(donor);
+#endif // COLVARS_USE_SOA
 
   get_keyval(conf, "cutoff",   r0, r0);
   get_keyval(conf, "expNumer", en, en);
@@ -342,7 +430,21 @@ int colvar::h_bond::init(std::string const &conf)
   return error_code;
 }
 
-
+#ifdef COLVARS_USE_SOA
+colvar::h_bond::h_bond(cvm::atom_group_soa::simple_atom const &acceptor,
+                       cvm::atom_group_soa::simple_atom const &donor,
+                       cvm::real r0_i, int en_i, int ed_i)
+  : h_bond()
+{
+  r0 = r0_i;
+  en = en_i;
+  ed = ed_i;
+  register_atom_group(new cvm::atom_group_soa);
+  auto modify_atom = atom_groups[0]->get_atom_modifier();
+  modify_atom.add_atom(acceptor);
+  modify_atom.add_atom(donor);
+}
+#else
 colvar::h_bond::h_bond(cvm::atom const &acceptor,
                        cvm::atom const &donor,
                        cvm::real r0_i, int en_i, int ed_i)
@@ -355,17 +457,34 @@ colvar::h_bond::h_bond(cvm::atom const &acceptor,
   atom_groups[0]->add_atom(acceptor);
   atom_groups[0]->add_atom(donor);
 }
+#endif // COLVARS_USE_SOA
 
 
 void colvar::h_bond::calc_value()
 {
   int const flags = coordnum::ef_null;
   cvm::rvector const r0_vec(0.0); // TODO enable the flag?
+#ifdef COLVARS_USE_SOA
+  cvm::rvector G1, G2;
+  const cvm::atom_pos A1{atom_groups[0]->pos_x(0),
+                         atom_groups[0]->pos_y(0),
+                         atom_groups[0]->pos_z(0)};
+  const cvm::atom_pos A2{atom_groups[0]->pos_x(1),
+                         atom_groups[0]->pos_y(1),
+                         atom_groups[0]->pos_z(1)};
+  x.real_value =
+    coordnum::switching_function<flags>(r0, r0_vec, en, ed,
+                                        A1, A2,
+                                        G1, G2,
+                                        NULL, 0.0);
+  // Skip the gradient
+#else
   x.real_value =
     coordnum::switching_function<flags>(r0, r0_vec, en, ed,
                                         (*atom_groups[0])[0],
                                         (*atom_groups[0])[1],
                                         NULL, 0.0);
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -373,10 +492,31 @@ void colvar::h_bond::calc_gradients()
 {
   int const flags = coordnum::ef_gradients;
   cvm::rvector const r0_vec(0.0); // TODO enable the flag?
+#ifdef COLVARS_USE_SOA
+  cvm::rvector G1, G2;
+  const cvm::atom_pos A1{atom_groups[0]->pos_x(0),
+                         atom_groups[0]->pos_y(0),
+                         atom_groups[0]->pos_z(0)};
+  const cvm::atom_pos A2{atom_groups[0]->pos_x(1),
+                         atom_groups[0]->pos_y(1),
+                         atom_groups[0]->pos_z(1)};
+  x.real_value =
+    coordnum::switching_function<flags>(r0, r0_vec, en, ed,
+                                        A1, A2,
+                                        G1, G2,
+                                        NULL, 0.0);
+  atom_groups[0]->grad_x(0) += G1.x;
+  atom_groups[0]->grad_y(0) += G1.y;
+  atom_groups[0]->grad_z(0) += G1.z;
+  atom_groups[0]->grad_x(1) += G2.x;
+  atom_groups[0]->grad_y(1) += G2.y;
+  atom_groups[0]->grad_z(1) += G2.z;
+#else
   coordnum::switching_function<flags>(r0, r0_vec, en, ed,
                                       (*atom_groups[0])[0],
                                       (*atom_groups[0])[1],
                                       NULL, 0.0);
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -455,12 +595,45 @@ template<int compute_flags> int colvar::selfcoordnum::compute_selfcoordnum()
   size_t const n = group1->size();
 
   // Always isotropic (TODO: enable the ellipsoid?)
+#ifdef COLVARS_USE_SOA
+#define CALL_KERNEL(flags) do {                         \
+  for (i = 0; i < n - 1; i++) {                         \
+    const cvm::atom_pos A1{group1->pos_x(i),            \
+                           group1->pos_y(i),            \
+                           group1->pos_z(i)};           \
+    cvm::rvector G1(0, 0, 0);                           \
+    for (j = i + 1; j < n; j++) {                       \
+      cvm::rvector G2(0, 0, 0);                         \
+      const cvm::atom_pos A2{group1->pos_x(j),          \
+                             group1->pos_y(j),          \
+                             group1->pos_z(j)};         \
+      x.real_value +=                                   \
+        coordnum::switching_function<flags>(            \
+          r0, r0_vec, en, ed, A1, A2, G1, G2,           \
+          &pairlist_elem, tolerance);                   \
+      if (flags & coordnum::ef_gradients) {             \
+        group1->grad_x(j) += G2.x;                      \
+        group1->grad_y(j) += G2.y;                      \
+        group1->grad_z(j) += G2.z;                      \
+      }                                                 \
+    }                                                   \
+    if (flags & coordnum::ef_gradients) {               \
+      group1->grad_x(i) += G1.x;                        \
+      group1->grad_y(i) += G1.y;                        \
+      group1->grad_z(i) += G1.z;                        \
+    }                                                   \
+  }                                                     \
+} while (0);
+#endif // COLVARS_USE_SOA
 
   if (use_pairlist) {
 
     if (rebuild_pairlist) {
       int const flags = compute_flags | coordnum::ef_use_pairlist |
         coordnum::ef_rebuild_pairlist;
+#ifdef COLVARS_USE_SOA
+      CALL_KERNEL(flags);
+#else
       for (i = 0; i < n - 1; i++) {
         for (j = i + 1; j < n; j++) {
           x.real_value +=
@@ -471,8 +644,12 @@ template<int compute_flags> int colvar::selfcoordnum::compute_selfcoordnum()
                                                 tolerance);
         }
       }
+#endif // COLVARS_USE_SOA
     } else {
       int const flags = compute_flags | coordnum::ef_use_pairlist;
+#ifdef COLVARS_USE_SOA
+      CALL_KERNEL(flags);
+#else
       for (i = 0; i < n - 1; i++) {
         for (j = i + 1; j < n; j++) {
           x.real_value +=
@@ -483,11 +660,15 @@ template<int compute_flags> int colvar::selfcoordnum::compute_selfcoordnum()
                                                 tolerance);
         }
       }
+#endif // COLVARS_USE_SOA
     }
 
   } else { // if (use_pairlist) {
 
     int const flags = compute_flags | coordnum::ef_null;
+#ifdef COLVARS_USE_SOA
+      CALL_KERNEL(flags);
+#else
     for (i = 0; i < n - 1; i++) {
       for (j = i + 1; j < n; j++) {
         x.real_value +=
@@ -498,8 +679,11 @@ template<int compute_flags> int colvar::selfcoordnum::compute_selfcoordnum()
                                               tolerance);
       }
     }
+#endif // COLVARS_USE_SOA
   }
-
+#ifdef COLVARS_USE_SOA
+#undef CALL_KERNEL
+#endif // COLVARS_USE_SOA
   return COLVARS_OK;
 }
 
@@ -581,48 +765,91 @@ int colvar::groupcoordnum::init(std::string const &conf)
 
 void colvar::groupcoordnum::calc_value()
 {
+#ifdef COLVARS_USE_SOA
+  const cvm::atom_pos A1 = group1->center_of_mass();
+  const cvm::atom_pos A2 = group2->center_of_mass();
+#define CALL_KERNEL(flags) do { \
+  cvm::rvector G1, G2; \
+  x.real_value = coordnum::switching_function<flags>(r0, r0_vec, en, ed, \
+                                                     A1, A2, G1, G2, NULL, 0.0); \
+} while (0);
+#else // COLVARS_USE_SOA
   // create fake atoms to hold the com coordinates
   cvm::atom group1_com_atom;
   cvm::atom group2_com_atom;
   group1_com_atom.pos = group1->center_of_mass();
   group2_com_atom.pos = group2->center_of_mass();
+#endif // COLVARS_USE_SOA
   if (b_anisotropic) {
     int const flags = coordnum::ef_anisotropic;
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(flags);
+#else
     x.real_value = coordnum::switching_function<flags>(r0, r0_vec, en, ed,
                                                        group1_com_atom,
                                                        group2_com_atom,
                                                        NULL, 0.0);
+#endif // COLVARS_USE_SOA
   } else {
     int const flags = coordnum::ef_null;
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(flags);
+#else
     x.real_value = coordnum::switching_function<flags>(r0, r0_vec, en, ed,
                                                        group1_com_atom,
                                                        group2_com_atom,
                                                        NULL, 0.0);
+#endif // COLVARS_USE_SOA
   }
+#ifdef COLVARS_USE_SOA
+#undef CALL_KERNEL
+#endif // COLVARS_USE_SOA
 }
 
 
 void colvar::groupcoordnum::calc_gradients()
 {
+#ifdef COLVARS_USE_SOA
+  const cvm::atom_pos A1 = group1->center_of_mass();
+  const cvm::atom_pos A2 = group2->center_of_mass();
+  cvm::rvector G1(0, 0, 0), G2(0, 0, 0);
+#define CALL_KERNEL(flags) do { \
+  x.real_value = coordnum::switching_function<flags>(r0, r0_vec, en, ed, \
+                                                     A1, A2, G1, G2, NULL, 0.0); \
+} while (0);
+#else
   cvm::atom group1_com_atom;
   cvm::atom group2_com_atom;
   group1_com_atom.pos = group1->center_of_mass();
   group2_com_atom.pos = group2->center_of_mass();
-
+#endif // COLVARS_USE_SOA
   if (b_anisotropic) {
     int const flags = coordnum::ef_gradients | coordnum::ef_anisotropic;
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(flags);
+#else
     coordnum::switching_function<flags>(r0, r0_vec, en, ed,
                                         group1_com_atom,
                                         group2_com_atom,
                                         NULL, 0.0);
+#endif // COLVARS_USE_SOA
   } else {
     int const flags = coordnum::ef_gradients;
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(flags);
+#else
     coordnum::switching_function<flags>(r0, r0_vec, en, ed,
                                         group1_com_atom,
                                         group2_com_atom,
                                         NULL, 0.0);
+#endif // COLVARS_USE_SOA
   }
 
+#ifdef COLVARS_USE_SOA
+  group1->set_weighted_gradient(G1);
+  group2->set_weighted_gradient(G2);
+#else
   group1->set_weighted_gradient(group1_com_atom.grad);
   group2->set_weighted_gradient(group2_com_atom.grad);
+#endif // COLVARS_USE_SOA
 }

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -438,14 +438,24 @@ int colvar::distance_inv::init(std::string const &conf)
     error_code |= cvm::error("Error: negative or zero exponent provided.\n", COLVARS_INPUT_ERROR);
   }
 
-  for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
-    for (cvm::atom_iter ai2 = group2->begin(); ai2 != group2->end(); ai2++) {
-      if (ai1->id == ai2->id) {
-        error_code |= cvm::error("Error: group1 and group2 have some atoms in common: this is not "
-                                 "allowed for distanceInv.\n",
-                                 COLVARS_INPUT_ERROR);
-      }
-    }
+  // for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
+  //   for (cvm::atom_iter ai2 = group2->begin(); ai2 != group2->end(); ai2++) {
+  //     if (ai1->id == ai2->id) {
+  //       error_code |= cvm::error("Error: group1 and group2 have some atoms in common: this is not "
+  //                                "allowed for distanceInv.\n",
+  //                                COLVARS_INPUT_ERROR);
+  //     }
+  //   }
+  // }
+  // TODO: Is using overlap instead of the above loop correct?
+#ifdef COLVARS_USE_SOA
+  if (cvm::atom_group_soa::overlap(*group1, *group2) != 0) {
+#else
+  if (cvm::atom_group::overlap(*group1, *group2) != 0) {
+#endif // COLVARS_USE_SOA
+    error_code |= cvm::error("Error: group1 and group2 have some atoms in common: this is not "
+                            "allowed for distanceInv.\n",
+                            COLVARS_INPUT_ERROR);
   }
 
   if (is_enabled(f_cvc_debug_gradient)) {
@@ -460,8 +470,44 @@ int colvar::distance_inv::init(std::string const &conf)
 
 void colvar::distance_inv::calc_value()
 {
+#ifdef COLVARS_USE_SOA
+#define CALL_KERNEL(USE_PBC_MINIMUM_IMAGE) do {        \
+  const int factor = -1*(exponent/2);                  \
+  for (size_t i = 0; i < group1->size(); ++i) {        \
+    const cvm::atom_pos pos1(group1->pos_x(i),         \
+                             group1->pos_y(i),         \
+                             group1->pos_z(i));        \
+    cvm::rvector g1(0, 0, 0);                          \
+    for (size_t j = 0; j < group2->size(); ++j) {      \
+      const cvm::atom_pos pos2(group2->pos_x(j),       \
+                               group2->pos_y(j),       \
+                               group2->pos_z(j));      \
+      cvm::rvector dv;                                 \
+      if (USE_PBC_MINIMUM_IMAGE) {                     \
+        dv = cvm::position_distance(pos1, pos2);       \
+      } else {                                         \
+        dv = pos2 - pos1;                              \
+      }                                                \
+      cvm::real const d2 = dv.norm2();                                      \
+      cvm::real const dinv = cvm::integer_power(d2, factor);                \
+      x.real_value += dinv;                                                 \
+      cvm::rvector const dsumddv = factor * dinv/d2 * 2.0 * dv;             \
+      g1 += -1.0 * dsumddv;             \
+      group2->grad_x(j) += dsumddv.x;   \
+      group2->grad_y(j) += dsumddv.y;   \
+      group2->grad_z(j) += dsumddv.z;   \
+    }                                   \
+    group1->grad_x(i) += g1.x; \
+    group1->grad_y(i) += g1.y; \
+    group1->grad_z(i) += g1.z; \
+  }                            \
+} while (0);
+#endif // COLVARS_USE_SOA
   x.real_value = 0.0;
   if (!is_enabled(f_cvc_pbc_minimum_image)) {
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(false);
+#else
     for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
       for (cvm::atom_iter ai2 = group2->begin(); ai2 != group2->end(); ai2++) {
         cvm::rvector const dv = ai2->pos - ai1->pos;
@@ -473,7 +519,11 @@ void colvar::distance_inv::calc_value()
         ai2->grad +=        dsumddv;
       }
     }
+#endif // COLVARS_USE_SOA
   } else {
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(true);
+#else
     for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
       for (cvm::atom_iter ai2 = group2->begin(); ai2 != group2->end(); ai2++) {
         cvm::rvector const dv = cvm::position_distance(ai1->pos, ai2->pos);
@@ -485,6 +535,7 @@ void colvar::distance_inv::calc_value()
         ai2->grad +=        dsumddv;
       }
     }
+#endif // COLVARS_USE_SOA
   }
 
   x.real_value *= 1.0 / cvm::real(group1->size() * group2->size());
@@ -493,12 +544,24 @@ void colvar::distance_inv::calc_value()
   cvm::real const dxdsum = (-1.0/(cvm::real(exponent))) *
     cvm::integer_power(x.real_value, exponent+1) /
     cvm::real(group1->size() * group2->size());
+#ifdef COLVARS_USE_SOA
+  const size_t num_grads_xyz_group1 = 3 * group1->size();
+  for (size_t i = 0; i < num_grads_xyz_group1; ++i) {
+    group1->grad_x(i) = group1->grad_x(i) * dxdsum;
+  }
+  const size_t num_grads_xyz_group2 = 3 * group2->size();
+  for (size_t i = 0; i < num_grads_xyz_group2; ++i) {
+    group2->grad_x(i) = group2->grad_x(i) * dxdsum;
+  }
+#undef CALL_KERNEL
+#else
   for (cvm::atom_iter ai1 = group1->begin(); ai1 != group1->end(); ai1++) {
     ai1->grad *= dxdsum;
   }
   for (cvm::atom_iter ai2 = group2->begin(); ai2 != group2->end(); ai2++) {
     ai2->grad *= dxdsum;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -531,8 +594,38 @@ int colvar::distance_pairs::init(std::string const &conf)
 void colvar::distance_pairs::calc_value()
 {
   x.vector1d_value.resize(group1->size() * group2->size());
-
+#ifdef COLVARS_USE_SOA
+#define CALL_KERNEL(USE_PBC_MINIMUM_IMAGE) do {                    \
+  for (size_t i1 = 0; i1 < group1->size(); ++i1) {                 \
+    const cvm::atom_pos pos1(group1->pos_x(i1),                    \
+                             group1->pos_y(i1),                    \
+                             group1->pos_z(i1));                   \
+    cvm::rvector g1(0, 0, 0);                                      \
+    for (size_t i2 = 0; i2 < group2->size(); i2++) {               \
+      const cvm::atom_pos pos2(group2->pos_x(i2),                  \
+                               group2->pos_y(i2),                  \
+                               group2->pos_z(i2));                 \
+      const cvm::rvector dv = USE_PBC_MINIMUM_IMAGE ?              \
+                              cvm::position_distance(pos1, pos2) : \
+                              pos2 - pos1;                         \
+      cvm::real const d = dv.norm();                               \
+      x.vector1d_value[i1*group2->size() + i2] = d;                \
+      const cvm::rvector g2 = dv.unit();                           \
+      g1 += -g2;                                                   \
+      /*group2->grad_x(i2) += g2.x;                                  \
+      group2->grad_y(i2) += g2.y;                                  \
+      group2->grad_z(i2) += g2.z;*/                                  \
+    }                                                              \
+    /*group1->grad_x(i1) += g1.x;                                    \
+    group1->grad_y(i1) += g1.y;                                    \
+    group1->grad_z(i1) += g1.z;*/                                    \
+  }                                                                \
+} while (0);
+#endif // COLVARS_USE_SOA
   if (!is_enabled(f_cvc_pbc_minimum_image)) {
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(false);
+#else
     size_t i1, i2;
     for (i1 = 0; i1 < group1->size(); i1++) {
       for (i2 = 0; i2 < group2->size(); i2++) {
@@ -543,7 +636,11 @@ void colvar::distance_pairs::calc_value()
         (*group2)[i2].grad =  dv.unit();
       }
     }
+#endif // COLVARS_USE_SOA
   } else {
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(true);
+#else
     size_t i1, i2;
     for (i1 = 0; i1 < group1->size(); i1++) {
       for (i2 = 0; i2 < group2->size(); i2++) {
@@ -555,7 +652,11 @@ void colvar::distance_pairs::calc_value()
         (*group2)[i2].grad =  dv.unit();
       }
     }
+#endif // COLVARS_USE_SOA
   }
+#ifdef COLVARS_USE_SOA
+#undef CALL_KERNEL
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -567,7 +668,36 @@ void colvar::distance_pairs::calc_gradients()
 
 void colvar::distance_pairs::apply_force(colvarvalue const &force)
 {
+#ifdef COLVARS_USE_SOA
+#define CALL_KERNEL(USE_PBC_MINIMUM_IMAGE) do {                         \
+  auto group1_force_obj = group1->get_group_force_object();             \
+  auto group2_force_obj = group2->get_group_force_object();             \
+  for (size_t i1 = 0; i1 < group1->size(); i1++) {                      \
+    const cvm::atom_pos pos1(group1->pos_x(i1),                         \
+                             group1->pos_y(i1),                         \
+                             group1->pos_z(i1));                        \
+    cvm::rvector f1(0, 0, 0);                                           \
+    for (size_t i2 = 0; i2 < group2->size(); i2++) {                    \
+      const cvm::atom_pos pos2(group2->pos_x(i2),                       \
+                               group2->pos_y(i2),                       \
+                               group2->pos_z(i2));                      \
+      const cvm::rvector dv = USE_PBC_MINIMUM_IMAGE ?                   \
+                              cvm::position_distance(pos1, pos2) :      \
+                              pos2 - pos1;                              \
+      cvm::real const d = dv.norm();                                    \
+      x.vector1d_value[i1*group2->size() + i2] = d;                     \
+      const cvm::rvector f2 = force[i1*group2->size() + i2] * dv.unit();\
+      f1 += -f2;                                                        \
+      group2_force_obj.add_atom_force(i2, f2);                          \
+    }                                                                   \
+    group1_force_obj.add_atom_force(i1, f1);                            \
+  }                                                                     \
+} while (0);
+#endif // COLVARS_USE_SOA
   if (!is_enabled(f_cvc_pbc_minimum_image)) {
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(false);
+#else
     size_t i1, i2;
     for (i1 = 0; i1 < group1->size(); i1++) {
       for (i2 = 0; i2 < group2->size(); i2++) {
@@ -576,7 +706,11 @@ void colvar::distance_pairs::apply_force(colvarvalue const &force)
         (*group2)[i2].apply_force(force[i1*group2->size() + i2] * dv.unit());
       }
     }
+#endif // COLVARS_USE_SOA
   } else {
+#ifdef COLVARS_USE_SOA
+    CALL_KERNEL(true);
+#else
     size_t i1, i2;
     for (i1 = 0; i1 < group1->size(); i1++) {
       for (i2 = 0; i2 < group2->size(); i2++) {
@@ -586,7 +720,11 @@ void colvar::distance_pairs::apply_force(colvarvalue const &force)
         (*group2)[i2].apply_force(force[i1*group2->size() + i2] * dv.unit());
       }
     }
+#endif // COLVARS_USE_SOA
   }
+#ifdef COLVARS_USE_SOA
+#undef CALL_KERNEL
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -641,10 +779,18 @@ void colvar::dipole_magnitude::calc_gradients()
 {
   cvm::real const aux1 = atoms->total_charge/atoms->total_mass;
   cvm::atom_pos const dipVunit = dipoleV.unit();
-
+#ifdef COLVARS_USE_SOA
+  for (size_t i = 0; i < atoms->size(); ++i) {
+    const cvm::rvector grad = (atoms->charge(i) - aux1 * atoms->mass(i)) * dipVunit;
+    atoms->grad_x(i) = grad.x;
+    atoms->grad_y(i) = grad.y;
+    atoms->grad_z(i) = grad.z;
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     ai->grad = (ai->charge - aux1*ai->mass) * dipVunit;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -668,8 +814,14 @@ int colvar::gyration::init(std::string const &conf)
     cvm::log("WARNING: explicit fitting parameters were provided for atom group \"atoms\".\n");
   } else {
     atoms->enable(f_ag_center);
+#ifdef COLVARS_USE_SOA
+    std::vector<cvm::atom_pos> ref_pos_aos{cvm::atom_pos(0, 0, 0)};
+    atoms->set_ref_pos_from_aos(ref_pos_aos);
+    atoms->fit_gradients.assign(3 * atoms->size(), 0);
+#else
     atoms->ref_pos.assign(1, cvm::atom_pos(0.0, 0.0, 0.0));
     atoms->fit_gradients.assign(atoms->size(), cvm::rvector(0.0, 0.0, 0.0));
+#endif // COLVARS_USE_SOA
   }
 
   return error_code;
@@ -679,9 +831,16 @@ int colvar::gyration::init(std::string const &conf)
 void colvar::gyration::calc_value()
 {
   x.real_value = 0.0;
+#ifdef COLVARS_USE_SOA
+  const size_t num_pos_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_pos_xyz; ++i) {
+    x.real_value += atoms->pos_x(i) * atoms->pos_x(i);
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     x.real_value += (ai->pos).norm2();
   }
+#endif // COLVARS_USE_SOA
   x.real_value = cvm::sqrt(x.real_value / cvm::real(atoms->size()));
 }
 
@@ -689,9 +848,16 @@ void colvar::gyration::calc_value()
 void colvar::gyration::calc_gradients()
 {
   cvm::real const drdx = 1.0/(cvm::real(atoms->size()) * x.real_value);
+#ifdef COLVARS_USE_SOA
+  const size_t num_pos_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_pos_xyz; ++i) {
+    atoms->grad_x(i) = drdx * atoms->pos_x(i);
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     ai->grad = drdx * ai->pos;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -701,10 +867,17 @@ void colvar::gyration::calc_force_invgrads()
 
   cvm::real const dxdr = 1.0/x.real_value;
   ft.real_value = 0.0;
-
+#ifdef COLVARS_USE_SOA
+  const size_t num_pos_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_pos_xyz; ++i) {
+    ft.real_value += atoms->pos_x(i) * atoms->total_force_x(i);
+  }
+  ft.real_value *= dxdr;
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     ft.real_value += dxdr * ai->pos * ai->total_force;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -724,17 +897,31 @@ colvar::inertia::inertia()
 void colvar::inertia::calc_value()
 {
   x.real_value = 0.0;
+#ifdef COLVARS_USE_SOA
+  const size_t num_pos_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_pos_xyz; ++i) {
+    x.real_value += atoms->pos_x(i) * atoms->pos_x(i);
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     x.real_value += (ai->pos).norm2();
   }
+#endif // COLVARS_USE_SOA
 }
 
 
 void colvar::inertia::calc_gradients()
 {
+#ifdef COLVARS_USE_SOA
+  const size_t num_pos_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_pos_xyz; ++i) {
+    atoms->grad_x(i) = 2.0 * atoms->pos_x(i);
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     ai->grad = 2.0 * ai->pos;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -764,18 +951,41 @@ int colvar::inertia_z::init(std::string const &conf)
 void colvar::inertia_z::calc_value()
 {
   x.real_value = 0.0;
+#ifdef COLVARS_USE_SOA
+  for (size_t i = 0; i < atoms->size(); ++i) {
+    const cvm::atom_pos pos(atoms->pos_x(i),
+                            atoms->pos_y(i),
+                            atoms->pos_z(i));
+    cvm::real const iprod = pos * axis;
+    x.real_value += iprod * iprod;
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     cvm::real const iprod = ai->pos * axis;
     x.real_value += iprod * iprod;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
 void colvar::inertia_z::calc_gradients()
 {
+#ifdef COLVARS_USE_SOA
+  for (size_t i = 0; i < atoms->size(); ++i) {
+    const cvm::atom_pos pos(atoms->pos_x(i),
+                            atoms->pos_y(i),
+                            atoms->pos_z(i));
+    cvm::real const iprod = pos * axis;
+    const cvm::rvector grad = 2.0 * iprod * axis;
+    atoms->grad_x(i) = grad.x;
+    atoms->grad_y(i) = grad.y;
+    atoms->grad_z(i) = grad.z;
+  }
+#else
   for (cvm::atom_iter ai = atoms->begin(); ai != atoms->end(); ai++) {
     ai->grad = 2.0 * (ai->pos * axis) * axis;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -869,7 +1079,11 @@ int colvar::rmsd::init(std::string const &conf)
     atoms->enable(f_ag_rotate);
     // default case: reference positions for calculating the rmsd are also those used
     // for fitting
+#ifdef COLVARS_USE_SOA
+    atoms->set_ref_pos_from_aos(ref_pos);
+#else
     atoms->ref_pos = ref_pos;
+#endif // COLVARS_USE_SOA
     atoms->center_ref_pos();
 
     cvm::log("This is a standard minimum RMSD, derivatives of the optimal rotation "
@@ -936,18 +1150,34 @@ void colvar::rmsd::calc_value()
   // rotational-translational fit is handled by the atom group
 
   x.real_value = 0.0;
+#ifdef COLVARS_USE_SOA
+  for (size_t ia = 0; ia < atoms->size(); ia++) {
+    const cvm::atom_pos pos_ia(
+      atoms->pos_x(ia), atoms->pos_y(ia), atoms->pos_z(ia));
+    x.real_value += (pos_ia - ref_pos[ia]).norm2();
+  }
+#else
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     x.real_value += ((*atoms)[ia].pos - ref_pos[ia]).norm2();
   }
+#endif // COLVARS_USE_SOA
   best_perm_index = 0;
 
   // Compute sum of squares for each symmetry permutation of atoms, keep the smallest
   size_t ref_pos_index = atoms->size();
   for (size_t ip = 1; ip < n_permutations; ip++) {
     cvm::real value = 0.0;
+#ifdef COLVARS_USE_SOA
+    for (size_t ia = 0; ia < atoms->size(); ia++) {
+      const cvm::atom_pos pos_ia(
+        atoms->pos_x(ia), atoms->pos_y(ia), atoms->pos_z(ia));
+      value += (pos_ia - ref_pos[ref_pos_index++]).norm2();
+    }
+#else
     for (size_t ia = 0; ia < atoms->size(); ia++) {
       value += ((*atoms)[ia].pos - ref_pos[ref_pos_index++]).norm2();
     }
+#endif // COLVARS_USE_SOA
     if (value < x.real_value) {
       x.real_value = value;
       best_perm_index = ip;
@@ -966,9 +1196,20 @@ void colvar::rmsd::calc_gradients()
 
   // Use the appropriate symmetry permutation of reference positions to calculate gradients
   size_t const start = atoms->size() * best_perm_index;
+#ifdef COLVARS_USE_SOA
+  for (size_t ia = 0; ia < atoms->size(); ia++) {
+    const cvm::atom_pos pos_ia(
+      atoms->pos_x(ia), atoms->pos_y(ia), atoms->pos_z(ia));
+    const cvm::rvector grad = (drmsddx2 * 2.0 * (pos_ia - ref_pos[start + ia]));
+    atoms->grad_x(ia) = grad.x;
+    atoms->grad_y(ia) = grad.y;
+    atoms->grad_z(ia) = grad.z;
+  }
+#else
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     (*atoms)[ia].grad = (drmsddx2 * 2.0 * ((*atoms)[ia].pos - ref_pos[start + ia]));
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -978,10 +1219,16 @@ void colvar::rmsd::calc_force_invgrads()
   ft.real_value = 0.0;
 
   // Note: gradient square norm is 1/N_atoms
-
+#ifdef COLVARS_USE_SOA
+  const size_t num_grad_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_grad_xyz; i++) {
+    ft.real_value += atoms->grad_x(i) * atoms->total_force_x(i);
+  }
+#else
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     ft.real_value += (*atoms)[ia].grad * (*atoms)[ia].total_force;
   }
+#endif // COLVARS_USE_SOA
   ft.real_value *= atoms->size();
 }
 
@@ -1130,7 +1377,11 @@ int colvar::eigenvector::init(std::string const &conf)
               "if this is not the desired behavior, disable them explicitly within the \"atoms\" block.\n");
     atoms->enable(f_ag_center);
     atoms->enable(f_ag_rotate);
+#ifdef COLVARS_USE_SOA
+    atoms->set_ref_pos_from_aos(ref_pos);
+#else
     atoms->ref_pos = ref_pos;
+#endif // COLVARS_USE_SOA
     atoms->center_ref_pos();
     atoms->disable(f_ag_fit_gradients); // cancel out if group is fitted on itself
                                         // and cvc is translationally invariant
@@ -1258,17 +1509,33 @@ int colvar::eigenvector::init(std::string const &conf)
 void colvar::eigenvector::calc_value()
 {
   x.real_value = 0.0;
+#ifdef COLVARS_USE_SOA
+  for (size_t i = 0; i < atoms->size(); i++) {
+    const cvm::atom_pos pos_i(
+      atoms->pos_x(i), atoms->pos_y(i), atoms->pos_z(i));
+    x.real_value += (pos_i - ref_pos[i]) * eigenvec[i];
+  }
+#else
   for (size_t i = 0; i < atoms->size(); i++) {
     x.real_value += ((*atoms)[i].pos - ref_pos[i]) * eigenvec[i];
   }
+#endif // COLVARS_USE_SOA
 }
 
 
 void colvar::eigenvector::calc_gradients()
 {
+#ifdef COLVARS_USE_SOA
+  for (size_t ia = 0; ia < atoms->size(); ia++) {
+    atoms->grad_x(ia) = eigenvec[ia].x;
+    atoms->grad_y(ia) = eigenvec[ia].y;
+    atoms->grad_z(ia) = eigenvec[ia].z;
+  }
+#else
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     (*atoms)[ia].grad = eigenvec[ia];
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -1276,11 +1543,18 @@ void colvar::eigenvector::calc_force_invgrads()
 {
   atoms->read_total_forces();
   ft.real_value = 0.0;
-
+#ifdef COLVARS_USE_SOA
+  const size_t num_grad_xyz = 3 * atoms->size();
+  for (size_t i = 0; i < num_grad_xyz; i++) {
+    ft.real_value += atoms->grad_x(i) * atoms->total_force_x(i);
+  }
+  ft.real_value *= eigenvec_invnorm2;
+#else
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     ft.real_value += eigenvec_invnorm2 * (*atoms)[ia].grad *
       (*atoms)[ia].total_force;
   }
+#endif // COLVARS_USE_SOA
 }
 
 
@@ -1381,7 +1655,13 @@ void colvar::cartesian::calc_value()
   size_t ia, j;
   for (ia = 0; ia < atoms->size(); ia++) {
     for (j = 0; j < dim; j++) {
+#ifdef COLVARS_USE_SOA
+      const cvm::atom_pos pos_ia(
+        atoms->pos_x(ia), atoms->pos_y(ia), atoms->pos_z(ia));
+      x.vector1d_value[dim*ia + j] = pos_ia[axes[j]];
+#else
       x.vector1d_value[dim*ia + j] = (*atoms)[ia].pos[axes[j]];
+#endif // COLVARS_USE_SOA
     }
   }
 }

--- a/src/colvarcomp_gpath.cpp
+++ b/src/colvarcomp_gpath.cpp
@@ -69,21 +69,33 @@ int colvar::CartesianBasedPath::init(std::string const &conf)
     }
     // Setup alignment to compute RMSD with respect to reference frames
     for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
-        cvm::atom_group* tmp_atoms = parse_group(conf, "atoms");
+        auto* tmp_atoms = parse_group(conf, "atoms");
         if (!has_user_defined_fitting) {
             // Swipe from the rmsd class
             tmp_atoms->enable(f_ag_center);
             tmp_atoms->enable(f_ag_rotate);
+#ifdef COLVARS_USE_SOA
+            tmp_atoms->set_ref_pos_from_aos(reference_frames[i_frame]);
+#else
             tmp_atoms->ref_pos = reference_frames[i_frame];
+#endif // COLVARS_USE_SOA
             tmp_atoms->center_ref_pos();
             tmp_atoms->enable(f_ag_fit_gradients);
         } else {
             // parse a group of atoms for fitting
             std::string fitting_group_name = std::string("fittingAtoms") + cvm::to_str(i_frame);
+#ifdef COLVARS_USE_SOA
+            cvm::atom_group_soa* tmp_fitting_atoms = new cvm::atom_group_soa(fitting_group_name.c_str());
+#else
             cvm::atom_group* tmp_fitting_atoms = new cvm::atom_group(fitting_group_name.c_str());
+#endif // COLVARS_USE_SOA
             tmp_fitting_atoms->parse(fitting_conf);
             tmp_fitting_atoms->disable(f_ag_scalable);
+#ifdef COLVARS_USE_SOA
+            tmp_fitting_atoms->fit_gradients.assign(3 * tmp_fitting_atoms->size(), 0);
+#else
             tmp_fitting_atoms->fit_gradients.assign(tmp_fitting_atoms->size(), cvm::atom_pos(0.0, 0.0, 0.0));
+#endif // COLVARS_USE_SOA
             std::string reference_position_file_lookup = "refPositionsFile" + cvm::to_str(i_frame + 1);
             std::string reference_position_filename;
             get_keyval(conf, reference_position_file_lookup.c_str(), reference_position_filename, std::string(""));
@@ -94,7 +106,11 @@ int colvar::CartesianBasedPath::init(std::string const &conf)
             tmp_atoms->enable(f_ag_rotate);
             tmp_atoms->b_user_defined_fit = true;
             tmp_atoms->disable(f_ag_scalable);
+#ifdef COLVARS_USE_SOA
+            tmp_atoms->set_ref_pos_from_aos(reference_fitting_position);
+#else
             tmp_atoms->ref_pos = reference_fitting_position;
+#endif // COLVARS_USE_SOA
             tmp_atoms->center_ref_pos();
             tmp_atoms->enable(f_ag_fit_gradients);
             tmp_atoms->enable(f_ag_fitting_group);
@@ -123,7 +139,15 @@ void colvar::CartesianBasedPath::computeDistanceToReferenceFrames(std::vector<cv
     for (size_t i_frame = 0; i_frame < reference_frames.size(); ++i_frame) {
         cvm::real frame_rmsd = 0.0;
         for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+#ifdef COLVARS_USE_SOA
+            const cvm::atom_pos p(
+                comp_atoms[i_frame]->pos_x(i_atom),
+                comp_atoms[i_frame]->pos_y(i_atom),
+                comp_atoms[i_frame]->pos_z(i_atom));
+            frame_rmsd += (p - reference_frames[i_frame][i_atom]).norm2();
+#else
             frame_rmsd += ((*(comp_atoms[i_frame]))[i_atom].pos - reference_frames[i_frame][i_atom]).norm2();
+#endif // COLVARS_USE_SOA
         }
         frame_rmsd /= cvm::real(atoms->size());
         frame_rmsd = cvm::sqrt(frame_rmsd);
@@ -215,10 +239,21 @@ void colvar::gspath::updateDistanceToReferenceFrames() {
 void colvar::gspath::prepareVectors() {
     size_t i_atom;
     for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+#ifdef COLVARS_USE_SOA
+        const cvm::atom_pos p1(comp_atoms[min_frame_index_1]->pos_x(i_atom),
+                               comp_atoms[min_frame_index_1]->pos_y(i_atom),
+                               comp_atoms[min_frame_index_1]->pos_z(i_atom));
+        v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - p1;
+        const cvm::atom_pos p2(comp_atoms[min_frame_index_2]->pos_x(i_atom),
+                               comp_atoms[min_frame_index_2]->pos_y(i_atom),
+                               comp_atoms[min_frame_index_2]->pos_z(i_atom));
+        v2[i_atom] = p2 - reference_frames[min_frame_index_2][i_atom];
+#else
         // v1 = s_m - z
         v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - (*(comp_atoms[min_frame_index_1]))[i_atom].pos;
         // v2 = z - s_(m-1)
         v2[i_atom] = (*(comp_atoms[min_frame_index_2]))[i_atom].pos - reference_frames[min_frame_index_2][i_atom];
+#endif // COLVARS_USE_SOA
     }
     if (min_frame_index_3 < 0 || min_frame_index_3 > M) {
         cvm::atom_pos reference_cog_1, reference_cog_2;
@@ -317,8 +352,17 @@ void colvar::gspath::calc_gradients() {
         tmp_atom_grad_v2[0] = sign * 0.5 * dfdv2[i_atom][0] / M;
         tmp_atom_grad_v2[1] = sign * 0.5 * dfdv2[i_atom][1] / M;
         tmp_atom_grad_v2[2] = sign * 0.5 * dfdv2[i_atom][2] / M;
+#ifdef COLVARS_USE_SOA
+        comp_atoms[min_frame_index_1]->grad_x(i_atom) += tmp_atom_grad_v1.x;
+        comp_atoms[min_frame_index_1]->grad_y(i_atom) += tmp_atom_grad_v1.y;
+        comp_atoms[min_frame_index_1]->grad_z(i_atom) += tmp_atom_grad_v1.z;
+        comp_atoms[min_frame_index_2]->grad_x(i_atom) += tmp_atom_grad_v2.x;
+        comp_atoms[min_frame_index_2]->grad_y(i_atom) += tmp_atom_grad_v2.y;
+        comp_atoms[min_frame_index_2]->grad_z(i_atom) += tmp_atom_grad_v2.z;
+#else
         (*(comp_atoms[min_frame_index_1]))[i_atom].grad += tmp_atom_grad_v1;
         (*(comp_atoms[min_frame_index_2]))[i_atom].grad += tmp_atom_grad_v2;
+#endif // COLVARS_USE_SOA
     }
 }
 
@@ -410,8 +454,19 @@ void colvar::gzpath::prepareVectors() {
     }
     const auto rot_mat_v4 = rot_v4.matrix();
     for (i_atom = 0; i_atom < atoms->size(); ++i_atom) {
+#ifdef COLVARS_USE_SOA
+        const cvm::atom_pos p1(comp_atoms[min_frame_index_1]->pos_x(i_atom),
+                               comp_atoms[min_frame_index_1]->pos_y(i_atom),
+                               comp_atoms[min_frame_index_1]->pos_z(i_atom));
+        const cvm::atom_pos p2(comp_atoms[min_frame_index_2]->pos_x(i_atom),
+                               comp_atoms[min_frame_index_2]->pos_y(i_atom),
+                               comp_atoms[min_frame_index_2]->pos_z(i_atom));
+        v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - p1;
+        v2[i_atom] = p2 - reference_frames[min_frame_index_2][i_atom];
+#else
         v1[i_atom] = reference_frames[min_frame_index_1][i_atom] - (*(comp_atoms[min_frame_index_1]))[i_atom].pos;
         v2[i_atom] = (*(comp_atoms[min_frame_index_2]))[i_atom].pos - reference_frames[min_frame_index_2][i_atom];
+#endif // COLVARS_USE_SOA
         // v4 only computes in gzpath
         // v4 = s_m - s_(m-1)
         v4[i_atom] = rot_mat_v4 * tmp_reference_frame_1[i_atom] - tmp_reference_frame_2[i_atom];
@@ -461,8 +516,17 @@ void colvar::gzpath::calc_gradients() {
     for (size_t i_atom = 0; i_atom < atoms->size(); ++i_atom) {
         tmp_atom_grad_v1 = -1.0 * dzdv1[i_atom];
         tmp_atom_grad_v2 = dzdv2[i_atom];
+#ifdef COLVARS_USE_SOA
+        comp_atoms[min_frame_index_1]->grad_x(i_atom) += tmp_atom_grad_v1.x;
+        comp_atoms[min_frame_index_1]->grad_y(i_atom) += tmp_atom_grad_v1.y;
+        comp_atoms[min_frame_index_1]->grad_z(i_atom) += tmp_atom_grad_v1.z;
+        comp_atoms[min_frame_index_2]->grad_x(i_atom) += tmp_atom_grad_v2.x;
+        comp_atoms[min_frame_index_2]->grad_y(i_atom) += tmp_atom_grad_v2.y;
+        comp_atoms[min_frame_index_2]->grad_z(i_atom) += tmp_atom_grad_v2.z;
+#else
         (*(comp_atoms[min_frame_index_1]))[i_atom].grad += tmp_atom_grad_v1;
         (*(comp_atoms[min_frame_index_2]))[i_atom].grad += tmp_atom_grad_v2;
+#endif // COLVARS_USE_SOA
     }
 }
 
@@ -768,7 +832,18 @@ void colvar::gspathCV::calc_gradients() {
                     // Loop over all atoms in the k-th atom group
                     for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
                         // Chain rule
+#ifdef COLVARS_USE_SOA
+                        cvm::rvector g(
+                            (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom),
+                            (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom),
+                            (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom));
+                        g = factor_polynomial * (g * tmp_cv_grad_v1[j_elem] + g * tmp_cv_grad_v2[j_elem]);
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom) = g.x;
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom) = g.y;
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom) = g.z;
+#else
                         (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = factor_polynomial * ((*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad * tmp_cv_grad_v1[j_elem] + (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad * tmp_cv_grad_v2[j_elem]);
+#endif // COLVARS_USE_SOA
                     }
                 }
             }
@@ -907,7 +982,18 @@ void colvar::gzpathCV::calc_gradients() {
                     // Loop over all atoms in the k-th atom group
                     for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
                         // Chain rule
+#ifdef COLVARS_USE_SOA
+                        cvm::rvector g(
+                            (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom),
+                            (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom),
+                            (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom));
+                        g = factor_polynomial * (g * tmp_cv_grad_v1[j_elem] + g * tmp_cv_grad_v2[j_elem]);
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom) = g.x;
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom) = g.y;
+                        (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom) = g.z;
+#else
                         (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = factor_polynomial * ((*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad * tmp_cv_grad_v1[j_elem] + (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad * tmp_cv_grad_v2[j_elem]);
+#endif // COLVARS_USE_SOA
                     }
                 }
             }

--- a/src/colvarcomp_neuralnetwork.cpp
+++ b/src/colvarcomp_neuralnetwork.cpp
@@ -178,7 +178,13 @@ void colvar::neuralNetwork::calc_gradients() {
             for (size_t j_elem = 0; j_elem < cv[i_cv]->value().size(); ++j_elem) {
                 for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
                     for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+#ifdef COLVARS_USE_SOA
+                        cv[i_cv]->atom_groups[k_ag]->grad_x(l_atom) *= factor_polynomial * factor;
+                        cv[i_cv]->atom_groups[k_ag]->grad_y(l_atom) *= factor_polynomial * factor;
+                        cv[i_cv]->atom_groups[k_ag]->grad_z(l_atom) *= factor_polynomial * factor;
+#else
                         (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = factor_polynomial * factor * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+#endif // COLVARS_USE_SOA
                     }
                 }
             }

--- a/src/colvarcomp_protein.cpp
+++ b/src/colvarcomp_protein.cpp
@@ -34,7 +34,11 @@ int colvar::alpha_angles::init(std::string const &conf)
   std::vector<int> residues;
 
   bool b_use_index_groups = false;
+#ifdef COLVARS_USE_SOA
+  cvm::atom_group_soa group_CA, group_N, group_O;
+#else
   cvm::atom_group group_CA, group_N, group_O;
+#endif // COLVARS_USE_SOA
 
   std::string residues_conf = "";
   std::string prefix;
@@ -66,9 +70,21 @@ int colvar::alpha_angles::init(std::string const &conf)
     get_keyval(conf, "prefix", prefix, "alpha_");
 
     // Not all groups are mandatory, parse silently
+#ifdef COLVARS_USE_SOA
+    {
+      // These lines must be in its own scope to ensure RAII
+      auto modify_group_CA = group_CA.get_atom_modifier();
+      auto modify_group_N = group_N.get_atom_modifier();
+      auto modify_group_O = group_O.get_atom_modifier();
+      modify_group_CA.add_index_group(prefix + "CA", true);
+      modify_group_N.add_index_group(prefix + "N", true);
+      modify_group_O.add_index_group(prefix + "O", true);
+    }
+#else
     group_CA.add_index_group(prefix + "CA", true);
     group_N.add_index_group(prefix + "N", true);
     group_O.add_index_group(prefix + "O", true);
+#endif // COLVARS_USE_SOA
     int na = group_CA.size();
     int nn = group_N.size();
     int no = group_O.size();
@@ -111,10 +127,21 @@ int colvar::alpha_angles::init(std::string const &conf)
         register_atom_group(theta.back()->atom_groups[2]);
       }
     } else {
+#ifdef COLVARS_USE_SOA
+      colvarproxy* const p = cvm::main()->proxy;
+#endif // COLVARS_USE_SOA
       for (size_t i = 0; i < residues.size()-2; i++) {
+#ifdef COLVARS_USE_SOA
+        theta.push_back(
+          new colvar::angle(
+            cvm::atom_group_soa::init_atom_from_proxy(p, r[i  ], "CA", sid),
+            cvm::atom_group_soa::init_atom_from_proxy(p, r[i+1], "CA", sid),
+            cvm::atom_group_soa::init_atom_from_proxy(p, r[i+2], "CA", sid)));
+#else
         theta.push_back(new colvar::angle(cvm::atom(r[i  ], "CA", sid),
                                           cvm::atom(r[i+1], "CA", sid),
                                           cvm::atom(r[i+2], "CA", sid)));
+#endif // COLVARS_USE_SOA
         register_atom_group(theta.back()->atom_groups[0]);
         register_atom_group(theta.back()->atom_groups[1]);
         register_atom_group(theta.back()->atom_groups[2]);
@@ -131,6 +158,9 @@ int colvar::alpha_angles::init(std::string const &conf)
     get_keyval(conf, "hBondExpDenom", ed, ed);
 
     if (hb_coeff > 0.0) {
+#ifdef COLVARS_USE_SOA
+      colvarproxy* const p = cvm::main()->proxy;
+#endif // COLVARS_USE_SOA
       if (b_use_index_groups) {
         if (group_N.size() < 5) {
           return cvm::error("Not enough atoms (" + cvm::to_str(group_N.size()) + ") in index group \"" + prefix + "N\"",
@@ -139,16 +169,30 @@ int colvar::alpha_angles::init(std::string const &conf)
         for (size_t i = 0; i < group_N.size()-4; i++) {
           // Note: we need to call the atom copy constructor here because
           // the h_bond constructor does not make copies of the provided atoms
+#ifdef COLVARS_USE_SOA
+          hb.push_back(
+            new colvar::h_bond(cvm::atom_group_soa::init_atom_from_proxy(p,group_O[i]),
+                               cvm::atom_group_soa::init_atom_from_proxy(p,group_N[i+4]),
+                               r0, en, ed));
+#else
           hb.push_back(new colvar::h_bond(cvm::atom(group_O[i]),
                                           cvm::atom(group_N[i+4]),
                                           r0, en, ed));
+#endif // COLVARS_USE_SOA
           register_atom_group(hb.back()->atom_groups[0]);
         }
       } else {
         for (size_t i = 0; i < residues.size()-4; i++) {
+#ifdef COLVARS_USE_SOA
+          hb.push_back(
+            new colvar::h_bond(cvm::atom_group_soa::init_atom_from_proxy(p,r[i  ], "O",  sid),
+                               cvm::atom_group_soa::init_atom_from_proxy(p,r[i+4], "N",  sid),
+                               r0, en, ed));
+#else
           hb.push_back(new colvar::h_bond(cvm::atom(r[i  ], "O",  sid),
                                           cvm::atom(r[i+4], "N",  sid),
                                           r0, en, ed));
+#endif // COLVARS_USE_SOA
           register_atom_group(hb.back()->atom_groups[0]);
         }
       }
@@ -251,11 +295,17 @@ void colvar::alpha_angles::collect_gradients(std::vector<int> const &atom_ids, s
       cvm::real const coeff = cvc_coeff * theta_norm * dfdt * (1.0/theta_tol);
 
       for (size_t j = 0; j < theta[i]->atom_groups.size(); j++) {
-        cvm::atom_group &ag = *(theta[i]->atom_groups[j]);
+        auto &ag = *(theta[i]->atom_groups[j]);
         for (size_t k = 0; k < ag.size(); k++) {
+#ifdef COLVARS_USE_SOA
+          size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
+                                      ag.id(k)) - atom_ids.begin();
+          atomic_gradients[a] += coeff * cvm::rvector(ag.grad_x(k), ag.grad_y(k), ag.grad_z(k));
+#else
           size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
                                       ag[k].id) - atom_ids.begin();
           atomic_gradients[a] += coeff * ag[k].grad;
+#endif // COLVARS_USE_SOA
         }
       }
     }
@@ -271,11 +321,17 @@ void colvar::alpha_angles::collect_gradients(std::vector<int> const &atom_ids, s
       cvm::real const coeff = cvc_coeff * 0.5 * hb_norm;
 
       for (size_t j = 0; j < hb[i]->atom_groups.size(); j++) {
-        cvm::atom_group &ag = *(hb[i]->atom_groups[j]);
+        auto &ag = *(hb[i]->atom_groups[j]);
         for (size_t k = 0; k < ag.size(); k++) {
+#ifdef COLVARS_USE_SOA
+          size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
+                                      ag.id(k)) - atom_ids.begin();
+          atomic_gradients[a] += coeff * cvm::rvector(ag.grad_x(k), ag.grad_y(k), ag.grad_z(k));
+#else
           size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
                                       ag[k].id) - atom_ids.begin();
           atomic_gradients[a] += coeff * ag[k].grad;
+#endif // COLVARS_USE_SOA
         }
       }
     }
@@ -347,7 +403,11 @@ int colvar::dihedPC::init(std::string const &conf)
   size_t n_residues;
   std::string residues_conf = "";
   std::string prefix;
+#ifdef COLVARS_USE_SOA
+  cvm::atom_group_soa group_CA, group_N, group_C;
+#else
   cvm::atom_group group_CA, group_N, group_C;
+#endif // COLVARS_USE_SOA
 
   // residueRange is mandatory for the topology-based case
   if (key_lookup(conf, "residueRange", &residues_conf)) {
@@ -374,9 +434,20 @@ int colvar::dihedPC::init(std::string const &conf)
     get_keyval(conf, "prefix", prefix, "dihed_");
 
     // All three groups are required
+#ifdef COLVARS_USE_SOA
+    {
+      auto modify_group_CA = group_CA.get_atom_modifier();
+      auto modify_group_N = group_N.get_atom_modifier();
+      auto modify_group_C = group_C.get_atom_modifier();
+      modify_group_CA.add_index_group(prefix + "CA");
+      modify_group_N.add_index_group(prefix + "N");
+      modify_group_C.add_index_group(prefix + "C");
+    }
+#else
     group_CA.add_index_group(prefix + "CA");
     group_N.add_index_group(prefix + "N");
     group_C.add_index_group(prefix + "C");
+#endif // COLVARS_USE_SOA
     int na = group_CA.size();
     int nn = group_N.size();
     int nc = group_C.size();
@@ -455,7 +526,9 @@ int colvar::dihedPC::init(std::string const &conf)
                              " (4 coeffs per residue, minus one residue).\n",
                              COLVARS_INPUT_ERROR);
   }
-
+#ifdef COLVARS_USE_SOA
+  colvarproxy* const p = cvm::main()->proxy;
+#endif // COLVARS_USE_SOA
   for (size_t i = 0; i < n_residues-1; i++) {
     // Psi
     if (b_use_index_groups) {
@@ -464,10 +537,19 @@ int colvar::dihedPC::init(std::string const &conf)
                                             group_C[i],
                                             group_N[i+1]));
     } else {
+#ifdef COLVARS_USE_SOA
+      theta.push_back(
+        new colvar::dihedral(
+          cvm::atom_group_soa::init_atom_from_proxy(p,r[i  ], "N", sid),
+          cvm::atom_group_soa::init_atom_from_proxy(p,r[i  ], "CA", sid),
+          cvm::atom_group_soa::init_atom_from_proxy(p,r[i  ], "C", sid),
+          cvm::atom_group_soa::init_atom_from_proxy(p,r[i+1], "N", sid)));
+#else
       theta.push_back(new colvar::dihedral(cvm::atom(r[i  ], "N", sid),
                                            cvm::atom(r[i  ], "CA", sid),
                                            cvm::atom(r[i  ], "C", sid),
                                            cvm::atom(r[i+1], "N", sid)));
+#endif // COLVARS_USE_SOA
     }
     register_atom_group(theta.back()->atom_groups[0]);
     register_atom_group(theta.back()->atom_groups[1]);
@@ -480,10 +562,18 @@ int colvar::dihedPC::init(std::string const &conf)
                                            group_CA[i+1],
                                            group_C[i+1]));
     } else {
+#ifdef COLVARS_USE_SOA
+      theta.push_back(
+        new colvar::dihedral(cvm::atom_group_soa::init_atom_from_proxy(p,r[i  ], "C", sid),
+                             cvm::atom_group_soa::init_atom_from_proxy(p,r[i+1], "N", sid),
+                             cvm::atom_group_soa::init_atom_from_proxy(p,r[i+1], "CA", sid),
+                             cvm::atom_group_soa::init_atom_from_proxy(p,r[i+1], "C", sid)));
+#else
       theta.push_back(new colvar::dihedral(cvm::atom(r[i  ], "C", sid),
                                            cvm::atom(r[i+1], "N", sid),
                                            cvm::atom(r[i+1], "CA", sid),
                                            cvm::atom(r[i+1], "C", sid)));
+#endif // COLVARS_USE_SOA
     }
     register_atom_group(theta.back()->atom_groups[0]);
     register_atom_group(theta.back()->atom_groups[1]);
@@ -541,11 +631,17 @@ void colvar::dihedPC::collect_gradients(std::vector<int> const &atom_ids, std::v
     cvm::real const coeff = cvc_coeff * (coeffs[2*i] * dcosdt + coeffs[2*i+1] * dsindt);
 
     for (size_t j = 0; j < theta[i]->atom_groups.size(); j++) {
-      cvm::atom_group &ag = *(theta[i]->atom_groups[j]);
+      auto &ag = *(theta[i]->atom_groups[j]);
       for (size_t k = 0; k < ag.size(); k++) {
+#ifdef COLVARS_USE_SOA
+        size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
+                                    ag.id(k)) - atom_ids.begin();
+        atomic_gradients[a] += coeff * cvm::rvector(ag.grad_x(k), ag.grad_y(k), ag.grad_z(k));
+#else
         size_t a = std::lower_bound(atom_ids.begin(), atom_ids.end(),
                                     ag[k].id) - atom_ids.begin();
         atomic_gradients[a] += coeff * ag[k].grad;
+#endif // COLVARS_USE_SOA
       }
     }
   }

--- a/src/colvarcomp_torchann.cpp
+++ b/src/colvarcomp_torchann.cpp
@@ -167,7 +167,13 @@ void colvar::torchANN::calc_gradients() {
 	const cvm::real factor = input_grad[l+j_elem].item<double>();
 	for (size_t k_ag = 0 ; k_ag < cv[i_cv]->atom_groups.size(); ++k_ag) {
 	  for (size_t l_atom = 0; l_atom < (cv[i_cv]->atom_groups)[k_ag]->size(); ++l_atom) {
+#ifdef COLVARS_USE_SOA
+            (cv[i_cv]->atom_groups)[k_ag]->grad_x(l_atom) *= factor_polynomial * factor;
+            (cv[i_cv]->atom_groups)[k_ag]->grad_y(l_atom) *= factor_polynomial * factor;
+            (cv[i_cv]->atom_groups)[k_ag]->grad_z(l_atom) *= factor_polynomial * factor;
+#else
 	    (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad = factor_polynomial * factor * (*(cv[i_cv]->atom_groups)[k_ag])[l_atom].grad;
+#endif // COLVARS_USE_SOA
 	  }
 	}
       }

--- a/src/colvarcomp_volmaps.cpp
+++ b/src/colvarcomp_volmaps.cpp
@@ -99,8 +99,13 @@ void colvar::map_total::calc_value()
       flags |= colvarproxy::volmap_flag_use_atom_field;
       w = &(atom_weights[0]);
     }
+#ifdef COLVARS_USE_SOA
+    proxy->compute_volmap(flags, volmap_id, atoms,
+                          &(x.real_value), w);
+#else
     proxy->compute_volmap(flags, volmap_id, atoms->begin(), atoms->end(),
                           &(x.real_value), w);
+#endif // COLVARS_USE_SOA
   } else {
     // Get the externally computed value
     x.real_value = proxy->get_volmap_value(volmap_index);

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -23,6 +23,8 @@
 #define COLVARS_BOUNDED_INV_TRIGONOMETRIC_FUNC
 #endif
 
+#define COLVARS_USE_SOA
+
 /*! \mainpage Main page
 This is the Developer's documentation for the Collective Variables module (Colvars).
 
@@ -234,6 +236,7 @@ static inline real acos(real const &x)
   // allow these classes to access protected data
   class atom;
   class atom_group;
+  class atom_group_soa;
   typedef std::vector<atom>::iterator       atom_iter;
   typedef std::vector<atom>::const_iterator atom_const_iter;
 
@@ -309,13 +312,22 @@ private:
   std::vector<int> colvars_smp_items;
 
   /// Array of named atom groups
+#ifdef COLVARS_USE_SOA
+  std::vector<atom_group_soa *> named_atom_groups_soa;
+#else
   std::vector<atom_group *> named_atom_groups;
+#endif // COLVARS_USE_SOA
 public:
+
+#ifdef COLVARS_USE_SOA
+  void register_named_atom_group_soa(atom_group_soa *ag);
+  void unregister_named_atom_group_soa(atom_group_soa *ag);
+#else
   /// Register a named atom group into named_atom_groups
   void register_named_atom_group(atom_group *ag);
-
   /// Remove a named atom group from named_atom_groups
   void unregister_named_atom_group(atom_group *ag);
+#endif
 
   /// Array of collective variables
   std::vector<colvar *> *variables();
@@ -569,7 +581,11 @@ public:
   static colvar * colvar_by_name(std::string const &name);
 
   /// Look up a named atom group by name; returns NULL if not found
+#ifdef COLVARS_USE_SOA
+  static atom_group_soa * atom_group_soa_by_name(std::string const& name);
+#else
   static atom_group * atom_group_by_name(std::string const &name);
+#endif // COLVARS_USE_SOA
 
   /// Load new configuration for the given bias -
   /// currently works for harmonic (force constant and/or centers)
@@ -800,17 +816,32 @@ public:
   /// and this string is non-empty, select atoms for which this field is
   /// non-zero \param pdb_field_value (optional) if non-zero, select only
   /// atoms whose pdb_field equals this
+#ifdef COLVARS_USE_SOA
+  static int load_coords(char const *filename,
+                         std::vector<rvector> *pos,
+                         atom_group_soa *atoms,
+                         std::string const &pdb_field,
+                         double pdb_field_value = 0.0);
+#else
   static int load_coords(char const *filename,
                          std::vector<rvector> *pos,
                          atom_group *atoms,
                          std::string const &pdb_field,
                          double pdb_field_value = 0.0);
+#endif // COLVARS_USE_SOA
 
   /// Load coordinates into an atom group from an XYZ file (assumes Angstroms)
+#ifdef COLVARS_USE_SOA
+  int load_coords_xyz(char const *filename,
+                      std::vector<rvector> *pos,
+                      atom_group_soa *atoms,
+                      bool keep_open = false);
+#else
   int load_coords_xyz(char const *filename,
                       std::vector<rvector> *pos,
                       atom_group *atoms,
                       bool keep_open = false);
+#endif // COLVARS_USE_SOA
 
   /// Frequency for collective variables trajectory output
   static size_t cv_traj_freq;

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -547,6 +547,16 @@ int colvarproxy::load_atoms_pdb(char const * /* filename */,
       COLVARS_NOT_IMPLEMENTED);
 }
 
+int colvarproxy::load_atoms_pdb(char const * /* filename */,
+                                cvm::atom_group_soa & /* atoms */,
+                                std::string const & /* pdb_field */,
+                                double /* pdb_field_value */)
+{
+  return cvm::error(
+      "Error: loading atom indices from a PDB file is currently not implemented in " +
+          engine_name() + ".\n",
+      COLVARS_NOT_IMPLEMENTED);
+}
 
 int colvarproxy::load_coords_pdb(char const * /* filename */,
                                  std::vector<cvm::atom_pos> & /* pos */,

--- a/src/colvarproxy.h
+++ b/src/colvarproxy.h
@@ -590,6 +590,9 @@ public:
   virtual int load_atoms_pdb(char const *filename, cvm::atom_group &atoms,
                              std::string const &pdb_field, double pdb_field_value);
 
+  virtual int load_atoms_pdb(char const *filename, cvm::atom_group_soa &atoms,
+                             std::string const &pdb_field, double pdb_field_value);
+
   /// \brief Load a set of coordinates from a PDB file
   /// \param[in] filename name of the file
   /// \param[in,out] pos array of coordinates to fill; if not empty, the number of its elements must match

--- a/src/colvarproxy_volmaps.cpp
+++ b/src/colvarproxy_volmaps.cpp
@@ -108,13 +108,20 @@ int colvarproxy_volmaps::get_volmap_id_from_name(char const *volmap_name)
   return -1;
 }
 
-
+#ifdef COLVARS_USE_SOA
+int colvarproxy_volmaps::compute_volmap(int /* flags */,
+                                        int /* volmap_id */,
+                                        cvm::atom_group_soa* ag,
+                                        cvm::real * /* value */,
+                                        cvm::real * /* atom_field */)
+#else
 int colvarproxy_volmaps::compute_volmap(int /* flags */,
                                         int /* volmap_id */,
                                         cvm::atom_iter /* atom_begin */,
                                         cvm::atom_iter /* atom_end */,
                                         cvm::real * /* value */,
                                         cvm::real * /* atom_field */)
+#endif // COLVARS_USE_SOA
 {
   return COLVARS_NOT_IMPLEMENTED;
 }

--- a/src/colvarproxy_volmaps.h
+++ b/src/colvarproxy_volmaps.h
@@ -3,6 +3,8 @@
 #ifndef COLVARPROXY_VOLMAPS_H
 #define COLVARPROXY_VOLMAPS_H
 
+#include "colvarmodule.h"
+
 
 /// \brief Container of grid-based objects
 class colvarproxy_volmaps {
@@ -75,6 +77,14 @@ public:
   }
 
   /// Re-weigh an atomic field (e.g. a colvar) by the value of a volumetric map
+
+#ifdef COLVARS_USE_SOA
+  virtual int compute_volmap(int flags,
+                             int volmap_id,
+                             cvm::atom_group_soa* ag,
+                             cvm::real *value,
+                             cvm::real *atom_field);
+#else
   /// \param flags Combination of flags
   /// \param volmap_id Numeric index of the map (no need to request it)
   /// \param atom_begin Iterator pointing to first atom
@@ -87,6 +97,7 @@ public:
                              cvm::atom_iter atom_end,
                              cvm::real *value,
                              cvm::real *atom_field);
+#endif // COLVARS_USE_SOA
 
   /// Flags controlling what computation is done on the map
   enum {

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1380,10 +1380,10 @@ public:
   /// \brief The rotation itself (implemented as a quaternion)
   cvm::quaternion q;
 
-  template <typename T1, typename T2>
+  template <typename T1, typename T2, bool soa>
   friend struct rotation_derivative;
 
-  template<typename T1, typename T2>
+  template<typename T1, typename T2, bool soa>
   friend void debug_gradients(
     cvm::rotation &rot,
     const std::vector<T1> &pos1,
@@ -1401,8 +1401,16 @@ public:
   /// DOI: 10.1002/jcc.20110  PubMed: 15376254
   void calc_optimal_rotation(std::vector<atom_pos> const &pos1,
                              std::vector<atom_pos> const &pos2);
+#ifdef COLVARS_USE_SOA
+  void calc_optimal_rotation_soa(
+    std::vector<cvm::real> const &pos1,
+    std::vector<cvm::real> const &pos2,
+    const size_t num_atoms_pos1,
+    const size_t num_atoms_pos2);
+#else
   void calc_optimal_rotation(std::vector<cvm::atom> const &pos1,
                              std::vector<atom_pos> const &pos2);
+#endif // COLVARS_USE_SOA
 
   /// Initialize member data
   int init();
@@ -1537,8 +1545,11 @@ protected:
   /// Build the correlation matrix C (used by calc_optimal_rotation())
   void build_correlation_matrix(std::vector<cvm::atom_pos> const &pos1,
                                 std::vector<cvm::atom_pos> const &pos2);
+#ifdef COLVARS_USE_SOA
+#else
   void build_correlation_matrix(std::vector<cvm::atom> const &pos1,
                                 std::vector<cvm::atom_pos> const &pos2);
+#endif // COLVARS_USE_SOA
 
   /// \brief Actual implementation of `calc_optimal_rotation` (and called by it)
   void calc_optimal_rotation_impl();

--- a/vmd/src/colvarproxy_vmd.C
+++ b/vmd/src/colvarproxy_vmd.C
@@ -826,11 +826,11 @@ void colvarproxy_vmd::compute_voldata(VolumetricData const *voldata,
   int i = 0;
   float coord[3], voxcoord[3], grad[3];
   cvm::rvector dV(0.0);
-  cvm::atom_iter ai = atom_begin;
   cvm::atom_pos const origin(0.0, 0.0, 0.0);
 #ifdef COLVARS_USE_SOA
-  for (; i < atoms.size(); ++i) {
+  for (; i < atoms->size(); ++i) {
 #else
+  cvm::atom_iter ai = atom_begin;
   for ( ; ai != atom_end; ai++, i++) {
 #endif // COLVARS_USE_SOA
     // Wrap around the origin

--- a/vmd/src/colvarproxy_vmd.h
+++ b/vmd/src/colvarproxy_vmd.h
@@ -22,6 +22,7 @@
 #include "colvarproxy.h"
 #include "colvartypes.h"
 #include "colvaratoms.h"
+#include "colvaratoms_soa.h"
 
 
 int tcl_colvars(ClientData clientData, Tcl_Interp *interp,
@@ -80,10 +81,17 @@ public:
                                            std::vector<const colvarvalue *> const &cvc_values,
                                            std::vector<cvm::matrix2d<cvm::real> > &gradient);
 
+#ifdef COLVARS_USE_SOA
+  virtual int load_atoms_pdb(char const *filename,
+                             cvm::atom_group_soa &atoms,
+                             std::string const &pdb_field,
+                             double const pdb_field_value = 0.0);
+#else
   virtual int load_atoms_pdb(char const *filename,
                              cvm::atom_group &atoms,
                              std::string const &pdb_field,
                              double const pdb_field_value = 0.0);
+#endif // COLVARS_USE_SOA
 
   virtual int load_coords_pdb(char const *filename,
                               std::vector<cvm::atom_pos> &pos,
@@ -116,15 +124,23 @@ public:
 
   virtual int compute_volmap(int flags,
                              int volmap_id,
+#ifdef COLVARS_USE_SOA
+                             cvm::atom_group_soa* atoms,
+#else
                              cvm::atom_iter atom_begin,
                              cvm::atom_iter atom_end,
+#endif // COLVARS_USE_SOA
                              cvm::real *value,
                              cvm::real *atom_field);
 
   template<int flags>
   void compute_voldata(VolumetricData const *voldata,
+#ifdef COLVARS_USE_SOA
+                       cvm::atom_group_soa* atoms,
+#else
                        cvm::atom_iter atom_begin,
                        cvm::atom_iter atom_end,
+#endif // COLVARS_USE_SOA
                        cvm::real *value,
                        cvm::real *atom_field);
 

--- a/vmd/src/colvars_files.pl
+++ b/vmd/src/colvars_files.pl
@@ -12,6 +12,7 @@ $colvars_defines = " -DVMDCOLVARS";
 @colvars_cc      = ();
 @colvars_cu      = ();
 @colvars_ccpp    = ('colvaratoms.C',
+                    'colvaratoms_soa.C',
                     'colvarbias.C',
                     'colvarbias_abf.C',
                     'colvarbias_abmd.C',
@@ -62,6 +63,7 @@ $colvars_defines = " -DVMDCOLVARS";
                     'colvar_neuralnetworkcompute.h',
                     'colvar_rotation_derivative.h',
                     'colvaratoms.h',
+                    'colvaratoms_soa.h',
                     'colvarbias.h',
                     'colvarbias_abf.h',
                     'colvarbias_abmd.h',


### PR DESCRIPTION
This is a PR with massive changes to introduce the SOA atom group class `cvm::atom_group_soa`, which tries to implement the first step in https://github.com/Colvars/colvars/discussions/655. Currently there are two LAMMPS tests failed but I cannot figure out why for the time being.