### PR TITLE
Simplify the clang-tidy check

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Install Apptainer
         shell: bash
         run: |
-          sudo apt -y bash install ccache tcl8.6-dev clang clang-tidy
+          sudo apt -y install bash ccache tcl8.6-dev clang clang-tidy
 
       - name: Configure and build the library (but do not run tests)
         env:

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -253,29 +253,18 @@ jobs:
       - name: Install Apptainer
         shell: bash
         run: |
-          sudo add-apt-repository -y ppa:apptainer/ppa
-          sudo apt update
-          sudo apt install -y apptainer-suid
-
-      - name: Get container images for build dependencies
-        shell: bash
-        working-directory: devel-tools
-        run: |
-          apptainer pull CentOS9-devel.sif oras://ghcr.io/colvars/devel-containers:CentOS9-devel
+          sudo apt -y bash install ccache tcl8.6-dev clang clang-tidy
 
       - name: Configure and build the library (but do not run tests)
         env:
+          CMAKE_BUILD_DIR: build
           CXX: clang++
           CC: clang
-        run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
-          cmake -DRUN_TESTS=OFF -P devel-tools/build_test_library.cmake
+        run: cmake -DRUN_TESTS=OFF -P devel-tools/build_test_library.cmake
 
       - name: Run "run-clang-tidy" in the "build" folder
         working-directory: build
-        run: |
-          apptainer exec ${{github.workspace}}/devel-tools/CentOS9-devel.sif \
-          run-clang-tidy -header-filter=.* -warnings-as-errors \* >& clang-tidy.log
+        run: bash ${{ github.workspace }}/devel-tools/run_clang_tidy.sh &> clang-tidy.log
 
       - name: Archive warnings artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -250,7 +250,7 @@ jobs:
           ref: 'master'
           path: 'openmm-source'
 
-      - name: Install Apptainer
+      - name: Install build dependencies, clang-tidy and bash for library
         shell: bash
         run: |
           sudo apt -y install bash ccache tcl8.6-dev clang clang-tidy
@@ -262,7 +262,7 @@ jobs:
           CC: clang
         run: cmake -DRUN_TESTS=OFF -P devel-tools/build_test_library.cmake
 
-      - name: Run "run-clang-tidy" in the "build" folder
+      - name: Run "run_clang_tidy.sh" in the "build" folder
         working-directory: build
         run: bash ${{ github.workspace }}/devel-tools/run_clang_tidy.sh &> clang-tidy.log
 

--- a/devel-tools/run_clang_tidy.sh
+++ b/devel-tools/run_clang_tidy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Get the top Colvars repo directory
+TOPDIR=$(git rev-parse --show-toplevel)
+if [ ! -d ${TOPDIR} ] ; then
+  echo "Error: cannot identify top project directory." >& 2
+  exit 1
+fi
+
+# Get the build directory
+COLVARS_BUILD_DIR="$(pwd)"
+
+# Get the Colvars source directory
+COLVARS_SOURCE_DIR="$TOPDIR/src"
+# Find all source files that are required to build the run_colvars_test
+COLVARS_STUB_SOURCE_DIR="$TOPDIR/misc_interfaces/stubs"
+COLVARS_TEST_SOURCE_DIR="$TOPDIR/tests/functional/"
+COLVARS_SOURCE_FILES=$(find $COLVARS_STUB_SOURCE_DIR $COLVARS_TEST_SOURCE_DIR $COLVARS_SOURCE_DIR -name "*.cpp")
+
+num_test_failed=0
+all_output=""
+# Run clang-tidy over all files and save the results
+for colvars_src_file in $COLVARS_SOURCE_FILES; do
+  clang_tidy_command="clang-tidy -p=$COLVARS_BUILD_DIR --warnings-as-errors='*' $colvars_src_file"
+  echo "Running $clang_tidy_command"
+  output="$(eval $clang_tidy_command 2>&1)" || exit_code=$?
+  all_output+="$output"
+  if [[ $exit_code -gt 0 ]]; then
+    num_test_failed=`expr $num_test_failed + 1`
+  fi
+done
+
+if [[ $num_test_failed -gt 0 ]]; then
+  echo "There are $num_test_failed test(s) failed."
+  echo "$all_output"
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
This PR uses a standalone shell script to run clang-tidy over all Colvars source files, excluding the Lepton source files. This PR also avoids pulling the apptainer container.