### PR TITLE
fix: try fixing the orientation sign

### DIFF
--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -142,15 +142,16 @@ void colvar::orientation::apply_force(colvarvalue const &force)
   cvm::quaternion const &FQ = force.quaternion_value;
 
   if (!atoms->noforce) {
+    const cvm::real sign = (rot.q).inner(ref_quat) >= 0.0 ? 1.0 : -1.0;
     rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
     cvm::vector1d<cvm::rvector> dq0_2;
     auto ag_force = atoms->get_group_force_object();
     for (size_t ia = 0; ia < atoms->size(); ia++) {
       rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-      const auto f_ia = FQ[0] * dq0_2[0] +
+      const auto f_ia = sign * (FQ[0] * dq0_2[0] +
                         FQ[1] * dq0_2[1] +
                         FQ[2] * dq0_2[2] +
-                        FQ[3] * dq0_2[3];
+                        FQ[3] * dq0_2[3]);
       ag_force.add_atom_force(ia, f_ia);
     }
   }
@@ -206,8 +207,9 @@ void colvar::orientation_angle::calc_value()
 
 void colvar::orientation_angle::calc_gradients()
 {
+  const cvm::real sign = (rot.q).q0 >= 0.0 ? 1.0 : -1.0;
   cvm::real const dxdq0 =
-    ( ((rot.q).q0 * (rot.q).q0 < 1.0) ?
+    sign * ( ((rot.q).q0 * (rot.q).q0 < 1.0) ?
       ((180.0 / PI) * (-2.0) / cvm::sqrt(1.0 - ((rot.q).q0 * (rot.q).q0))) :
       0.0 );
 


### PR DESCRIPTION
An attempt to fix #827

It look likes that the sign does not affect the dynamics in the NAMD tests, but I am not sure if the tests cover both the positive and the negative cases.