### PR TITLE
Check that pull requests can be cherry-picked onto branches

### DIFF
--- a/.github/workflows/check-cherry-pick.yml
+++ b/.github/workflows/check-cherry-pick.yml
@@ -1,34 +1,33 @@
 name: "Check cherry-pick compatibility"
 
 # Triggered on newly opened PRs and on subsequent pushes; checks whether
-# the PR commits can be cleanly cherry-picked onto a set of long-lived branches.
+# the PR's commits can be cleanly cherry-picked onto a set of long-lived branches.
 
 on:
   pull_request:
     types: [opened, synchronize, labeled]
+    branches: [master]
 
 jobs:
 
-  # ── Development branches: checked for every PR ─────────────────────────
+  # Check against maintenance branches for PRs with the label "bugfix"
 
-  check-cherry-pick-devel:
-    name: "Cherry-pick onto ${{ matrix.branch }}"
+  check-cherry-pick-maint:
+    name: "Cherry-pick onto ${{ matrix.branch }} (bugfixes only)"
+    if: contains(github.event.pull_request.labels.*.name, 'bugfix')
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false          # report all failures, not just the first one
+      fail-fast: false
       matrix:
         branch:
-          - master
-          - gromacs-2025
           - gromacs-2026
           - namd-3.0
-          - lammps-stable_22Jul2025
 
     steps:
       - name: Checkout repository with full history
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0        # need the full graph for cherry-pick
+          fetch-depth: 0
 
       - name: Configure git identity
         run: |
@@ -69,18 +68,20 @@ jobs:
             exit 1
           fi
 
-  # ── Maintenance branches: checked only for PRs labelled "bugfix" ───────
 
-  check-cherry-pick-maint:
-    name: "Cherry-pick onto ${{ matrix.branch }} (maintenance)"
-    if: contains(github.event.pull_request.labels.*.name, 'bugfix')
+  # Check against development branches on every PR: ideally we'll fast forward everything, but
+  # some of these branches may later become "maintenance" ones
+
+  check-cherry-pick-devel:
+    name: "Cherry-pick onto ${{ matrix.branch }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         branch:
-          - gromacs-2024
-          - namd-2.14
+          - gromacs-2027
+          - lammps-develop
+          - namd-3.1
 
     steps:
       - name: Checkout repository with full history

--- a/.github/workflows/check-cherry-pick.yml
+++ b/.github/workflows/check-cherry-pick.yml
@@ -74,6 +74,9 @@ jobs:
 
   check-cherry-pick-devel:
     name: "Cherry-pick onto ${{ matrix.branch }}"
+    # TODO either remove this condition below, or merge with the job above if we decide to only
+    # update these “engine” branches only after PRs have been merged in the engines' repos
+    if: contains(github.event.pull_request.labels.*.name, 'bugfix')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/check-cherry-pick.yml
+++ b/.github/workflows/check-cherry-pick.yml
@@ -1,0 +1,127 @@
+name: "Check cherry-pick compatibility"
+
+# Triggered on newly opened PRs and on subsequent pushes; checks whether
+# the PR commits can be cleanly cherry-picked onto a set of long-lived branches.
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+
+  # ── Development branches: checked for every PR ─────────────────────────
+
+  check-cherry-pick-devel:
+    name: "Cherry-pick onto ${{ matrix.branch }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false          # report all failures, not just the first one
+      matrix:
+        branch:
+          - master
+          - gromacs-2025
+          - gromacs-2026
+          - namd-3.0
+          - lammps-stable_22Jul2025
+
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0        # need the full graph for cherry-pick
+
+      - name: Configure git identity
+        run: |
+          git config user.email "noreply@github.com"
+          git config user.name "CI runner"
+
+      - name: Fetch all remote branches
+        run: git fetch origin
+
+      - name: Collect commits introduced by this PR
+        id: commits
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COMMITS=$(git log --reverse --format="%H" "${BASE_SHA}..${HEAD_SHA}")
+          if [[ -z "$COMMITS" ]]; then
+            echo "No commits found between ${BASE_SHA} and ${HEAD_SHA}; nothing to cherry-pick."
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Commits to cherry-pick:"
+            echo "$COMMITS"
+            # Store as a single space-separated string for use in the next step
+            echo "list=$(echo $COMMITS | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Try cherry-pick onto ${{ matrix.branch }}
+        if: steps.commits.outputs.empty == 'false'
+        run: |
+          git checkout -b test-cherry-pick "origin/${{ matrix.branch }}"
+          if git cherry-pick ${{ steps.commits.outputs.list }}; then
+            echo "Cherry-pick onto ${{ matrix.branch }} succeeded."
+          else
+            git cherry-pick --abort 2>/dev/null || true
+            echo "::error::Cherry-pick onto ${{ matrix.branch }} failed." \
+              "The PR commits may need to be adapted before they can be" \
+              "applied to that branch."
+            exit 1
+          fi
+
+  # ── Maintenance branches: checked only for PRs labelled "bugfix" ───────
+
+  check-cherry-pick-maint:
+    name: "Cherry-pick onto ${{ matrix.branch }} (maintenance)"
+    if: contains(github.event.pull_request.labels.*.name, 'bugfix')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - gromacs-2024
+          - namd-2.14
+
+    steps:
+      - name: Checkout repository with full history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.email "noreply@github.com"
+          git config user.name "CI runner"
+
+      - name: Fetch all remote branches
+        run: git fetch origin
+
+      - name: Collect commits introduced by this PR
+        id: commits
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          COMMITS=$(git log --reverse --format="%H" "${BASE_SHA}..${HEAD_SHA}")
+          if [[ -z "$COMMITS" ]]; then
+            echo "No commits found between ${BASE_SHA} and ${HEAD_SHA}; nothing to cherry-pick."
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Commits to cherry-pick:"
+            echo "$COMMITS"
+            echo "list=$(echo $COMMITS | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+            echo "empty=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Try cherry-pick onto ${{ matrix.branch }}
+        if: steps.commits.outputs.empty == 'false'
+        run: |
+          git checkout -b test-cherry-pick "origin/${{ matrix.branch }}"
+          if git cherry-pick ${{ steps.commits.outputs.list }}; then
+            echo "Cherry-pick onto ${{ matrix.branch }} succeeded."
+          else
+            git cherry-pick --abort 2>/dev/null || true
+            echo "::error::Cherry-pick onto ${{ matrix.branch }} failed." \
+              "The PR commits may need to be adapted before they can be" \
+              "applied to that branch."
+            exit 1
+          fi

--- a/.github/workflows/check-cherry-pick.yml
+++ b/.github/workflows/check-cherry-pick.yml
@@ -1,4 +1,4 @@
-name: "Check cherry-pick compatibility"
+name: "Check cherry-pick"
 
 # Triggered on newly opened PRs and on subsequent pushes; checks whether
 # the PR's commits can be cleanly cherry-picked onto a set of long-lived branches.
@@ -13,7 +13,7 @@ jobs:
   # Check against maintenance branches for PRs with the label "bugfix"
 
   check-cherry-pick-maint:
-    name: "Cherry-pick onto ${{ matrix.branch }} (bugfixes only)"
+    name: "Cherry-pick onto ${{ matrix.branch }} (bugfixes-only branch)"
     if: contains(github.event.pull_request.labels.*.name, 'bugfix')
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -148,7 +148,7 @@ jobs:
           path: 'openmm-source'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: cpp
           build-mode: manual
@@ -157,7 +157,7 @@ jobs:
         run: cmake -DRUN_TESTS=OFF -P devel-tools/build_test_library.cmake
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
 
 
   build-linux-x86_64-clang-analyzer:


### PR DESCRIPTION
Ensure that bugfixes can be easily backported onto a list of pre-defined maintenance branches.  Currently, this list includes:
- `gromacs-2026`
- `namd-3.0`
On those branches, only PRs labeled `bugfix` are tested

Also tests other development branches:
- `gromacs-2027`
- `lammps-develop`
- `namd-3.1`
because they may become maintenance ones later on.  We probably have to agree on how to update them (fast-forwarding everything from `master` on a rolling basis, or do that only when the PRs to those packages are merged).