### PR TITLE
Update Colvars_traj documentation

### DIFF
--- a/colvartools/plot_colvars_traj.py
+++ b/colvartools/plot_colvars_traj.py
@@ -93,7 +93,7 @@ class Colvars_traj(object):
     """Trajectories of collective variables, as read from a list of
     colvars.traj files.
     Can be accessed as a dictionary using a variable's name as key; each
-    variable's trajectory is an instance of colvars_traj"""
+    variable's trajectory is an instance of Colvar_traj"""
 
     def __init__(self, filenames=None, first=0, last=None, every=1):
         """


### PR DESCRIPTION
If I understand correctly, **Colvars_traj** creates a new instance of **Colvar_traj** for each collective variable. Right now the documentation reads like each collective variable is an instance of Colvars_traj. I think this is a typo, unless I'm not understanding the code (in which case, an explanation would be very much appreciated)