### PR TITLE
Minor changes to maintenance script to parse GitHub metadata

### DIFF
--- a/devel-tools/print_pr_list.py
+++ b/devel-tools/print_pr_list.py
@@ -27,9 +27,9 @@ def affects_backend(labels, backend=None):
     return False
 
 
-def get_pr_list(state='merged', label=None):
+def get_pr_list(state='merged', target='master', label=None):
     # 10,000 sounds like a reasonable limit for the Colvars repo
-    cmd = f"gh pr list --state {state} --limit 10000 --json number,url,mergedAt,title,author,labels"
+    cmd = f"gh pr list --base {target} --state {state} --limit 10000 --json number,url,mergedAt,title,author,labels"
     if label:
         cmd += f" --label {label}"
     try:
@@ -100,7 +100,7 @@ def print_pr_report(kwargs):
     if kwargs['format'] == 'message':
         print(msg + ":")
 
-    pr_db = get_pr_list(state=kwargs['state'], label=kwargs['label'])
+    pr_db = get_pr_list(state=kwargs['state'], target=kwargs['target'], label=kwargs['label'])
     all_authors = []
     for pr in pr_db:
         pr['mergedAt'] = date_parser.parse(pr['mergedAt']).timestamp()
@@ -145,6 +145,10 @@ if __name__ == '__main__':
                         default='merged',
                         choices=['open', 'closed', 'merged', 'all'],
                         help="List PRs in this state")
+    parser.add_argument('--target',
+                        default='master',
+                        type=str,
+                        help="List PRs targeting this branch")
     parser.add_argument('--format',
                         default='message',
                         choices=['message', 'numbers'],

--- a/devel-tools/print_pr_list.py
+++ b/devel-tools/print_pr_list.py
@@ -97,9 +97,10 @@ def print_pr_report(kwargs):
     else:
         until_date_ts = 0
 
-    print(msg + ":")
+    if kwargs['format'] == 'message':
+        print(msg + ":")
 
-    pr_db = get_pr_list(kwargs.get('state'), label=kwargs['label'])
+    pr_db = get_pr_list(state=kwargs['state'], label=kwargs['label'])
     all_authors = []
     for pr in pr_db:
         pr['mergedAt'] = date_parser.parse(pr['mergedAt']).timestamp()
@@ -108,12 +109,16 @@ def print_pr_report(kwargs):
                 pr_labels, kwargs.get('backend')):
             pr_authors = get_pr_authors(pr)
             all_authors += pr_authors
-            print()
-            print("-", pr['number'], pr['title'])
-            print(" ", pr['url'], "("+", ".join(pr_authors)+")")
+            if kwargs['format'] == 'numbers':
+                print(pr['number'])
+            if kwargs['format'] == 'message':
+                print()
+                print("-", pr['number'], pr['title'])
+                print(" ", pr['url'], "("+", ".join(pr_authors)+")")
 
-    print()
-    print("Authors:", ", ".join(sorted(list(set(all_authors)), key=str.casefold)))
+    if kwargs['format'] == 'message':
+        print()
+        print("Authors:", ", ".join(sorted(list(set(all_authors)), key=str.casefold)))
 
 
 if __name__ == '__main__':
@@ -137,10 +142,13 @@ if __name__ == '__main__':
                         type=str,
                         help="List only PRs with this label")
     parser.add_argument('--state',
-                        type=str,
                         default='merged',
                         choices=['open', 'closed', 'merged', 'all'],
                         help="List PRs in this state")
+    parser.add_argument('--format',
+                        default='message',
+                        choices=['message', 'numbers'],
+                        help="Print the report as either a human-readable message, or just a list of PR numbers")
     kwargs = vars(parser.parse_args())
 
     print_pr_report(kwargs)

--- a/devel-tools/print_pr_list.py
+++ b/devel-tools/print_pr_list.py
@@ -95,7 +95,7 @@ def print_pr_report(kwargs):
         else:
             msg += f" merged until {until_date}"
     else:
-        until_date_ts = 0
+        until_date_ts = 2**36
 
     if kwargs['format'] == 'message':
         print(msg + ":")


### PR DESCRIPTION
Some fixes and updates to the script to allow listing the individual commits from PRs after their branches are rebased onto master.

Note: this requires that for each PR the original branch is available in the repo, because the GH CLI returns the *original* commit hashes, not the rebased ones.  It would be useful if we kept around the branches for bugfix PRs until the step of cherry-picking into release branches is automated.