### PR TITLE
fix: fix the out-of-bound access in from_simple_string

### DIFF
--- a/src/colvartypes.h
+++ b/src/colvartypes.h
@@ -345,7 +345,7 @@ public:
     std::stringstream stream(s);
     size_t i = 0;
     if (this->size()) {
-      while ((stream >> (*this)[i]) && (i < this->size())) {
+      while ((i < this->size()) && (stream >> (*this)[i])) {
         i++;
       }
       if (i < this->size()) {


### PR DESCRIPTION
This commit ensures that the boundary check happens first.

See https://github.com/Colvars/colvars/pull/887#issuecomment-3607727878.