### PR TITLE
Optimize the calculation of fit gradients and update the documentation (fix #560)

### DIFF
--- a/doc/colvars-refman-main.tex
+++ b/doc/colvars-refman-main.tex
@@ -5252,10 +5252,16 @@ The following options have default values appropriate for the vast majority of a
     the gradients of some colvars include terms proportional to
     $\partial{}R/\partial\mathbf{x}_{i}$ (rotational gradients) and
     $\partial\mathbf{x}^{\mathrm{C}}/\partial\mathbf{x}_{i}$ (translational gradients).
+    In practice, these terms are calculated as follows,\newline
+    $\begin{aligned}
+\nabla_k \zeta(\mathbf{X})&=\sum_{l,\rm main}\left[\nabla_l f \cdot \nabla_k R\left(\mathbf{x}_l-\mathbf{\bar{x}}^{\rm (fit)}\right) - \frac{1}{n^{\rm (fit)}} \nabla_l f \cdot R \mathbbm{1}\right] \\
+&=\left(\sum_{l,\rm main}\nabla_l f \cdot\frac{\partial R}{\partial q_0}\left(\mathbf{x}_l-\mathbf{\bar{x}}^{\rm (fit)}\right), \sum_{l,\rm main}\nabla_l f \cdot\frac{\partial R}{\partial q_1}\left(\mathbf{x}_l-\mathbf{\bar{x}}^{\rm (fit)}\right), \sum_{l,\rm main}\nabla_l f \cdot\frac{\partial R}{\partial q_2}\left(\mathbf{x}_l-\mathbf{\bar{x}}^{\rm (fit)}\right), \right.\\
+&\left.\sum_{l,\rm main}\nabla_l f \cdot\frac{\partial R}{\partial q_3}\left(\mathbf{x}_l-\mathbf{\bar{x}}^{\rm (fit)}\right)\right) \cdot \left(\nabla_k q_0, \nabla_k q_1, \nabla_k q_2, \nabla_k q_3\right)-\frac{1}{n^{\rm (fit)}} R^{\intercal}\sum_{l,\rm main}{\nabla_l f}
+\end{aligned}$\newline
     By default, these terms are calculated and included in the total gradients;
     if this option is set to \texttt{off}, they are neglected.
-    In the case of a minimum RMSD component, this flag is automatically disabled because the contributions of those derivatives to the gradients cancel out; other types of variable will require projecting each of the gradients of the variable onto each of the gradients of the roto-translation (i.e.{} a $O(N^2)$ loop).
-    When \refkey{fittingGroup}{atom-group|fittingGroup} is enabled, the computation is a $O(N\times{}M)$ loop for all variables, including RMSDs.
+    In the case of a minimum RMSD component, this flag is automatically disabled because the contributions of those derivatives to the gradients cancel out; other types of variable will require projecting each of the gradients of the variable onto each of the gradients of the roto-translation.
+    When \refkey{fittingGroup}{atom-group|fittingGroup} is enabled, the computation is a $O(n^{(\rm fit)}+n^{(\rm main)})$ loop for all variables, including RMSDs.
 }
 
 \end{itemize}

--- a/doc/colvars-refman.tex
+++ b/doc/colvars-refman.tex
@@ -15,6 +15,7 @@
 
 \usepackage{amsmath}
 \usepackage{amssymb}
+\usepackage{bbm}
 \usepackage{mathrsfs}
 
 \usepackage[T1]{fontenc}

--- a/src/colvar_rotation_derivative.h
+++ b/src/colvar_rotation_derivative.h
@@ -330,10 +330,10 @@ struct rotation_derivative {
     const cvm::rvector (&ds)[4][4],
     cvm::rvector* _noalias const dl0_out,
     std::array<cvm::rvector, 4>* _noalias const dq0_out,
-    cvm::matrix2d<cvm::rvector>* _noalias const ds_out) const {
+    std::array<std::array<cvm::rvector, 4>, 4>* _noalias const ds_out) const {
     if (use_ds) {
       // this code path is for debug_gradients, so not necessary to unroll the loop
-      *ds_out = cvm::matrix2d<cvm::rvector>(4, 4);
+      *ds_out = std::array<std::array<cvm::rvector, 4>, 4>();
       for (int i = 0; i < 4; ++i) {
         for (int j = 0; j < 4; ++j) {
           (*ds_out)[i][j] = ds[i][j];
@@ -465,7 +465,7 @@ struct rotation_derivative {
   void calc_derivative_wrt_group1(
     size_t ia, cvm::rvector* _noalias const dl0_1_out = nullptr,
     std::array<cvm::rvector, 4>* _noalias const dq0_1_out = nullptr,
-    cvm::matrix2d<cvm::rvector>* _noalias const ds_1_out = nullptr) const {
+    std::array<std::array<cvm::rvector, 4>, 4>* _noalias const ds_1_out = nullptr) const {
       // if (dl0_1_out == nullptr && dq0_1_out == nullptr) return;
       const cvm::real a2x = m_pos2[ia];
       const cvm::real a2y = m_pos2[ia + m_num_atoms_pos2];
@@ -491,7 +491,7 @@ struct rotation_derivative {
   void calc_derivative_wrt_group2(
     size_t ia, cvm::rvector* _noalias const dl0_2_out = nullptr,
     std::array<cvm::rvector, 4>* _noalias const dq0_2_out = nullptr,
-    cvm::matrix2d<cvm::rvector>* _noalias const ds_2_out = nullptr) const {
+    std::array<std::array<cvm::rvector, 4>, 4>* _noalias const ds_2_out = nullptr) const {
     // if (dl0_2_out == nullptr && dq0_2_out == nullptr) return;
     const cvm::real a1x = m_pos1[ia];
     const cvm::real a1y = m_pos1[ia + m_num_atoms_pos1];

--- a/src/colvar_rotation_derivative.h
+++ b/src/colvar_rotation_derivative.h
@@ -4,6 +4,7 @@
 #include "colvartypes.h"
 #include <type_traits>
 #include <cstring>
+#include <array>
 
 #ifndef _noalias
 #if defined(__INTEL_COMPILER) || (defined(__PGI) && !defined(__NVCOMPILER))
@@ -328,7 +329,7 @@ struct rotation_derivative {
   void calc_derivative_impl(
     const cvm::rvector (&ds)[4][4],
     cvm::rvector* _noalias const dl0_out,
-    cvm::vector1d<cvm::rvector>* _noalias const dq0_out,
+    std::array<cvm::rvector, 4>* _noalias const dq0_out,
     cvm::matrix2d<cvm::rvector>* _noalias const ds_out) const {
     if (use_ds) {
       // this code path is for debug_gradients, so not necessary to unroll the loop
@@ -367,7 +368,7 @@ struct rotation_derivative {
     }
     if (use_dq) {
       // we can skip this check if a fixed-size array is used
-      if (dq0_out->size() != 4) dq0_out->resize(4);
+      // if (dq0_out->size() != 4) dq0_out->resize(4);
       /* manually loop unrolling of the following loop:
         dq0_1.reset();
         for (size_t p = 0; p < 4; p++) {
@@ -463,7 +464,7 @@ struct rotation_derivative {
   template <bool use_dl, bool use_dq, bool use_ds>
   void calc_derivative_wrt_group1(
     size_t ia, cvm::rvector* _noalias const dl0_1_out = nullptr,
-    cvm::vector1d<cvm::rvector>* _noalias const dq0_1_out = nullptr,
+    std::array<cvm::rvector, 4>* _noalias const dq0_1_out = nullptr,
     cvm::matrix2d<cvm::rvector>* _noalias const ds_1_out = nullptr) const {
       // if (dl0_1_out == nullptr && dq0_1_out == nullptr) return;
       const cvm::real a2x = m_pos2[ia];
@@ -489,7 +490,7 @@ struct rotation_derivative {
   template <bool use_dl, bool use_dq, bool use_ds>
   void calc_derivative_wrt_group2(
     size_t ia, cvm::rvector* _noalias const dl0_2_out = nullptr,
-    cvm::vector1d<cvm::rvector>* _noalias const dq0_2_out = nullptr,
+    std::array<cvm::rvector, 4>* _noalias const dq0_2_out = nullptr,
     cvm::matrix2d<cvm::rvector>* _noalias const ds_2_out = nullptr) const {
     // if (dl0_2_out == nullptr && dq0_2_out == nullptr) return;
     const cvm::real a1x = m_pos1[ia];

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -1460,7 +1460,7 @@ void cvm::atom_group::calc_fit_forces_impl(
   const auto rot_inv = rot.inverse().matrix();
   // temporary variables for computing and summing derivatives
   cvm::real sum_dxdq[4] = {0, 0, 0, 0};
-  cvm::vector1d<cvm::rvector> dq0_1(4);
+  std::array<cvm::rvector, 4> dq0_1;
   // loop 1: iterate over the current atom group
   for (size_t i = 0; i < size(); i++) {
     if (B_ag_center) {

--- a/src/colvaratoms.cpp
+++ b/src/colvaratoms.cpp
@@ -1464,20 +1464,21 @@ void cvm::atom_group::calc_fit_forces_impl(
   std::array<cvm::rvector, 4> dq0_1;
   // loop 1: iterate over the current atom group
   for (size_t i = 0; i < size(); i++) {
+    cvm::rvector const main_vec = accessor_main(i);
     if (B_ag_center) {
-      atom_grad += accessor_main(i);
+      atom_grad += main_vec;
     }
     if (B_ag_rotate) {
       // Project the forces or gradients to the rotation matrix elements
-      C[0][0] += accessor_main(i).x * pos_unrotated_x(i);
-      C[0][1] += accessor_main(i).x * pos_unrotated_y(i);
-      C[0][2] += accessor_main(i).x * pos_unrotated_z(i);
-      C[1][0] += accessor_main(i).y * pos_unrotated_x(i);
-      C[1][1] += accessor_main(i).y * pos_unrotated_y(i);
-      C[1][2] += accessor_main(i).y * pos_unrotated_z(i);
-      C[2][0] += accessor_main(i).z * pos_unrotated_x(i);
-      C[2][1] += accessor_main(i).z * pos_unrotated_y(i);
-      C[2][2] += accessor_main(i).z * pos_unrotated_z(i);
+      C[0][0] += main_vec.x * pos_unrotated_x(i);
+      C[0][1] += main_vec.x * pos_unrotated_y(i);
+      C[0][2] += main_vec.x * pos_unrotated_z(i);
+      C[1][0] += main_vec.y * pos_unrotated_x(i);
+      C[1][1] += main_vec.y * pos_unrotated_y(i);
+      C[1][2] += main_vec.y * pos_unrotated_z(i);
+      C[2][0] += main_vec.z * pos_unrotated_x(i);
+      C[2][1] += main_vec.z * pos_unrotated_y(i);
+      C[2][2] += main_vec.z * pos_unrotated_z(i);
     }
   }
   if (B_ag_rotate) {

--- a/src/colvaratoms.h
+++ b/src/colvaratoms.h
@@ -458,11 +458,13 @@ public:
    *
    *  This function is used to (i) project the gradients of CV with respect to
    *  rotated main group atoms to fitting group atoms, or (ii) project the forces
-   *  on rotated main group atoms to fitting group atoms, by the following two steps
+   *  on rotated main group atoms to fitting group atoms, by the following three steps
    *  (using the goal (ii) for example):
-   *  (1) Loop over the positions of main group atoms and call cvm::quaternion::position_derivative_inner
-   *      to project the forces on rotated main group atoms to the forces on quaternion.
-   *  (2) Loop over the positions of fitting group atoms, compute the gradients of
+   *  (1) Loop over the positions of main group atoms and project the forces on rotated main group
+   *      atoms to the forces on the nine rotation matrix elements;
+   *  (2) Project the forces on the rotation matrix elements to the forces on the four
+   *      components of the corresponding quaternion \f$\mathbf{q}\f$;
+   *  (3) Loop over the positions of fitting group atoms, compute the gradients of
    *      \f$\mathbf{q}\f$ with respect to the position of each atom, and then multiply
    *      that with the force on \f$\mathbf{q}\f$ (chain rule).
    */

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -1044,7 +1044,7 @@ void colvar::rmsd::calc_Jacobian_derivative()
     cvm::matrix2d<cvm::rvector> grad_rot_mat(3, 3);
     // gradients of products of 2 quaternion components
     cvm::rvector g11, g22, g33, g01, g02, g03, g12, g13, g23;
-    cvm::vector1d<cvm::rvector> dq;
+    std::array<cvm::rvector, 4> dq;
     atoms->rot_deriv->prepare_derivative(rotation_derivative_dldq::use_dq);
     for (size_t ia = 0; ia < atoms->size(); ia++) {
 
@@ -1344,7 +1344,7 @@ void colvar::eigenvector::calc_Jacobian_derivative()
 
   cvm::real sum = 0.0;
 
-  cvm::vector1d<cvm::rvector> dq_1;
+  std::array<cvm::rvector, 4> dq_1;
   atoms->rot_deriv->prepare_derivative(rotation_derivative_dldq::use_dq);
   for (size_t ia = 0; ia < atoms->size(); ia++) {
 

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -144,7 +144,7 @@ void colvar::orientation::apply_force(colvarvalue const &force)
   if (!atoms->noforce) {
     const cvm::real sign = (rot.q).inner(ref_quat) >= 0.0 ? 1.0 : -1.0;
     rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-    cvm::vector1d<cvm::rvector> dq0_2;
+    std::array<cvm::rvector, 4> dq0_2;
     auto ag_force = atoms->get_group_force_object();
     for (size_t ia = 0; ia < atoms->size(); ia++) {
       rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
@@ -214,7 +214,7 @@ void colvar::orientation_angle::calc_gradients()
       0.0 );
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     const cvm::rvector g = dxdq0 * dq0_2[0];
@@ -277,7 +277,7 @@ void colvar::orientation_proj::calc_gradients()
 {
   cvm::real const dxdq0 = 2.0 * 2.0 * (rot.q).q0;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     const cvm::rvector g = dxdq0 * dq0_2[0];
@@ -328,7 +328,7 @@ void colvar::tilt::calc_gradients()
   cvm::quaternion const dxdq = rot.dcos_theta_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     cvm::rvector grad(0, 0, 0);
@@ -368,7 +368,7 @@ void colvar::spin_angle::calc_gradients()
   cvm::quaternion const dxdq = rot.dspin_angle_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     cvm::rvector grad(0, 0, 0);
@@ -419,7 +419,7 @@ void colvar::euler_phi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (-4 * q2 * (-2 * q0 * q1 - 2 * q2 * q3) + 2 * q3 * (-2 * q1 * q1 - 2 * q2 * q2 + 1)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * 2 * q2 * (-2 * q1 * q1 - 2 * q2 * q2 + 1) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     const cvm::rvector grad = (dxdq0 * dq0_2[0]) +
@@ -470,7 +470,7 @@ void colvar::euler_psi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (2 * q1 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q2 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * (2 * q0 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q3 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     const cvm::rvector grad = (dxdq0 * dq0_2[0]) +
@@ -519,7 +519,7 @@ void colvar::euler_theta::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * 2 * q0 / denominator;
   const cvm::real dxdq3 = (180.0/PI) * -2 * q1 / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  cvm::vector1d<cvm::rvector> dq0_2;
+  std::array<cvm::rvector, 4> dq0_2;
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
     const cvm::rvector grad = (dxdq0 * dq0_2[0]) +

--- a/src/colvartypes.cpp
+++ b/src/colvartypes.cpp
@@ -322,7 +322,7 @@ void colvarmodule::rotation::debug_gradients(
             "\n");
   rotation_derivative deriv(rot, pos1, pos2, num_atoms_pos1, num_atoms_pos2);
   cvm::rvector dl0_2;
-  cvm::vector1d<cvm::rvector> dq0_2(4);
+  std::array<cvm::rvector, 4> dq0_2;
   cvm::matrix2d<cvm::rvector> ds_2;
 #ifdef COLVARS_LAMMPS
     MathEigen::Jacobi<cvm::real,

--- a/src/colvartypes.cpp
+++ b/src/colvartypes.cpp
@@ -323,7 +323,7 @@ void colvarmodule::rotation::debug_gradients(
   rotation_derivative deriv(rot, pos1, pos2, num_atoms_pos1, num_atoms_pos2);
   cvm::rvector dl0_2;
   std::array<cvm::rvector, 4> dq0_2;
-  cvm::matrix2d<cvm::rvector> ds_2;
+  std::array<std::array<cvm::rvector, 4>, 4> ds_2;
 #ifdef COLVARS_LAMMPS
     MathEigen::Jacobi<cvm::real,
                       cvm::real[4],

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1263,7 +1263,7 @@ public:
    *  where \f$\mathbf{e}\f$ is \f$[1, 1, 1]\f$ and \f$\odot\f$ is the element-wise product (Hadamard product).
    */
   inline std::array<cvm::real, 4> derivative_element_wise_product_sum(const cvm::real (&C)[3][3]) const {
-    return std::array<cvm::real, 4>{
+    return std::array<cvm::real, 4>{{
       2.0 * ( q0 * C[0][0] - q3 * C[0][1] + q2 * C[0][2] +
               q3 * C[1][0] + q0 * C[1][1] - q1 * C[1][2] +
              -q2 * C[2][0] + q1 * C[2][1] + q0 * C[2][2]),
@@ -1276,7 +1276,7 @@ public:
       2.0 * (-q3 * C[0][0] - q0 * C[0][1] + q1 * C[0][2] +
               q0 * C[1][0] - q3 * C[1][1] + q2 * C[1][2] +
               q1 * C[2][0] + q2 * C[2][1] + q3 * C[2][2])
-    };
+    }};
   }
 
   /// \brief Return the cosine between the orientation frame

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1231,36 +1231,37 @@ public:
                                   vec.z * ( q1 * pos.x + q2 * pos.y + q3 * pos.z)));
   }
 
-  /// \brief Calculate the sums of element-wise products of a given matrix with respect to dR/dq0, dR/dq1, dR/dq2 and dR/dq3
-  /// \param C A 3x3 matrix
-  /// \return A 4-element tuple (see the detailed documentation below).
-  ///
-  /// This function is mainly used for projecting the gradients or forces on
-  /// a rotation matrix to the gradients or forces on the quaternion of the
-  /// same rotation matrix. Mathematically, let \f$C\f$ be the matrix
-  /// \f[
-  /// \begin{bmatrix}
-  /// \frac{\partial f}{\partial R_{00}} & \frac{\partial f}{\partial R_{01}} & \frac{\partial f}{\partial R_{02}} \\
-  /// \frac{\partial f}{\partial R_{10}} & \frac{\partial f}{\partial R_{11}} & \frac{\partial f}{\partial R_{12}} \\
-  /// \frac{\partial f}{\partial R_{20}} & \frac{\partial f}{\partial R_{21}} & \frac{\partial f}{\partial R_{22}}
-  /// \end{bmatrix}
-  /// \f]
-  /// and \f$\frac{{\rm d}R}{{\rm d}q_{i}}\f$ be
-  /// \f[
-  /// \begin{bmatrix}
-  /// \frac{\partial R_{00}}{\partial q_i} & \frac{\partial R_{01}}{\partial q_i} & \frac{\partial R_{02}}{\partial q_i} \\
-  /// \frac{\partial R_{10}}{\partial q_i} & \frac{\partial R_{11}}{\partial q_i} & \frac{\partial R_{12}}{\partial q_i} \\
-  /// \frac{\partial R_{20}}{\partial q_i} & \frac{\partial R_{21}}{\partial q_i} & \frac{\partial R_{22}}{\partial q_i}
-  /// \end{bmatrix}
-  /// \f]
-  /// This function returns
-  /// \f[
-  /// \left[\mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_0}\right)\mathbf{e},
-  ///       \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_1}\right)\mathbf{e},
-  ///       \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_2}\right)\mathbf{e},
-  ///       \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_3}\right)\mathbf{e}\right]
-  /// \f]
-  /// where \f$\mathbf{e}\f$ is \f$[1, 1, 1]\f$ and \f$\odot\f$ is the element-wise product (Hadamard product).
+  /** \brief Calculate the sums of element-wise products of a given matrix with respect to dR/dq0, dR/dq1, dR/dq2 and dR/dq3
+   *  \param C A 3x3 matrix
+   *  \return A 4-element tuple (see the detailed documentation below).
+   *
+   *  This function is mainly used for projecting the gradients or forces on
+   *  a rotation matrix to the gradients or forces on the quaternion of the
+   *  same rotation matrix. Mathematically, let \f$C\f$ be the matrix
+   *  \f[
+   *  \begin{bmatrix}
+   *  \frac{\partial f}{\partial R_{00}} & \frac{\partial f}{\partial R_{01}} & \frac{\partial f}{\partial R_{02}} \\
+   *  \frac{\partial f}{\partial R_{10}} & \frac{\partial f}{\partial R_{11}} & \frac{\partial f}{\partial R_{12}} \\
+   *  \frac{\partial f}{\partial R_{20}} & \frac{\partial f}{\partial R_{21}} & \frac{\partial f}{\partial R_{22}}
+   *  \end{bmatrix}
+   *  \f]
+   *  and \f$\frac{{\rm d}R}{{\rm d}q_{i}}\f$ be
+   *  \f[
+   *  \begin{bmatrix}
+   *  \frac{\partial R_{00}}{\partial q_i} & \frac{\partial R_{01}}{\partial q_i} & \frac{\partial R_{02}}{\partial q_i} \\
+   *  \frac{\partial R_{10}}{\partial q_i} & \frac{\partial R_{11}}{\partial q_i} & \frac{\partial R_{12}}{\partial q_i} \\
+   *  \frac{\partial R_{20}}{\partial q_i} & \frac{\partial R_{21}}{\partial q_i} & \frac{\partial R_{22}}{\partial q_i}
+   *  \end{bmatrix}
+   *  \f]
+   *  This function returns
+   *  \f[
+   *  \left[\mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_0}\right)\mathbf{e},
+   *        \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_1}\right)\mathbf{e},
+   *        \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_2}\right)\mathbf{e},
+   *        \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_3}\right)\mathbf{e}\right]
+   *  \f]
+   *  where \f$\mathbf{e}\f$ is \f$[1, 1, 1]\f$ and \f$\odot\f$ is the element-wise product (Hadamard product).
+   */
   inline std::array<cvm::real, 4> derivative_element_wise_product_sum(const cvm::real (&C)[3][3]) const {
     return std::array<cvm::real, 4>{
       2.0 * ( q0 * C[0][0] - q3 * C[0][1] + q2 * C[0][2] +

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1176,61 +1176,6 @@ public:
     return R;
   }
 
-
-  /// \brief Multiply the given vector by the derivative of the given
-  /// (rotated) position with respect to the quaternion
-  /// \param pos The position \f$\mathbf{x}\f$.
-  /// \param vec The vector \f$\mathbf{v}\f$.
-  /// \return A quaternion (see the detailed documentation below).
-  ///
-  /// This function is mainly used for projecting the gradients or forces on
-  /// the rotated atoms to the forces on quaternion. Assume this rotation can
-  /// be represented as \f$R(\mathbf{q})\f$,
-  /// where \f$\mathbf{q} := (q_0, q_1, q_2, q_3)\f$
-  /// is the current quaternion, the function returns the following new
-  /// quaternion:
-  /// \f[
-  /// \left(\mathbf{v}^\mathrm{T}\frac{\partial R(\mathbf{q})}{\partial q_0}\mathbf{x},
-  ///       \mathbf{v}^\mathrm{T}\frac{\partial R(\mathbf{q})}{\partial q_1}\mathbf{x},
-  ///       \mathbf{v}^\mathrm{T}\frac{\partial R(\mathbf{q})}{\partial q_2}\mathbf{x},
-  ///       \mathbf{v}^\mathrm{T}\frac{\partial R(\mathbf{q})}{\partial q_3}\mathbf{x}\right)
-  /// \f]
-  /// where \f$\mathbf{v}\f$ is usually the gradient of \f$\xi\f$ with respect to
-  /// the rotated frame \f$\tilde{\mathbf{X}}\f$,
-  /// \f$\partial \xi / \partial \tilde{\mathbf{X}}\f$, or the force acting on it
-  /// (\f$\mathbf{F}_{\tilde{\mathbf{X}}}\f$).
-  /// By using the following loop in pseudo C++ code,
-  /// either \f$\partial \xi / \partial \tilde{\mathbf{X}}\f$
-  /// or \f$\mathbf{F}_{\tilde{\mathbf{X}}}\f$, can be projected to
-  /// \f$\partial \xi / \partial \mathbf{q}\f$ or \f$\mathbf{F}_q\f$ into `sum_dxdq`:
-  /// @code
-  /// cvm::real sum_dxdq[4] = {0, 0, 0, 0};
-  /// for (size_t i = 0; i < main_group_size(); ++i) {
-  ///   const cvm::rvector v = grad_or_force_on_rotated_main_group(i);
-  ///   const cvm::rvector x = unrotated_main_group_positions(i);
-  ///   cvm::quaternion const dxdq = position_derivative_inner(x, v);
-  ///   sum_dxdq[0] += dxdq[0];
-  ///   sum_dxdq[1] += dxdq[1];
-  ///   sum_dxdq[2] += dxdq[2];
-  ///   sum_dxdq[3] += dxdq[3];
-  /// }
-  /// @endcode
-  inline cvm::quaternion position_derivative_inner(cvm::rvector const &pos,
-                                            cvm::rvector const &vec) const {
-    return cvm::quaternion(2.0 * (vec.x * ( q0 * pos.x - q3 * pos.y + q2 * pos.z) +
-                                  vec.y * ( q3 * pos.x + q0 * pos.y - q1 * pos.z) +
-                                  vec.z * (-q2 * pos.x + q1 * pos.y + q0 * pos.z)),
-                           2.0 * (vec.x * ( q1 * pos.x + q2 * pos.y + q3 * pos.z) +
-                                  vec.y * ( q2 * pos.x - q1 * pos.y - q0 * pos.z) +
-                                  vec.z * ( q3 * pos.x + q0 * pos.y - q1 * pos.z)),
-                           2.0 * (vec.x * (-q2 * pos.x + q1 * pos.y + q0 * pos.z) +
-                                  vec.y * ( q1 * pos.x + q2 * pos.y + q3 * pos.z) +
-                                  vec.z * (-q0 * pos.x + q3 * pos.y - q2 * pos.z)),
-                           2.0 * (vec.x * (-q3 * pos.x - q0 * pos.y + q1 * pos.z) +
-                                  vec.y * ( q0 * pos.x - q3 * pos.y + q2 * pos.z) +
-                                  vec.z * ( q1 * pos.x + q2 * pos.y + q3 * pos.z)));
-  }
-
   /** \brief Calculate the sums of element-wise products of a given matrix with respect to dR/dq0, dR/dq1, dR/dq2 and dR/dq3
    *  \param C A 3x3 matrix
    *  \return A 4-element tuple (see the detailed documentation below).

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -12,6 +12,7 @@
 
 #include <sstream> // TODO specialize templates and replace this with iosfwd
 #include <vector>
+#include <array>
 
 #ifdef COLVARS_LAMMPS
 // Use open-source Jacobi implementation

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -1230,6 +1230,52 @@ public:
                                   vec.z * ( q1 * pos.x + q2 * pos.y + q3 * pos.z)));
   }
 
+  /// \brief Calculate the sums of element-wise products of a given matrix with respect to dR/dq0, dR/dq1, dR/dq2 and dR/dq3
+  /// \param C A 3x3 matrix
+  /// \return A 4-element tuple (see the detailed documentation below).
+  ///
+  /// This function is mainly used for projecting the gradients or forces on
+  /// a rotation matrix to the gradients or forces on the quaternion of the
+  /// same rotation matrix. Mathematically, let \f$C\f$ be the matrix
+  /// \f[
+  /// \begin{bmatrix}
+  /// \frac{\partial f}{\partial R_{00}} & \frac{\partial f}{\partial R_{01}} & \frac{\partial f}{\partial R_{02}} \\
+  /// \frac{\partial f}{\partial R_{10}} & \frac{\partial f}{\partial R_{11}} & \frac{\partial f}{\partial R_{12}} \\
+  /// \frac{\partial f}{\partial R_{20}} & \frac{\partial f}{\partial R_{21}} & \frac{\partial f}{\partial R_{22}}
+  /// \end{bmatrix}
+  /// \f]
+  /// and \f$\frac{{\rm d}R}{{\rm d}q_{i}}\f$ be
+  /// \f[
+  /// \begin{bmatrix}
+  /// \frac{\partial R_{00}}{\partial q_i} & \frac{\partial R_{01}}{\partial q_i} & \frac{\partial R_{02}}{\partial q_i} \\
+  /// \frac{\partial R_{10}}{\partial q_i} & \frac{\partial R_{11}}{\partial q_i} & \frac{\partial R_{12}}{\partial q_i} \\
+  /// \frac{\partial R_{20}}{\partial q_i} & \frac{\partial R_{21}}{\partial q_i} & \frac{\partial R_{22}}{\partial q_i}
+  /// \end{bmatrix}
+  /// \f]
+  /// This function returns
+  /// \f[
+  /// \left[\mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_0}\right)\mathbf{e},
+  ///       \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_1}\right)\mathbf{e},
+  ///       \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_2}\right)\mathbf{e},
+  ///       \mathbf{e}^T\left(C \odot \frac{{\rm d}R}{{\rm d}q_3}\right)\mathbf{e}\right]
+  /// \f]
+  /// where \f$\mathbf{e}\f$ is \f$[1, 1, 1]\f$ and \f$\odot\f$ is the element-wise product (Hadamard product).
+  inline std::array<cvm::real, 4> derivative_element_wise_product_sum(const cvm::real (&C)[3][3]) const {
+    return std::array<cvm::real, 4>{
+      2.0 * ( q0 * C[0][0] - q3 * C[0][1] + q2 * C[0][2] +
+              q3 * C[1][0] + q0 * C[1][1] - q1 * C[1][2] +
+             -q2 * C[2][0] + q1 * C[2][1] + q0 * C[2][2]),
+      2.0 * ( q1 * C[0][0] + q2 * C[0][1] + q3 * C[0][2] +
+              q2 * C[1][0] - q1 * C[1][1] - q0 * C[1][2] +
+              q3 * C[2][0] + q0 * C[2][1] - q1 * C[2][2]),
+      2.0 * (-q2 * C[0][0] + q1 * C[0][1] + q0 * C[0][2] +
+              q1 * C[1][0] + q2 * C[1][1] + q3 * C[1][2] +
+             -q0 * C[2][0] + q3 * C[2][1] - q2 * C[2][2]),
+      2.0 * (-q3 * C[0][0] - q0 * C[0][1] + q1 * C[0][2] +
+              q0 * C[1][0] - q3 * C[1][1] + q2 * C[1][2] +
+              q1 * C[2][0] + q2 * C[2][1] + q3 * C[2][2])
+    };
+  }
 
   /// \brief Return the cosine between the orientation frame
   /// associated to this quaternion and another


### PR DESCRIPTION
This PR avoids the expensive `position_derivative_inner` by projecting the forces on the rotated frame to 9 rotation matrix elements at first, and then projecting the forces to the quaternion. This PR also completes https://github.com/Colvars/colvars/issues/560 and updates the time complexity of fit gradients in the user manual.