### PR TITLE
cleanup: Remove now unused proxy PBC distance functions

### DIFF
--- a/lammps/src/COLVARS/colvarproxy_lammps.cpp
+++ b/lammps/src/COLVARS/colvarproxy_lammps.cpp
@@ -175,19 +175,6 @@ double colvarproxy_lammps::compute()
 
 /* ---------------------------------------------------------------------- */
 
-cvm::rvector colvarproxy_lammps::position_distance(cvm::atom_pos const &pos1,
-                                                   cvm::atom_pos const &pos2)
-  const
-{
-  double xtmp = pos2.x - pos1.x;
-  double ytmp = pos2.y - pos1.y;
-  double ztmp = pos2.z - pos1.z;
-  _lmp->domain->minimum_image_big(FLERR, xtmp,ytmp,ztmp);
-  return {xtmp, ytmp, ztmp};
-}
-
-/* ---------------------------------------------------------------------- */
-
 void colvarproxy_lammps::log(std::string const &message)
 {
   LAMMPS_NS::utils::logmesg(_lmp, message);

--- a/lammps/src/COLVARS/colvarproxy_lammps.h
+++ b/lammps/src/COLVARS/colvarproxy_lammps.h
@@ -79,9 +79,6 @@ class colvarproxy_lammps : public colvarproxy {
   void log(std::string const &message) override;
   void error(std::string const &message) override;
 
-  [[nodiscard]] cvm::rvector position_distance(cvm::atom_pos const &pos1,
-                                 cvm::atom_pos const &pos2) const override;
-
   cvm::real rand_gaussian() override;
 
   int init_atom(int atom_number) override;

--- a/namd/src/colvarproxy_namd.C
+++ b/namd/src/colvarproxy_namd.C
@@ -870,19 +870,6 @@ void colvarproxy_namd::update_atom_properties(int index)
 }
 
 
-cvm::rvector colvarproxy_namd::position_distance(cvm::atom_pos const &pos1,
-                                                 cvm::atom_pos const &pos2) const
-{
-  Position const p1(pos1.x, pos1.y, pos1.z);
-  Position const p2(pos2.x, pos2.y, pos2.z);
-  Lattice const *lattice = globalmaster->get_lattice();
-  // For triclinic cells, use Lattice::wrap_nearest_delta instead (computes the shift vector)
-  Vector const d = lattice->orthogonal() ? lattice->delta(p2, p1)
-                                         : ((p2 - p1) + lattice->wrap_nearest_delta(p2 - p1));
-  return cvm::rvector(d.x, d.y, d.z);
-}
-
-
 colvarproxy_namd::e_pdb_field colvarproxy_namd::pdb_field_str2enum(std::string const &pdb_field_str)
 {
   colvarproxy_namd::e_pdb_field pdb_field = e_pdb_none;

--- a/namd/src/colvarproxy_namd.h
+++ b/namd/src/colvarproxy_namd.h
@@ -203,9 +203,6 @@ public:
 
   void update_atom_properties(int index);
 
-  cvm::rvector position_distance(cvm::atom_pos const &pos1,
-                                 cvm::atom_pos const &pos2) const;
-
   enum e_pdb_field {
     e_pdb_none,
     e_pdb_occ,


### PR DESCRIPTION
Removing functions that should have been removed as part of #919 