### PR TITLE
fix: fix the compilation of the CUDAGM plugin

### DIFF
--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
@@ -58,7 +58,7 @@ enum e_pdb_field {
 };
 
 // Copied from colvarproxy_namd.C
-e_pdb_field pdb_field_str2enum(std::string const &pdb_field_str)
+e_pdb_field pdb_field_str2enum(std::string const &pdb_field_str, colvarmodule* cvmodule)
 {
   e_pdb_field pdb_field = e_pdb_none;
 
@@ -258,7 +258,8 @@ colvarproxy_impl::colvarproxy_impl(
   mAtomsChanged(false),
   first_timestep(true), previous_NAMD_step(0),
   simParams(s), molecule(m), mScriptTcl(t) {
-  colvars = nullptr;
+  // colvars = nullptr;
+  cvmodule = nullptr;
 #ifdef CUDAGLOBALMASTERCOLVARS_CUDA_PROFILING
   mEventAttrib.version = NVTX_VERSION;
   mEventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
@@ -288,7 +289,7 @@ int colvarproxy_impl::reset() {
 int colvarproxy_impl::setup() {
   colvarproxy::parse_module_config();
   int error_code = colvarproxy::setup();
-  if (colvars->size() == 0) {
+  if (cvmodule->size() == 0) {
     // Module is empty, nothing to do
     return COLVARS_OK;
   }
@@ -300,11 +301,11 @@ int colvarproxy_impl::setup() {
   set_integration_timestep(simParams->dt);
   log("updating target temperature (T = "+
       cvm::to_str(target_temperature())+" K).\n");
-  error_code |= colvars->update_engine_parameters();
-  error_code |= colvars->setup_input();
-  error_code |= colvars->setup_output();
+  error_code |= cvmodule->update_engine_parameters();
+  error_code |= cvmodule->setup_input();
+  error_code |= cvmodule->setup_output();
   if (has_gpu_support()) {
-    cvm::log("Warning: the GPU support in Colvars is still experimental!\n");
+    cvmodule->log("Warning: the GPU support in Colvars is still experimental!\n");
   }
   return error_code;
 }
@@ -333,20 +334,22 @@ void colvarproxy_impl::initialize_from_cudagm(
   updated_masses_ = updated_charges_ = true;
   engine_name_ = "NAMD_CUDAGLOBALMASTER";
   // if (colvars != nullptr) delete colvars;
-  if (colvars == nullptr) {
-    colvars = new colvarmodule(this);
+  if (cvmodule == nullptr) {
+    // std::cerr << "Creating cvmodule" << std::endl;
+    // printf("Creating cvmodule\n");
+    cvmodule = new colvarmodule(this);
   }
-  cvm::log("Using " + engine_name_ + " interface, version "+
+  cvmodule->log("Using " + engine_name_ + " interface, version "+
            cvm::to_str(0)+".\n");
-  colvars->cite_feature("NAMD engine");
-  colvars->cite_feature("Colvars-NAMD interface");
+  cvmodule->cite_feature("NAMD engine");
+  cvmodule->cite_feature("Colvars-NAMD interface");
   for (auto it = mConfigFiles.begin(); it != mConfigFiles.end(); ++it) {
     add_config("configfile", *it);
   }
   update_target_temperature();
   setup();
   if (simParams->firstTimestep != 0) {
-    colvars->set_initial_step(static_cast<cvm::step_number>(simParams->firstTimestep));
+    cvmodule->set_initial_step(static_cast<cvm::step_number>(simParams->firstTimestep));
   }
   colvarproxy_io::set_output_prefix(std::string(simParams->outputFilename));
   colvarproxy_io::set_restart_output_prefix(std::string(simParams->restartFilename));
@@ -430,7 +433,7 @@ int colvarproxy_impl::check_atom_id(int atom_number) {
 
 // Copied from colvarproxy_namd.C
 int colvarproxy_impl::set_unit_system(std::string const &units_in, bool /*check_only*/) {
-  cvm::log("units_in = " + units_in + "\n");
+  cvmodule->log("units_in = " + units_in + "\n");
   if (units_in != "real") {
     cvmodule->error("Error: Specified unit system \"" + units_in + "\" is unsupported in NAMD. Supported units are \"real\" (A, kcal/mol).\n");
     return COLVARS_ERROR;
@@ -451,7 +454,7 @@ void colvarproxy_impl::log(std::string const &message) {
 void colvarproxy_impl::error(std::string const &message)
 {
   log(message);
-  switch (cvm::get_error()) {
+  switch (cvmodule->get_error()) {
   case COLVARS_FILE_ERROR:
     errno = EIO; break;
   case COLVARS_NOT_IMPLEMENTED:
@@ -483,7 +486,7 @@ int colvarproxy_impl::load_coords_pdb(char const *pdb_filename,
   e_pdb_field pdb_field_index;
   bool const use_pdb_field = (pdb_field_str.size() > 0);
   if (use_pdb_field) {
-    pdb_field_index = pdb_field_str2enum(pdb_field_str);
+    pdb_field_index = pdb_field_str2enum(pdb_field_str, this->cvmodule);
   }
 
   // next index to be looked up in PDB file (if list is supplied)
@@ -593,7 +596,7 @@ int colvarproxy_impl::load_atoms_pdb(char const *pdb_filename,
   PDB *pdb = new PDB(pdb_filename);
   size_t const pdb_natoms = pdb->num_atoms();
 
-  e_pdb_field pdb_field_index = pdb_field_str2enum(pdb_field_str);
+  e_pdb_field pdb_field_index = pdb_field_str2enum(pdb_field_str, cvmodule);
   auto modify_atoms = atoms.get_atom_modifier();
   for (size_t ipdb = 0; ipdb < pdb_natoms; ipdb++) {
 
@@ -634,7 +637,7 @@ int colvarproxy_impl::load_atoms_pdb(char const *pdb_filename,
   }
 
   delete pdb;
-  return (cvm::get_error() ? COLVARS_ERROR : COLVARS_OK);
+  return (cvmodule->get_error() ? COLVARS_ERROR : COLVARS_OK);
 }
 
 void colvarproxy_impl::allocateDeviceArrays() {
@@ -795,13 +798,13 @@ void colvarproxy_impl::calculate() {
   if (first_timestep) {
     // setup();
     update_target_temperature();
-    colvars->update_engine_parameters();
-    colvars->setup_input();
-    colvars->setup_output();
+    cvmodule->update_engine_parameters();
+    cvmodule->setup_input();
+    cvmodule->setup_output();
     first_timestep = false;
   } else {
     if ( step - previous_NAMD_step == 1 ) {
-      colvars->it++;
+      cvmodule->it++;
       b_simulation_continuing = false;
     } else {
       // Cases covered by this condition:
@@ -814,7 +817,7 @@ void colvarproxy_impl::calculate() {
       colvarproxy_io::set_output_prefix(std::string(simParams->outputFilename));
       colvarproxy_io::set_restart_output_prefix(std::string(simParams->restartFilename));
       colvarproxy_io::set_default_restart_frequency(simParams->restartFrequency);
-      colvars->setup_output();
+      cvmodule->setup_output();
     }
   }
   previous_NAMD_step = step;
@@ -830,7 +833,7 @@ void colvarproxy_impl::calculate() {
   if (cvm::debug()) {
     print_input_atomic_data();
   }
-  if (colvars->calc() != COLVARS_OK) {
+  if (cvmodule->calc() != COLVARS_OK) {
     cvmodule->error("Error in the collective variables module.\n", COLVARS_ERROR);
   }
   if (cvm::debug()) {
@@ -873,7 +876,7 @@ std::ostream & colvarproxy_impl::output_stream(std::string const &output_name,
                                                std::string const description)
 {
   if (cvm::debug()) {
-    cvm::log("Using colvarproxy_namd::output_stream()\n");
+    cvmodule->log("Using colvarproxy_namd::output_stream()\n");
   }
 
   if (!io_available()) {

--- a/src/colvargrid_integrate.cpp
+++ b/src/colvargrid_integrate.cpp
@@ -1,7 +1,6 @@
 #include "colvargrid_integrate.h"
 
-#include <iostream>
-#include <iomanip>
+#include <cstdio>
 
 
 colvargrid_integrate::colvargrid_integrate(std::vector<colvar *> &colvars,
@@ -677,8 +676,9 @@ void colvargrid_integrate::nr_linbcg_sym(const std::vector<cvm::real> &b, std::v
     }
 //     asolve(r,z);  // precon
     err = l2norm(r)/bnrm;
-    if (cvm::debug())
-      std::cout << "iter=" << std::setw(4) << iter+1 << std::setw(12) << err << std::endl;
+    if (cvm::debug()) {
+      std::printf("iter=%4d %12lf\n", iter+1, err);
+    }
     if (err <= tol)
       break;
   }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#include <cstdio>
 
 #include "colvarmodule.h"
 #include "colvar_gpu_support.h"
@@ -1941,20 +1942,18 @@ int colvarmodule::read_traj(char const *traj_filename,
       if ( (it < traj_read_begin) ) {
 
         if ((it % 1000) == 0)
-          std::cerr << "Skipping trajectory step " << it
-                    << "                    \r";
+          std::fprintf(stderr, "Skipping trajectory step %lld                    \r", (long long)it);
 
         continue;
 
       } else {
 
         if ((it % 1000) == 0)
-          std::cerr << "Reading from trajectory, step = " << it
-                    << "                    \r";
+          std::fprintf(stderr, "Reading from trajectory, step = %lld                    \r", (long long)it);
 
         if ( (traj_read_end > traj_read_begin) &&
              (it > traj_read_end) ) {
-          std::cerr << "\n";
+          std::fprintf(stderr, "\n");
           this->error("Reached the end of the trajectory, "
                      "read_end = "+this->to_str(traj_read_end)+"\n",
                      COLVARS_FILE_ERROR);
@@ -2116,7 +2115,8 @@ void colvarmodule::log(std::string const &message, int min_log_level)
       proxy->log(message + trailing_newline);
     }
   } else { // Safe without a proxy pointer
-    std::cout << message + trailing_newline;
+    // std::cout << message + trailing_newline;
+    std::printf("%s%s", message.c_str(), trailing_newline.c_str());
   }
 }
 
@@ -2207,7 +2207,7 @@ int colvarmodule::error(std::string const &message, int code)
     return get_error();
 
   } else { // Safe without a proxy pointer
-    std::cerr << prefix + message + trailing_newline;
+    std::fprintf(stderr, "%s%s%s", prefix.c_str(), message.c_str(), trailing_newline.c_str());
     return code;
   }
 }

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <unordered_map>
 #include <memory>
+#include <cstdio>
 
 #include "colvars_version.h"
 #include "colvar_gpu_calc.h"
@@ -756,7 +757,7 @@ public:
     if (colvarmodule::main()) {
       colvarmodule::main()->log(message);
     } else {
-      std::cout << "colvars: " << message << std::endl;
+      std::printf("colvars: %s\n", message.c_str());
     }
   }
 

--- a/src/colvarproxy.cpp
+++ b/src/colvarproxy.cpp
@@ -731,7 +731,7 @@ void colvarproxy::print_output_atomic_data()
 
 void colvarproxy::log(std::string const &message)
 {
-  fprintf(stdout, "colvars: %s", message.c_str());
+  std::fprintf(stdout, "colvars: %s", message.c_str());
 }
 
 


### PR DESCRIPTION
While testing the fix, I found another issue of using std::cout with RTLD_DEEPBIND (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42679), which crashes NAMD, so I have to change std::cout to printf and std::cerr to fprintf with stderr.

A more eligant solution is to raise the C++ standard to C++23 and use a compiler with std::print and std::println supports, but it is not possible for the time being.