### PR TITLE
fix: avoid crash in VMD on MacOS

### DIFF
--- a/vmd/cv_dashboard/cv_dashboard_editor.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_editor.tcl
@@ -766,8 +766,16 @@ proc ::cv_dashboard::cvs_from_labels {} {
 # loading the precomputed values
 
 proc ::cv_dashboard::cvs_from_traj {} {
+  global tcl_platform
+  if { $tcl_platform(os) == "Darwin"} {
+    # work around Tk bug in MacOS
+    # https://core.tcl-lang.org/tk/tktview/080a28104e25e054f8f5869d9333aa57c221b896
+    set extension ".traj"
+  } else {
+    set extension ".colvars.traj"
+  }
   set files [tk_getOpenFile -title "Input colvars trajectory files for the complete trajectory" \
-       -multiple true -filetypes {{"Colvars traj" .colvars.traj} {"All files" *}}]
+       -multiple true -filetypes [list [list "Colvars traj" $extension] {"All files" *}]]
     # -initialdir $::cv_dashboard::config_dir]
   if {[llength $files] > 0 } {
     ::cv_dashboard::load_cv_traj $files

--- a/vmd/cv_dashboard/cv_dashboard_main.tcl
+++ b/vmd/cv_dashboard/cv_dashboard_main.tcl
@@ -1610,8 +1610,16 @@ proc ::cv_dashboard::createRotationMenu { row } {
 # Open file dialog to choose file name, then save colvars trajectory
 
 proc ::cv_dashboard::save_traj_dialog {} {
+  global tcl_platform
+  if { $tcl_platform(os) == "Darwin"} {
+    # work around Tk bug in MacOS
+    # https://core.tcl-lang.org/tk/tktview/080a28104e25e054f8f5869d9333aa57c221b896
+    set extension ".traj"
+  } else {
+    set extension ".colvars.traj"
+  }
   set file [tk_getSaveFile -title "Colvars trajectory file to be written" \
-      -filetypes {{"Colvars traj" .colvars.traj} {"All files" *}}]
+      -filetypes [list [list "Colvars traj" $extension] {"All files" *}]]
   if {[llength $file] > 0 } {
     ::cv_dashboard::save_traj_file $file
   }


### PR DESCRIPTION
due to Tk bug triggering OSX crash when using file extensions with more than one dot, or not beginning with a dot.

https://core.tcl-lang.org/tk/tktview/080a28104e25e054f8f5869d9333aa57c221b896

Bug is fixed upstream, but I am adding a platform-specific hack to work around it.

Might be fixed in Tk 9.0?

Marked draft until tested on the relevant platform.