### PR TITLE
feat: Emphasize Colvars error message in NAMD

### DIFF
--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -718,12 +718,12 @@ void colvarproxy_namd::error(std::string const &message)
   case COLVARS_MEMORY_ERROR:
     errno = ENOMEM; break;
   }
-  char const *msg = "Error in the collective variables module "
-    "(see above for details)";
+  std::string const errmsg("Errors in the Colvars module (check the full output for details)\n\n" +
+                           message);
   if (errno) {
-    NAMD_err(msg);
+    NAMD_err(errmsg.c_str());
   } else {
-    NAMD_die(msg);
+    NAMD_die(errmsg.c_str());
   }
 }
 


### PR DESCRIPTION
Make the Colvars error message stand out by printing it to stderr, and replace the "see above" message with something more robust when folks are redirecting.

```
$ namd3 test.namd  > out
FATAL ERROR: Error in the Colvars module (check the full output for details)

  Error: the value of lowerWall must be set explicitly.
```