### PR TITLE
fix: save the gradients before calc_value in debug_gradients

### DIFF
--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include "colvardeps.h"
 #include "colvarmodule.h"
 #include "colvarvalue.h"
 #include "colvar.h"
@@ -1184,6 +1185,7 @@ int colvar::eigenvector::init(std::string const &conf)
               "if this is not the desired behavior, disable them explicitly within the \"atoms\" block.\n");
     atoms->enable(f_ag_center);
     atoms->enable(f_ag_rotate);
+    atoms->enable(f_ag_fit_gradients);
     atoms->set_ref_pos_from_aos(ref_pos);
     atoms->center_ref_pos();
   }


### PR DESCRIPTION
This commit saves the gradients and fit gradients for all atom groups in a CVC before changing the atom positions in calc_value(), since some CVCs compute the gradients in calc_value() and therefore change the gradients buffers.

This commit also reverts 2bafda0346c0b6789f661ec211dea31675f7aabe since enable(f_ag_fit_gradients) is necessary for running possibly do_feature_side_effects that makes thing work.