### PR TITLE
Use two-point numerical difference for debug gradients and commutative relative error calculation

### DIFF
--- a/tests/input_files/orientationangle-fitgroup_harmonic-fixed/test.in
+++ b/tests/input_files/orientationangle-fitgroup_harmonic-fixed/test.in
@@ -11,6 +11,7 @@ colvar {
     width 0.5
 
     orientationAngle {
+        debugGradients on
         atoms {
             indexGroup RMSD_atoms
             centerToReference yes

--- a/tests/input_files/orientationangle_harmonic-fixed/test.in
+++ b/tests/input_files/orientationangle_harmonic-fixed/test.in
@@ -11,6 +11,7 @@ colvar {
     width 0.5
 
     orientationAngle {
+        debugGradients on
         atoms {
             indexGroup RMSD_atoms
         }

--- a/tests/orientationangle-fitgroup.in
+++ b/tests/orientationangle-fitgroup.in
@@ -7,6 +7,7 @@ colvar {
     width 0.5
 
     orientationAngle {
+        debugGradients on
         atoms {
             indexGroup RMSD_atoms
             centerToReference yes

--- a/tests/orientationangle.in
+++ b/tests/orientationangle.in
@@ -7,6 +7,7 @@ colvar {
     width 0.5
 
     orientationAngle {
+        debugGradients on
         atoms {
             indexGroup RMSD_atoms
         }


### PR DESCRIPTION
This PR should solve the issue of running the gradient tests on ARM64 and possibly on x86-64 with the Intel compiler. The relative error is computed with a commutative formula from https://floating-point-gui.de/errors/comparison/. This PR also enables the tests for the orientation angle CVC.