### PR TITLE
Do not set PBC info in NAMD proxy

### DIFF
--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
@@ -757,30 +757,7 @@ void colvarproxy_impl::calculate() {
     }
   }
   previous_NAMD_step = step;
-  if (mClient->requestUpdateLattice()) {
-    unit_cell_x.set(h_mLattice[0], h_mLattice[1], h_mLattice[2]);
-    unit_cell_y.set(h_mLattice[3], h_mLattice[4], h_mLattice[5]);
-    unit_cell_z.set(h_mLattice[6], h_mLattice[7], h_mLattice[8]);
-    const Vector a1(h_mLattice[0], h_mLattice[1], h_mLattice[2]);
-    const Vector a2(h_mLattice[3], h_mLattice[4], h_mLattice[5]);
-    const Vector a3(h_mLattice[6], h_mLattice[7], h_mLattice[8]);
-    const int p1 = ( a1.length2() ? 1 : 0 );
-    const int p2 = ( a2.length2() ? 1 : 0 );
-    const int p3 = ( a3.length2() ? 1 : 0 );
-    if (!p1 && !p2 && !p3) {
-      boundaries_type = boundaries_non_periodic;
-      reset_pbc_lattice();
-    } else if (p1 && p2 && p3) {
-      if (( ! ( a1.y || a1.z || a2.x || a2.z || a3.x || a3.y ) )) {
-        boundaries_type = boundaries_pbc_ortho;
-      } else {
-        boundaries_type = boundaries_pbc_triclinic;
-      }
-      colvarproxy_system::update_pbc_lattice();
-    } else {
-      boundaries_type = boundaries_unsupported;
-    }
-  }
+
   // Run Colvars
 #ifdef CUDAGLOBALMASTERCOLVARS_CUDA_PROFILING
   nvtxRangePushEx(&mEventAttrib);

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -388,29 +388,6 @@ void colvarproxy_namd::calculate()
   previous_NAMD_step = step;
   if (accelMDOn) update_accelMD_info();
 
-  {
-    Vector const a = lattice->a();
-    Vector const b = lattice->b();
-    Vector const c = lattice->c();
-    unit_cell_x.set(a.x, a.y, a.z);
-    unit_cell_y.set(b.x, b.y, c.z);
-    unit_cell_z.set(c.x, c.y, c.z);
-  }
-
-  if (!lattice->a_p() && !lattice->b_p() && !lattice->c_p()) {
-    boundaries_type = boundaries_non_periodic;
-    reset_pbc_lattice();
-  } else if (lattice->a_p() && lattice->b_p() && lattice->c_p()) {
-    if (lattice->orthogonal()) {
-      boundaries_type = boundaries_pbc_ortho;
-    } else {
-      boundaries_type = boundaries_pbc_triclinic;
-    }
-    colvarproxy_system::update_pbc_lattice();
-  } else {
-    boundaries_type = boundaries_unsupported;
-  }
-
   if (cvm::debug()) {
     cvm::log(std::string(cvm::line_marker)+
              "colvarproxy_namd, step no. "+cvm::to_str(colvars->it)+"\n"+


### PR DESCRIPTION
It is never used because the NAMD proxy calls NAMD PBC functions directly. In addition, it never gets updated, so the info was outdated most of the time in constant-P simulations.

Leaving everything at zero is safer to avoid unexpected use of wrong information.