### PR TITLE
opt: optimize the forces or gradients from q to the fitting group

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -1443,7 +1443,8 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9
+MATHJAX_VERSION        = MathJax_3
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example

--- a/src/colvar_rotation_derivative.h
+++ b/src/colvar_rotation_derivative.h
@@ -503,6 +503,45 @@ struct rotation_derivative {
       {{-a1y,  a1x,  0.0}, { a1z,  0.0,  a1x}, { 0.0,  a1z,  a1y}, {-a1x, -a1y,  a1z}}};
     calc_derivative_impl<use_dl, use_dq, use_ds>(ds_2, dl0_2_out, dq0_2_out, ds_2_out);
   }
+
+  template <int N>
+  inline cvm::rmatrix compute_dxdC(const std::array<cvm::real, N> sum_dxdq) const {
+    cvm::rmatrix result;
+    for (int i = 0; i < N; ++i) {
+      result.xx += sum_dxdq[i] * ( tmp_Q0Q0_L[i][0][0] + tmp_Q0Q0_L[i][1][1] - tmp_Q0Q0_L[i][2][2] - tmp_Q0Q0_L[i][3][3] );
+      result.xy += sum_dxdq[i] * ( tmp_Q0Q0_L[i][0][3] + tmp_Q0Q0_L[i][1][2] + tmp_Q0Q0_L[i][2][1] + tmp_Q0Q0_L[i][3][0] );
+      result.xz += sum_dxdq[i] * (-tmp_Q0Q0_L[i][0][2] + tmp_Q0Q0_L[i][1][3] - tmp_Q0Q0_L[i][2][0] + tmp_Q0Q0_L[i][3][1] );
+      result.yx += sum_dxdq[i] * (-tmp_Q0Q0_L[i][0][3] + tmp_Q0Q0_L[i][1][2] + tmp_Q0Q0_L[i][2][1] - tmp_Q0Q0_L[i][3][0] );
+      result.yy += sum_dxdq[i] * ( tmp_Q0Q0_L[i][0][0] - tmp_Q0Q0_L[i][1][1] + tmp_Q0Q0_L[i][2][2] - tmp_Q0Q0_L[i][3][3] );
+      result.yz += sum_dxdq[i] * ( tmp_Q0Q0_L[i][0][1] + tmp_Q0Q0_L[i][1][0] + tmp_Q0Q0_L[i][2][3] + tmp_Q0Q0_L[i][3][2] );
+      result.zx += sum_dxdq[i] * ( tmp_Q0Q0_L[i][0][2] + tmp_Q0Q0_L[i][1][3] + tmp_Q0Q0_L[i][2][0] + tmp_Q0Q0_L[i][3][1] );
+      result.zy += sum_dxdq[i] * (-tmp_Q0Q0_L[i][0][1] - tmp_Q0Q0_L[i][1][0] + tmp_Q0Q0_L[i][2][3] + tmp_Q0Q0_L[i][3][2]);
+      result.zz += sum_dxdq[i] * ( tmp_Q0Q0_L[i][0][0] - tmp_Q0Q0_L[i][1][1] - tmp_Q0Q0_L[i][2][2] + tmp_Q0Q0_L[i][3][3] );
+    }
+    return result;
+  }
+
+  inline cvm::rvector compute_dxdgroup1(size_t ia, const cvm::rmatrix& dxdC) const {
+    const cvm::real a2x = m_pos2[ia];
+    const cvm::real a2y = m_pos2[ia + m_num_atoms_pos2];
+    const cvm::real a2z = m_pos2[ia + 2 * m_num_atoms_pos2];
+    const cvm::rvector result{
+      dxdC.xx * a2x + dxdC.xy * a2y + dxdC.xz * a2z,
+      dxdC.yx * a2x + dxdC.yy * a2y + dxdC.yz * a2z,
+      dxdC.zx * a2x + dxdC.zy * a2y + dxdC.zz * a2z};
+    return result;
+  }
+
+  inline cvm::rvector compute_dxdgroup2(size_t ia, const cvm::rmatrix& dxdC) const {
+    const cvm::real a1x = m_pos1[ia];
+    const cvm::real a1y = m_pos1[ia + m_num_atoms_pos2];
+    const cvm::real a1z = m_pos1[ia + 2 * m_num_atoms_pos2];
+    const cvm::rvector result{
+      dxdC.xx * a1x + dxdC.yx * a1y + dxdC.zx * a1z,
+      dxdC.xy * a1x + dxdC.yy * a1y + dxdC.zy * a1z,
+      dxdC.xz * a1x + dxdC.yz * a1y + dxdC.zz * a1z};
+    return result;
+  }
 };
 
 #endif // COLVAR_ROTATION_DERIVATIVE

--- a/src/colvar_rotation_derivative.h
+++ b/src/colvar_rotation_derivative.h
@@ -516,6 +516,22 @@ struct rotation_derivative {
     calc_derivative_impl<use_dl, use_dq, use_ds>(ds_2, dl0_2_out, dq0_2_out, ds_2_out);
   }
 
+  /*! @brief Project the force on \f$q_i\f$ (or the gradient of
+   *  \f$\frac{\mathrm{d}x}{\mathrm{d}q_i}\f$) to the force on the correlation
+   *  matrix \f$C=\mathbf{r}_1^\intercal\mathbf{r}_2\f$, where \f$\mathbf{r}_1\f$ and
+   *  \f$\mathbf{r}_2\f$ are \f$N\times 3\f$ matrices containing the atom
+   *  positions of atom group 1 and atom group 2 after centering on origin.
+   *
+   *  This function can be only called after
+   *  prepare_derivative(rotation_derivative_dldq::use_dq). It mulitplies the input with
+   *  \f$\frac{\mathrm{d}q_i}{\mathrm{d}C}\f$.
+   *
+   *  @tparam i The i-th component of the quaternion, must be in the range [0, 3]
+   *  @param[in] f_on_q The force on \f$q_i\f$ or the gradient of \f$\frac{\mathrm{d}x}{\mathrm{d}q_i}\f$
+   *
+   *  @return A 3x3 matrix. The matrix element at row \f$j\f$ and column \f$k\f$
+   *  is \f$f_{q_i}\frac{\mathrm{d}q_i}{\mathrm{d}C_{jk}}\f$.
+   */
   template <int i>
   inline cvm::rmatrix project_force_to_C_from_dxdqi(cvm::real f_on_q) const {
     static_assert((i < 4) && (i >= 0), "i must be in [0, 3] in project_force_to_C_from_dxdqi.");
@@ -532,6 +548,23 @@ struct rotation_derivative {
     return result;
   }
 
+  /*! @brief Project the force on \f$\mathbf{q}\f$ (or the gradient of
+   *  \f$\frac{\mathrm{d}x}{\mathrm{d}q_i}\f$) to the force on the correlation
+   *  matrix \f$C=\mathbf{r}_1^\intercal\mathbf{r}_2\f$, where \f$\mathbf{r}_1\f$ and
+   *  \f$\mathbf{r}_2\f$ are \f$N\times 3\f$ matrices containing the atom
+   *  positions of atom group 1 and atom group 2 after centering on origin.
+   *
+   *  See also project_force_to_C_from_dxdqi().
+   *
+   *  @tparam dim4_array_t The type of force acting on \f$\mathbf{q}\f$.
+   *
+   *  @param[in] sum_dxdq The force on \f$\mathbf{q}\f$ or the gradient vector
+   *  \f$(\frac{\mathrm{d}x}{\mathrm{d}q_0}, \frac{\mathrm{d}x}{\mathrm{d}q_1}, \frac{\mathrm{d}x}{\mathrm{d}q_2}, \frac{\mathrm{d}x}{\mathrm{d}q_3})\f$.
+   *
+   *  @return A 3x3 matrix. The matrix element at row \f$j\f$ and column \f$k\f$
+   *  is \f$\sum_{i=0}^3 f_{q_i}\frac{\mathrm{d}q_i}{\mathrm{d}C_{jk}}\f$.
+   *
+   */
   template <typename dim4_array_t>
   inline cvm::rmatrix project_force_to_C_from_dxdq(const dim4_array_t& sum_dxdq) const {
     cvm::rmatrix result;
@@ -542,6 +575,16 @@ struct rotation_derivative {
     return result;
   }
 
+  /*! @brief Project the force on the correlation matrix \f$C\f$ to \f$\mathbf{r}_1\f$
+   *
+   *  Let \f$C=\mathbf{r}_1^\intercal\mathbf{r}_2\f$, and the force on \f$C\f$ be
+   *  \f$F_{C}\f$. This function returns the force on the i-th atom of \f$\mathbf{r}_1\f$.
+   *
+   *  @param[in] ia The atom index of the i-th atom in \f$\mathbf{r}_1\f$
+   *  @param[in] dxdC The 3x3 matrix containing the forces on each element of \f$C\f$
+   *
+   *  @return The force on the i-th atom of \f$\mathbf{r}_1\f$
+   */
   inline cvm::rvector project_force_to_group1(size_t ia, const cvm::rmatrix& dxdC) const {
     const cvm::real a2x = *(pos2x + ia);
     const cvm::real a2y = *(pos2y + ia);
@@ -553,6 +596,16 @@ struct rotation_derivative {
     return result;
   }
 
+  /*! @brief Project the force on the correlation matrix \f$C\f$ to \f$\mathbf{r}_2\f$
+   *
+   *  Let \f$C=\mathbf{r}_1^\intercal\mathbf{r}_2\f$, and the force on \f$C\f$ be
+   *  \f$F_{C}\f$. This function returns the force on the i-th atom of \f$\mathbf{r}_2\f$.
+   *
+   *  @param[in] ia The atom index of the i-th atom in \f$\mathbf{r}_2\f$
+   *  @param[in] dxdC The 3x3 matrix containing the forces on each element of \f$C\f$
+   *
+   *  @return The force on the i-th atom of \f$\mathbf{r}_2\f$
+   */
   inline cvm::rvector project_force_to_group2(size_t ia, const cvm::rmatrix& dxdC) const {
     const cvm::real a1x = *(pos1x + ia);
     const cvm::real a1y = *(pos1y + ia);

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -144,10 +144,10 @@ void colvar::orientation::apply_force(colvarvalue const &force)
   if (!atoms->noforce) {
     const cvm::real sign = (rot.q).inner(ref_quat) >= 0.0 ? 1.0 : -1.0;
     rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-    const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{FQ.q0, FQ.q1, FQ.q2, FQ.q3}});
+    const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdq(FQ);
     auto ag_force = atoms->get_group_force_object();
     for (size_t ia = 0; ia < atoms->size(); ia++) {
-      const auto f_ia = sign * (rot_deriv_impl->compute_dxdgroup2(ia, dxdC));
+      const auto f_ia = sign * (rot_deriv_impl->project_force_to_group2(ia, dxdC));
       ag_force.add_atom_force(ia, f_ia);
     }
   }
@@ -210,9 +210,9 @@ void colvar::orientation_angle::calc_gradients()
       0.0 );
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({{dxdq0}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdqi<0>(dxdq0);
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector g = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector g = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = g.x;
     atoms->grad_y(ia) = g.y;
     atoms->grad_z(ia) = g.z;
@@ -272,9 +272,9 @@ void colvar::orientation_proj::calc_gradients()
 {
   cvm::real const dxdq0 = 2.0 * 2.0 * (rot.q).q0;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({{dxdq0}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdqi<0>(dxdq0);
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector g = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector g = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = g.x;
     atoms->grad_y(ia) = g.y;
     atoms->grad_z(ia) = g.z;
@@ -322,9 +322,9 @@ void colvar::tilt::calc_gradients()
   cvm::quaternion const dxdq = rot.dcos_theta_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdq(dxdq);
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector grad = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -358,9 +358,9 @@ void colvar::spin_angle::calc_gradients()
   cvm::quaternion const dxdq = rot.dspin_angle_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdq(dxdq);
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector grad = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -405,9 +405,9 @@ void colvar::euler_phi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (-4 * q2 * (-2 * q0 * q1 - 2 * q2 * q3) + 2 * q3 * (-2 * q1 * q1 - 2 * q2 * q2 + 1)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * 2 * q2 * (-2 * q1 * q1 - 2 * q2 * q2 + 1) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq0, dxdq1, dxdq2, dxdq3}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdq(std::array<cvm::real, 4>{{dxdq0, dxdq1, dxdq2, dxdq3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector grad = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -452,9 +452,9 @@ void colvar::euler_psi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (2 * q1 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q2 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * (2 * q0 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q3 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq0, dxdq1, dxdq2, dxdq3}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdq(std::array<cvm::real, 4>{{dxdq0, dxdq1, dxdq2, dxdq3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector grad = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -497,9 +497,9 @@ void colvar::euler_theta::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * 2 * q0 / denominator;
   const cvm::real dxdq3 = (180.0/PI) * -2 * q1 / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq0, dxdq1, dxdq2, dxdq3}});
+  const cvm::rmatrix dxdC = rot_deriv_impl->project_force_to_C_from_dxdq(std::array<cvm::real, 4>{{dxdq0, dxdq1, dxdq2, dxdq3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
+    const cvm::rvector grad = rot_deriv_impl->project_force_to_group2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -144,14 +144,10 @@ void colvar::orientation::apply_force(colvarvalue const &force)
   if (!atoms->noforce) {
     const cvm::real sign = (rot.q).inner(ref_quat) >= 0.0 ? 1.0 : -1.0;
     rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-    std::array<cvm::rvector, 4> dq0_2;
+    const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({FQ.q0, FQ.q1, FQ.q2, FQ.q3});
     auto ag_force = atoms->get_group_force_object();
     for (size_t ia = 0; ia < atoms->size(); ia++) {
-      rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-      const auto f_ia = sign * (FQ[0] * dq0_2[0] +
-                        FQ[1] * dq0_2[1] +
-                        FQ[2] * dq0_2[2] +
-                        FQ[3] * dq0_2[3]);
+      const auto f_ia = sign * (rot_deriv_impl->compute_dxdgroup2(ia, dxdC));
       ag_force.add_atom_force(ia, f_ia);
     }
   }
@@ -214,10 +210,9 @@ void colvar::orientation_angle::calc_gradients()
       0.0 );
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({dxdq0});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    const cvm::rvector g = dxdq0 * dq0_2[0];
+    const cvm::rvector g = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = g.x;
     atoms->grad_y(ia) = g.y;
     atoms->grad_z(ia) = g.z;
@@ -277,10 +272,9 @@ void colvar::orientation_proj::calc_gradients()
 {
   cvm::real const dxdq0 = 2.0 * 2.0 * (rot.q).q0;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({dxdq0});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    const cvm::rvector g = dxdq0 * dq0_2[0];
+    const cvm::rvector g = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = g.x;
     atoms->grad_y(ia) = g.y;
     atoms->grad_z(ia) = g.z;
@@ -328,13 +322,9 @@ void colvar::tilt::calc_gradients()
   cvm::quaternion const dxdq = rot.dcos_theta_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    cvm::rvector grad(0, 0, 0);
-    for (size_t iq = 0; iq < 4; iq++) {
-      grad += (dxdq[iq] * dq0_2[iq]);
-    }
+    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -368,13 +358,9 @@ void colvar::spin_angle::calc_gradients()
   cvm::quaternion const dxdq = rot.dspin_angle_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    cvm::rvector grad(0, 0, 0);
-    for (size_t iq = 0; iq < 4; iq++) {
-      grad += (dxdq[iq] * dq0_2[iq]);
-    }
+    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -419,13 +405,9 @@ void colvar::euler_phi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (-4 * q2 * (-2 * q0 * q1 - 2 * q2 * q3) + 2 * q3 * (-2 * q1 * q1 - 2 * q2 * q2 + 1)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * 2 * q2 * (-2 * q1 * q1 - 2 * q2 * q2 + 1) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq0, dxdq1, dxdq2, dxdq3});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    const cvm::rvector grad = (dxdq0 * dq0_2[0]) +
-                              (dxdq1 * dq0_2[1]) +
-                              (dxdq2 * dq0_2[2]) +
-                              (dxdq3 * dq0_2[3]);
+    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -470,13 +452,9 @@ void colvar::euler_psi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (2 * q1 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q2 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * (2 * q0 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q3 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq0, dxdq1, dxdq2, dxdq3});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    const cvm::rvector grad = (dxdq0 * dq0_2[0]) +
-                              (dxdq1 * dq0_2[1]) +
-                              (dxdq2 * dq0_2[2]) +
-                              (dxdq3 * dq0_2[3]);
+    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;
@@ -519,13 +497,9 @@ void colvar::euler_theta::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * 2 * q0 / denominator;
   const cvm::real dxdq3 = (180.0/PI) * -2 * q1 / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  std::array<cvm::rvector, 4> dq0_2;
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq0, dxdq1, dxdq2, dxdq3});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
-    rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-    const cvm::rvector grad = (dxdq0 * dq0_2[0]) +
-                              (dxdq1 * dq0_2[1]) +
-                              (dxdq2 * dq0_2[2]) +
-                              (dxdq3 * dq0_2[3]);
+    const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
     atoms->grad_y(ia) = grad.y;
     atoms->grad_z(ia) = grad.z;

--- a/src/colvarcomp_rotations.cpp
+++ b/src/colvarcomp_rotations.cpp
@@ -144,7 +144,7 @@ void colvar::orientation::apply_force(colvarvalue const &force)
   if (!atoms->noforce) {
     const cvm::real sign = (rot.q).inner(ref_quat) >= 0.0 ? 1.0 : -1.0;
     rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-    const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({FQ.q0, FQ.q1, FQ.q2, FQ.q3});
+    const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{FQ.q0, FQ.q1, FQ.q2, FQ.q3}});
     auto ag_force = atoms->get_group_force_object();
     for (size_t ia = 0; ia < atoms->size(); ia++) {
       const auto f_ia = sign * (rot_deriv_impl->compute_dxdgroup2(ia, dxdC));
@@ -210,7 +210,7 @@ void colvar::orientation_angle::calc_gradients()
       0.0 );
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({dxdq0});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({{dxdq0}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector g = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = g.x;
@@ -272,7 +272,7 @@ void colvar::orientation_proj::calc_gradients()
 {
   cvm::real const dxdq0 = 2.0 * 2.0 * (rot.q).q0;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({dxdq0});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<1>({{dxdq0}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector g = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = g.x;
@@ -322,7 +322,7 @@ void colvar::tilt::calc_gradients()
   cvm::quaternion const dxdq = rot.dcos_theta_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
@@ -358,7 +358,7 @@ void colvar::spin_angle::calc_gradients()
   cvm::quaternion const dxdq = rot.dspin_angle_dq(axis);
 
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq.q0, dxdq.q1, dxdq.q2, dxdq.q3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
@@ -405,7 +405,7 @@ void colvar::euler_phi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (-4 * q2 * (-2 * q0 * q1 - 2 * q2 * q3) + 2 * q3 * (-2 * q1 * q1 - 2 * q2 * q2 + 1)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * 2 * q2 * (-2 * q1 * q1 - 2 * q2 * q2 + 1) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq0, dxdq1, dxdq2, dxdq3});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq0, dxdq1, dxdq2, dxdq3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
@@ -452,7 +452,7 @@ void colvar::euler_psi::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * (2 * q1 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q2 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   const cvm::real dxdq3 = (180.0/PI) * (2 * q0 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) - 4 * q3 * (-2 * q0 * q3 - 2 * q1 * q2)) / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq0, dxdq1, dxdq2, dxdq3});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq0, dxdq1, dxdq2, dxdq3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;
@@ -497,7 +497,7 @@ void colvar::euler_theta::calc_gradients()
   const cvm::real dxdq2 = (180.0/PI) * 2 * q0 / denominator;
   const cvm::real dxdq3 = (180.0/PI) * -2 * q1 / denominator;
   rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
-  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({dxdq0, dxdq1, dxdq2, dxdq3});
+  const cvm::rmatrix dxdC = rot_deriv_impl->compute_dxdC<4>({{dxdq0, dxdq1, dxdq2, dxdq3}});
   for (size_t ia = 0; ia < atoms->size(); ia++) {
     const cvm::rvector grad = rot_deriv_impl->compute_dxdgroup2(ia, dxdC);
     atoms->grad_x(ia) = grad.x;

--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -946,6 +946,19 @@ public:
                         m.yx*r.x + m.yy*r.y + m.yz*r.z,
                         m.zx*r.x + m.zy*r.y + m.zz*r.z);
   }
+
+  inline rmatrix& operator+=(const rmatrix& rhs) {
+    this->xx += rhs.xx;
+    this->xy += rhs.xy;
+    this->xz += rhs.xz;
+    this->yx += rhs.yx;
+    this->yy += rhs.yy;
+    this->yz += rhs.yz;
+    this->zx += rhs.zx;
+    this->zy += rhs.zy;
+    this->zz += rhs.zz;
+    return *this;
+  }
 };
 
 


### PR DESCRIPTION
This commit projects the forces acting on q, or the gradients of a CV with respect to q, onto the forces acting on the correlation matrix, or the gradients of a CV with respect to the correlation matrix at first. Then, the forces or the gradients on the fitting group are computed from the forces or the gradients on the correlation matrix.

By doing so, the number of multiplication operations in each iteration of the loop over fitting group atoms is reduced from 204 (64 * 3 + 4 * 3) to 9, and the number of addition/subtraction operations is reduced from 69 to 9.

The old routines like calc_derivative_wrt_group1 and calc_derivative_wrt_group2 are retained for Jacobian calculations.