### PR TITLE
Rename m_output_index to output_component in torchANN

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -3814,7 +3814,7 @@ This component requires that \MDENGINE{} is linked against the libTorch library;
     \texttt{torchANN}}{%
     Name of the file containing the model (PyTorch format)}{%
     filename}{%
-    This file contains the PyTorch model, as saved for example by the \texttt{torch.save()} function.
+    This file contains the PyTorch model, as saved for example by the \texttt{torch.jit.save()} function.
   }
 
 \item %

--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -3818,14 +3818,14 @@ This component requires that \MDENGINE{} is linked against the libTorch library;
   }
 
 \item %
-  \labelkey{colvar|torchANN|m_output_index}
+  \labelkey{colvar|torchANN|output_component}
   \keydef
-    {m\_output\_index}{%
+    {output\_component}{%
     \texttt{torchANN}}{%
-    Index of the component to use}{%
+    Index of the output node to use}{%
     0-based integer}{%
     0}{%
-    When the output of the ANN has multiple components, this option selects the component to be used as the collective variable.
+    This option specifies the index of the output node to be used as the value collective variable (see also the equivalent keyword \refkey{output\_component}{colvar|NeuralNetwork|output_component} in the built-in neural network implementation).
   }
 
 \item %

--- a/src/colvarcomp_torchann.cpp
+++ b/src/colvarcomp_torchann.cpp
@@ -15,6 +15,7 @@
 
 #include "colvarcomp_torchann.h"
 
+
 #ifdef COLVARS_TORCH
 
 colvar::torchANN::torchANN()
@@ -40,8 +41,14 @@ int colvar::torchANN::init(std::string const &conf) {
     return cvm::error("Error: couldn't load libtorch model (see below).\n" + cvm::to_str(e.what()),
                       COLVARS_INPUT_ERROR);
   }
-  get_keyval(conf, "m_output_index", m_output_index, 0);
-  get_keyval(conf, "doubleInputTensor", use_double_input, false);
+
+  auto const legacy_keyword = get_keyval(conf, "m_output_index", m_output_index, m_output_index);
+  if (legacy_keyword) {
+    cvm::log("Warning: m_output_index is a deprecated keyword, please use output_component instead.\n");
+  }
+  get_keyval(conf, "output_component", m_output_index, m_output_index);
+
+  get_keyval(conf, "doubleInputTensor", use_double_input, use_double_input);
   //get_keyval(conf, "useGPU", use_gpu, false);
 
   cvc_indices.resize(cv.size(),0);

--- a/src/colvarcomp_torchann.h
+++ b/src/colvarcomp_torchann.h
@@ -29,8 +29,8 @@ class colvar::torchANN
 protected:
     torch::jit::script::Module nn;
     /// the index of nn output component
-    size_t m_output_index;
-    bool use_double_input;
+    size_t m_output_index = 0;
+    bool use_double_input = false;
     //bool use_gpu;
     // 1d tensor, concatenation of values of sub-cvcs
     torch::Tensor input_tensor;


### PR DESCRIPTION
Make the option more consistent with the `neuralNetwork` component.

Also fix the example of the PyTorch code in the doc