### PR TITLE
fix: synchronize the reduction change from NAMD

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -608,7 +608,7 @@ void colvarproxy_namd::calculate()
   #if !defined(NAMD_UNIFIED_REDUCTION)
   reduction->submit();
   #else
-  submitReduction();
+  // submitReduction();
   #endif
   #endif
 


### PR DESCRIPTION
The submit of reductions has been moved to the main GlobalMaster class. See https://gitlab.com/tcbgUIUC/namd/-/merge_requests/410 for more information.

This PR also requires updating the https://github.com/Colvars/namd repo.