### PR TITLE
build: guard the CUDAGM interface by NAMD_CUDA and NAMD_HIP macros

### DIFF
--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
@@ -18,6 +18,8 @@
 #include <nvtx3/nvToolsExtCuda.h>
 #endif // CUDAGLOBALMASTERCOLVARS_CUDA_PROFILING
 
+#if defined (NAMD_CUDA) || defined (NAMD_HIP)
+
 #if defined (__linux__) || defined (__APPLE__)
 extern "C" {
   CudaGlobalMasterColvars* allocator() {
@@ -1159,3 +1161,5 @@ int CudaGlobalMasterColvars::updateFromTCLCommand(const std::vector<std::string>
   delete[] objv;
   return error_code;
 }
+
+#endif // defined (NAMD_CUDA) || defined (NAMD_HIP)

--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.h
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.h
@@ -17,6 +17,8 @@
 
 #include "HipDefines.h"
 
+#if defined (NAMD_CUDA) || defined (NAMD_HIP)
+
 class Lattice;
 
 class colvarproxy_impl;
@@ -80,5 +82,7 @@ private:
   std::vector<AtomID> mEmpty;
   std::string mTCLResult;
 };
+
+#endif // defined (NAMD_CUDA) || defined (NAMD_HIP)
 
 #endif // COLVARPROXY_CUDAGLOBALMASTER_H

--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster_kernel.cu
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster_kernel.cu
@@ -1,5 +1,7 @@
 #include "colvarproxy_cudaglobalmaster_kernel.h"
 
+#if defined (NAMD_CUDA) || defined (NAMD_HIP)
+
 __global__ void transpose_to_host_rvector_kernel(
   const double* __restrict d_data_in,
   cvm::rvector* __restrict h_data_out,
@@ -72,3 +74,5 @@ void copy_float_to_host_double(
   copy_float_to_host_double_kernel<<<grid, block_size, 0, stream>>>(
     d_data_in, h_data_out, num_atoms);
 }
+
+#endif // defined (NAMD_CUDA) || defined (NAMD_HIP)

--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster_kernel.h
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster_kernel.h
@@ -3,6 +3,8 @@
 
 #include "colvartypes.h"
 
+#if defined (NAMD_CUDA) || defined (NAMD_HIP)
+
 #ifdef NAMD_CUDA
 #include <cuda_runtime.h>
 #endif  // NAMD_CUDA
@@ -39,5 +41,7 @@ void copy_float_to_host_double(
   cvm::real* h_data_out,
   const int num_atoms,
   cudaStream_t stream);
+
+#endif // defined (NAMD_CUDA) || defined (NAMD_HIP)
 
 #endif // COLVARPROXY_CUDAGLOBALMASTER_KERNEL_H


### PR DESCRIPTION
Only build the plugin when NAMD_CUDA or NAMD_HIP is defined. This commit is a step to integrate the plugin in the NAMD's build scripts.