### PR TITLE
test: fix run_tests.sh in GROMACS test suite

### DIFF
--- a/gromacs/tests/library/run_tests.sh
+++ b/gromacs/tests/library/run_tests.sh
@@ -152,46 +152,41 @@ for dir in ${DIRLIST} ; do
 
   if [ ! -d AutoDiff ] ; then
     echo ""
-    echo "  Creating directory AutoDiff, use -g to fill it."
+    echo "  Creating directory AutoDiff"
     mkdir AutoDiff
-    cd $BASEDIR
-    continue
-  else
+    # Still run the tests to check for successful completion
+  fi
 
-    if $gen_ref_output; then
+  if $gen_ref_output; then
 
-      if ! { ls AutoDiff/ | grep -q test ; } then
-        echo ""
-        echo "  Warning: directory AutoDiff empty!"
-        # cd $BASEDIR
-        # continue
-      fi
-
-      # first, remove target files from work directory
-      for f in AutoDiff/*
-      do
-        base=`basename $f`
-        if [ -f $base ]
-        then
-          mv $base $base.backup
-        fi
-      done
+    if ! { ls AutoDiff/ | grep -q test ; } then
+      echo "  Directory AutoDiff is empty, populating..."
     fi
+
+    # first, remove target files from work directory
+    for f in AutoDiff/*
+    do
+      base=`basename $f`
+      if [ -f $base ]
+      then
+        mv $base $base.backup
+      fi
+    done
   fi
 
   if $cleanup; then
     cleanup_files
   fi
 
-  simulations=(test test.restart)
-  if [ "${dir##*/}" = "000_multiple_walkers_mtd" ] ; then
-    simulations=(test{.rep1,.rep2} test{.rep1,.rep2}.restart)
-  fi
 
   # Run simulation(s)
   if [ -f run.sh ]
   then
     # Special run script e.g. for interface tests
+    if $verbose ; then
+      echo "Running simulation with special script: $(${TPUT_BLUE})run.sh$(${TPUT_CLEAR})"
+    fi
+
     ./run.sh $BINARY
     RETVAL=$?
 
@@ -213,7 +208,15 @@ for dir in ${DIRLIST} ; do
       cp a/${basename}.colvars.traj .
     fi
   else
+    simulations=(test test.restart)
+    if [ "${dir##*/}" = "000_multiple_walkers_mtd" ] ; then
+      simulations=(test{.rep1,.rep2} test{.rep1,.rep2}.restart)
+    fi
+
     for basename in ${simulations[@]} ; do
+      if $verbose ; then
+        echo "Running simulation with basename: $(${TPUT_BLUE})${basename}$(${TPUT_CLEAR})"
+      fi
 
       # Create symlinks to the Colvars config file, index file, and xyz file
       if [ -f ${basename}.in ] ; then

--- a/gromacs/tests/library/run_tests.sh
+++ b/gromacs/tests/library/run_tests.sh
@@ -5,6 +5,8 @@
 # It's best to have Gromacs compiled in double precsision
 # Reference files have been generated with Gromacs version 2020.3
 
+shopt -s nullglob
+
 TMPDIR=/tmp
 DIRLIST=''
 BINARY=gmx_d
@@ -161,8 +163,8 @@ for dir in ${DIRLIST} ; do
       if ! { ls AutoDiff/ | grep -q test ; } then
         echo ""
         echo "  Warning: directory AutoDiff empty!"
-        cd $BASEDIR
-        continue
+        # cd $BASEDIR
+        # continue
       fi
 
       # first, remove target files from work directory
@@ -310,9 +312,11 @@ for dir in ${DIRLIST} ; do
         grep ':-) GROMACS -' ${basename}.out | head -n 1 > gromacs-version.txt
         grep 'Initializing the collective variables module, version' ${basename}.out | head -n 1 >> gromacs-version.txt
         grep 'Using GROMACS interface, version' ${basename}.out | head -n 1 >> gromacs-version.txt
-        cp ${basename}.colvars.state.stripped AutoDiff/
-        cp ${basename}.colvars.traj           AutoDiff/
-        cp ${basename}.colvars.out            AutoDiff/
+        [ -f ${basename}.colvars.state.stripped ] && cp ${basename}.colvars.state.stripped AutoDiff/
+        [ -f ${basename}.colvars.traj ] && cp ${basename}.colvars.traj           AutoDiff/
+        [ -f ${basename}.colvars.out ] && cp ${basename}.colvars.out            AutoDiff/
+        [ -f ${basename}.part0002.colvars.state.stripped ] && cp ${basename}.part0002.colvars.state.stripped AutoDiff/${basename}.colvars.state.stripped
+        [ -f ${basename}.part0002.colvars.traj ] && cp ${basename}.part0002.colvars.traj AutoDiff/${basename}.colvars.traj
         if [ -f ${basename}.histogram1.dat ] ; then
           cp -f ${basename}.histogram1.dat AutoDiff/
         fi


### PR DESCRIPTION
@jhenin I don't know why there is `part0002` in the filenames. This might be just a workaround.