### PR TITLE
[RFC] Refactor atom groups read data

### DIFF
--- a/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
+++ b/namd/cudaglobalmaster/colvarproxy_cudaglobalmaster.C
@@ -207,14 +207,15 @@ public:
   cvm::real* proxy_atoms_new_colvar_forces_gpu() override {return d_mAppliedForces;}
   cudaStream_t get_default_stream() override {return mStream;}
   void set_lattice();
-  cvm::system_boundary_conditions get_system_boundaries()  override {
+  int update_system_boundaries()  override {
+    int error_code = COLVARS_OK;
     if (mClient->requestUpdateLattice()) {
       if (has_gpu_support()) {
-        cudaCheck(cudaEventSynchronize(get_event(colvarproxy_gpu::event_type::update_lattice)));
+        error_code |= checkGPUError(cudaEventSynchronize(get_event(colvarproxy_gpu::event_type::update_lattice)));
       }
       set_lattice();
     }
-    return boundaries_;
+    return error_code;
   };
   friend class CudaGlobalMasterColvars;
 private:

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1513,11 +1513,6 @@ int colvar::calc_cvc_values(int first_cvc, size_t num_cvcs)
        i++) {
     if (!cvcs[i]->is_enabled()) continue;
     cvc_count++;
-    if (use_gpu) {
-      error_code |= (cvcs[i])->read_data_gpu();
-    } else {
-      (cvcs[i])->read_data();
-    }
     if (use_gpu && cvcs[i]->is_enabled(f_cvc_support_gpu)) {
       error_code |= (cvcs[i])->calc_value_gpu();
     } else {
@@ -1651,26 +1646,6 @@ int colvar::calc_cvc_gradients(int first_cvc, size_t num_cvcs)
       cvmodule->log("Done calculating gradients of colvar \""+this->name+"\".\n");
   }
 
-  // Fit gradients of atom groups.
-  // TODO: Ideally, this loop should loop over all atom groups from colvarmodule,
-  // since it is possible to share the same atom group over multiple different
-  // CVCs and different colvar {...}, but this is how Colvars designed...
-  for (i = first_cvc, cvc_count = 0;
-      (i < cvcs.size()) && (cvc_count < cvc_max_count);
-      i++) {
-    if (!cvcs[i]->is_enabled()) continue;
-    cvc_count++;
-    if ((cvcs[i])->is_enabled(f_cvc_gradient)) {
-      if (use_gpu) {
-        error_code |= (cvcs[i])->calc_fit_gradients_gpu();
-      } else {
-        // if requested, propagate (via chain rule) the gradients above
-        // to the atoms used to define the roto-translation
-        (cvcs[i])->calc_fit_gradients();
-      }
-    }
-  }
-
   if (use_gpu) {
     for (i = first_cvc, cvc_count = 0;
         (i < cvcs.size()) && (cvc_count < cvc_max_count);
@@ -1685,6 +1660,17 @@ int colvar::calc_cvc_gradients(int first_cvc, size_t num_cvcs)
     }
   }
 
+  cvmodule->decrease_depth();
+
+  return error_code;
+}
+
+int colvar::debug_cvc_gradients(int first_cvc, size_t num_cvcs) {
+  cvmodule->increase_depth();
+  int error_code = COLVARS_OK;
+  size_t const cvc_max_count = num_cvcs ? num_cvcs : num_active_cvcs();
+  size_t i, cvc_count;
+  const bool use_gpu = cvmodule->proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::gpu;
   // Debug gradients
   for (i = first_cvc, cvc_count = 0;
       (i < cvcs.size()) && (cvc_count < cvc_max_count);
@@ -1699,9 +1685,7 @@ int colvar::calc_cvc_gradients(int first_cvc, size_t num_cvcs)
       }
     }
   }
-
   cvmodule->decrease_depth();
-
   return error_code;
 }
 

--- a/src/colvar.cpp
+++ b/src/colvar.cpp
@@ -1434,19 +1434,10 @@ int colvar::calc_cvcs(int first_cvc, size_t num_cvcs)
     return error_code;
   }
 
-  if (cvmodule->proxy->total_forces_valid() && (!is_enabled(f_cv_total_force_current_step))) {
-    // Use Jacobian derivative computed at previous timestep and the total forces from the same
-    // step, collected just now from the engine
-    error_code |= calc_cvc_total_force(first_cvc, num_cvcs);
-  }
   // atom coordinates are updated by the next line
   error_code |= calc_cvc_values(first_cvc, num_cvcs);
   error_code |= calc_cvc_gradients(first_cvc, num_cvcs);
   error_code |= calc_cvc_Jacobians(first_cvc, num_cvcs);
-  if (is_enabled(f_cv_total_force_current_step)){
-    // Use Jacobian derivative from this timestep
-    error_code |= calc_cvc_total_force(first_cvc, num_cvcs);
-  }
 
   if (cvm::debug())
     cvmodule->log("Done calculating colvar \""+this->name+"\".\n");

--- a/src/colvar.h
+++ b/src/colvar.h
@@ -319,6 +319,8 @@ public:
   /// \brief Same as \link colvar::calc_cvc_values \endlink but for Jacobian derivatives/forces
   int calc_cvc_Jacobians(int first, size_t num_cvcs);
 
+  int debug_cvc_gradients(int first = 0, size_t num_cvcs = 0);
+
   /// \brief Collect quantities from CVCs and update aggregated data for the colvar
   int collect_cvc_data();
 

--- a/src/colvarcomp.cpp
+++ b/src/colvarcomp.cpp
@@ -394,6 +394,9 @@ colvar::cvc::~cvc()
   free_children_deps();
   remove_all_children();
   for (size_t i = 0; i < atom_groups.size(); i++) {
+    cvmodule->unregister_atom_group_from_cvc(atom_groups[i]);
+  }
+  for (size_t i = 0; i < atom_groups.size(); i++) {
     if (atom_groups[i] != NULL) delete atom_groups[i];
   }
 #if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
@@ -453,6 +456,7 @@ void colvar::cvc::register_atom_group(cvm::atom_group *ag)
   atom_groups.push_back(ag);
   add_child(ag);
   enable(f_cvc_explicit_atom_groups);
+  cvmodule->register_atom_group_from_cvc(ag);
 }
 
 
@@ -487,63 +491,6 @@ int colvar::cvc::set_param(std::string const &param_name,
   }
 
   return colvarparams::set_param(param_name, new_value);
-}
-
-
-void colvar::cvc::read_data()
-{
-  if (is_enabled(f_cvc_pbc_minimum_image)) {
-    // Copy boundary conditions from the proxy
-    boundary_conditions = cvmodule->proxy->get_system_boundaries();
-  } else {
-    // Set as non-periodic boundary conditions (default) for this CVC
-    boundary_conditions.reset();
-  }
-
-  if (is_enabled(f_cvc_explicit_atom_groups)) {
-    for (auto agi = atom_groups.begin(); agi != atom_groups.end(); agi++) {
-      auto &atoms = *(*agi);
-      atoms.reset_atoms_data();
-      atoms.read_positions();
-      atoms.calc_required_properties();
-      // each atom group will take care of its own fitting_group, if defined
-    }
-  }
-}
-
-int colvar::cvc::read_data_gpu() {
-  int error_code = COLVARS_OK;
-#if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
-  colvarproxy* proxy = cvmodule->proxy;
-  if ((proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::gpu) && is_enabled(f_cvc_explicit_atom_groups)) {
-    if (is_enabled(colvardeps::f_cvc_require_cpu_buffers)) {
-      // We need to reset the atom group data if it requires CPU buffers
-      for (auto agi = atom_groups.begin(); agi != atom_groups.end(); agi++) {
-        (*agi)->reset_atoms_data();
-      }
-    }
-    for (auto agi = atom_groups.begin(); agi != atom_groups.end(); agi++) {
-      error_code |= (*agi)->get_gpu_atom_group()->read_data_gpu(*agi);
-    }
-    // NOTE: In after_read_data_sync, there are calls to synchronize the
-    // CUDA events for checking if the eigendecompositions are failed, so
-    // I separate read_data_gpu and after_read_data_sync into two loops for possibly
-    // better parallelization.
-    for (auto agi = atom_groups.begin(); agi != atom_groups.end(); agi++) {
-      // Synchronize the results to CPU if necessary
-      error_code |= (*agi)->get_gpu_atom_group()->after_read_data_sync(
-        *agi, is_enabled(colvardeps::f_cvc_require_cpu_buffers));
-    }
-  }
-#endif
-  if (is_enabled(f_cvc_pbc_minimum_image)) {
-    // Copy boundary conditions from the proxy
-    boundary_conditions = cvmodule->proxy->get_system_boundaries();
-  } else {
-    // Set as non-periodic boundary conditions (default) for this CVC
-    boundary_conditions.reset();
-  }
-  return error_code;
 }
 
 
@@ -623,16 +570,6 @@ void colvar::cvc::calc_Jacobian_derivative()
   cvmodule->error("Error: calculation of Jacobian derivatives is not implemented "
              "for colvar components of type \""+function_type()+"\".\n",
              COLVARS_NOT_IMPLEMENTED);
-}
-
-
-void colvar::cvc::calc_fit_gradients()
-{
-  if (is_enabled(f_cvc_explicit_gradient)) {
-    for (size_t ig = 0; ig < atom_groups.size(); ig++) {
-      atom_groups[ig]->calc_fit_gradients();
-    }
-  }
 }
 
 
@@ -1252,19 +1189,6 @@ void colvar::cvc::wrap(colvarvalue &x_unwrapped) const
     cvm::real const shift = cvm::floor((x_unwrapped.real_value - wrap_center) / period + 0.5);
     x_unwrapped.real_value -= shift * period;
   }
-}
-
-
-int colvar::cvc::calc_fit_gradients_gpu() {
-  int error_code = COLVARS_OK;
-#if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
-  if (is_enabled(f_cvc_explicit_gradient)) {
-    for (auto agi = atom_groups.begin(); agi != atom_groups.end(); agi++) {
-      error_code |= (*agi)->get_gpu_atom_group()->calc_fit_gradients_gpu(*agi);
-    }
-  }
-#endif
-  return error_code;
 }
 
 

--- a/src/colvarcomp.h
+++ b/src/colvarcomp.h
@@ -136,10 +136,6 @@ public:
   /// \brief Get vector of vectors of atom IDs for all atom groups
   virtual std::vector<std::vector<int> > get_atom_lists();
 
-  /// \brief Obtain data needed for the calculation for the backend
-  virtual void read_data();
-  virtual int read_data_gpu();
-
   /// \brief Calculate the variable
   virtual void calc_value() = 0;
   virtual int calc_value_gpu() { return COLVARS_NOT_IMPLEMENTED; }
@@ -152,10 +148,6 @@ public:
   virtual int calc_gradients_gpu() { return COLVARS_NOT_IMPLEMENTED; }
   /// \brief CPU-side calculation after the graph in add_calc_gradients_node is done on GPU
   virtual int calc_gradients_after_gpu() { return COLVARS_OK; }
-
-  /// \brief Calculate the atomic fit gradients
-  void calc_fit_gradients();
-  int calc_fit_gradients_gpu();
 
   /// \brief Calculate finite-difference gradients alongside the analytical ones, for each Cartesian component
   virtual void debug_gradients();
@@ -343,7 +335,7 @@ protected:
   cvm::real width = 0.0;
 
   /// Boundary conditions for the system, copied from the engine when needed
-  cvm::system_boundary_conditions boundary_conditions;
+  // cvm::system_boundary_conditions boundary_conditions;
 
 #if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
   std::array<cudaEvent_t, static_cast<int>(event_type::num_event_types)> events = {};

--- a/src/colvarcomp_angles.cpp
+++ b/src/colvarcomp_angles.cpp
@@ -59,6 +59,7 @@ colvar::angle::angle(cvm::atom_group::simple_atom const &a1,
 
 void colvar::angle::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   cvm::atom_pos const g1_pos = group1->center_of_mass();
   cvm::atom_pos const g2_pos = group2->center_of_mass();
   cvm::atom_pos const g3_pos = group3->center_of_mass();
@@ -146,6 +147,7 @@ int colvar::dipole_angle::init(std::string const &conf)
 
 void colvar::dipole_angle::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   cvm::atom_pos const g1_pos = group1->center_of_mass();
   cvm::atom_pos const g2_pos = group2->center_of_mass();
   cvm::atom_pos const g3_pos = group3->center_of_mass();
@@ -269,6 +271,7 @@ colvar::dihedral::dihedral(cvm::atom_group::simple_atom const &a1,
 
 void colvar::dihedral::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   cvm::atom_pos const g1_pos = group1->center_of_mass();
   cvm::atom_pos const g2_pos = group2->center_of_mass();
   cvm::atom_pos const g3_pos = group3->center_of_mass();

--- a/src/colvarcomp_angles.cpp
+++ b/src/colvarcomp_angles.cpp
@@ -60,6 +60,9 @@ colvar::angle::angle(cvm::atom_group::simple_atom const &a1,
 void colvar::angle::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   cvm::atom_pos const g1_pos = group1->center_of_mass();
   cvm::atom_pos const g2_pos = group2->center_of_mass();
   cvm::atom_pos const g3_pos = group3->center_of_mass();
@@ -148,6 +151,9 @@ int colvar::dipole_angle::init(std::string const &conf)
 void colvar::dipole_angle::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   cvm::atom_pos const g1_pos = group1->center_of_mass();
   cvm::atom_pos const g2_pos = group2->center_of_mass();
   cvm::atom_pos const g3_pos = group3->center_of_mass();
@@ -272,6 +278,9 @@ colvar::dihedral::dihedral(cvm::atom_group::simple_atom const &a1,
 void colvar::dihedral::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   cvm::atom_pos const g1_pos = group1->center_of_mass();
   cvm::atom_pos const g2_pos = group2->center_of_mass();
   cvm::atom_pos const g3_pos = group3->center_of_mass();

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -86,6 +86,7 @@ public:
         }
       }
     }
+    auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
     // NOTE: We pass boundary_conditions as a function argument from CPU, so this is not necessary
     // for the time being, but it may be useful if the boundary_conditions is GPU-resident.
     // error_code |= checkGPUError(cudaStreamWaitEvent(
@@ -100,7 +101,7 @@ public:
       cvc->group1->get_gpu_atom_group()->get_gpu_buffers().d_atoms_pos,
       cvc->group2->get_gpu_atom_group()->get_gpu_buffers().d_atoms_pos,
       cvc->group1->size(), cvc->group2->size(), cvc->en, cvc->ed,
-      cvc->inv_r0_vec, cvc->inv_r0sq_vec, cvc->boundary_conditions,
+      cvc->inv_r0_vec, cvc->inv_r0sq_vec, boundary_conditions,
       cvc->group1->get_gpu_atom_group()->get_gpu_buffers().d_atoms_grad,
       cvc->group2->get_gpu_atom_group()->get_gpu_buffers().d_atoms_grad,
       cvc->tolerance, cvc->tolerance_l2_max,
@@ -121,6 +122,7 @@ public:
       return cvmodule->error("calc_value_group_to_com is called incorrectly.\n",
                              COLVARS_BUG_ERROR);
     }
+    auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
     int error_code = COLVARS_OK;
     auto group = cvc->b_group1_center_only ? cvc->group2 : cvc->group1;
     auto group_com = cvc->b_group1_center_only ? cvc->group1 : cvc->group2;
@@ -138,7 +140,7 @@ public:
       group->get_gpu_atom_group()->get_gpu_buffers().d_atoms_pos,
       group_com->get_gpu_atom_group()->get_gpu_buffers().d_com,
       group->size(), cvc->en, cvc->ed, cvc->inv_r0_vec,
-      cvc->inv_r0sq_vec, cvc->boundary_conditions,
+      cvc->inv_r0sq_vec, boundary_conditions,
       group->get_gpu_atom_group()->get_gpu_buffers().d_atoms_grad,
       cvc->tolerance, cvc->tolerance_l2_max, d_pairlist, d_tbcount,
       d_com_grad_tmp[0], d_com_grad_out[0], d_coordnum, h_coordnum,
@@ -160,6 +162,7 @@ public:
       return cvmodule->error("calc_value_two_coms is called incorrectly.\n",
                              COLVARS_BUG_ERROR);
     }
+    auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
     int error_code = COLVARS_OK;
     // NOTE: We pass boundary_conditions as a function argument from CPU, so this is not necessary
     // for the time being, but it may be useful if the boundary_conditions is GPU-resident.
@@ -175,7 +178,7 @@ public:
       cvc->group1->get_gpu_atom_group()->get_gpu_buffers().d_com,
       cvc->group2->get_gpu_atom_group()->get_gpu_buffers().d_com,
       cvc->en, cvc->ed, cvc->inv_r0_vec, cvc->inv_r0sq_vec,
-      cvc->boundary_conditions,
+      boundary_conditions,
       cvc->tolerance, cvc->tolerance_l2_max, d_pairlist,
       d_com_grad_out[0], d_com_grad_out[1], h_coordnum, flags, cvc->get_stream(), cvmodule);
     error_code |= checkGPUError(cudaEventRecord(
@@ -199,6 +202,7 @@ public:
       error_code |= selfCoordNumTileList.buildTileLists(
         cvc->group1->size(), cvc->b_enable_pairlist, gpu_warp_size, cvc->get_stream());
     }
+    auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
     error_code |= checkGPUError(cudaStreamWaitEvent(
       cvc->get_stream(), cvmodule->proxy->get_event(colvarproxy_gpu::event_type::update_lattice)));
     error_code |= checkGPUError(cudaStreamWaitEvent(
@@ -207,7 +211,7 @@ public:
     error_code |= colvars_gpu::calc_value_coordnum_self_group(
       cvc->group1->get_gpu_atom_group()->get_gpu_buffers().d_atoms_pos,
       cvc->group1->size(), cvc->en, cvc->ed, cvc->inv_r0_vec, cvc->inv_r0sq_vec,
-      cvc->boundary_conditions,
+      boundary_conditions,
       cvc->group1->get_gpu_atom_group()->get_gpu_buffers().d_atoms_grad,
       selfCoordNumTileList.d_tileLists, selfCoordNumTileList.d_tileListsStart, selfCoordNumTileList.d_tileListsLen,
       cvc->tolerance, cvc->tolerance_l2_max, d_pairlist,
@@ -582,6 +586,7 @@ void inline colvar::coordnum::main_loop()
   cvm::atom_pos const group1_com = group1->center_of_mass();
   cvm::atom_pos const group2_com = group2->center_of_mass();
   cvm::rvector group1_com_grad, group2_com_grad;
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
 
   bool *pairlist_elem = pairlist.get();
 
@@ -824,6 +829,7 @@ colvar::h_bond::h_bond(cvm::atom_group::simple_atom const &acceptor,
 void colvar::h_bond::calc_value()
 {
   constexpr int flags = coordnum::ef_null;
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   cvm::rvector G1, G2;
   const cvm::atom_pos A1{atom_groups[0]->pos_x(0),
                          atom_groups[0]->pos_y(0),
@@ -865,6 +871,7 @@ void colvar::h_bond::calc_value()
 void colvar::h_bond::calc_gradients()
 {
   int constexpr flags = coordnum::ef_gradients;
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   const cvm::rvector inv_r0_vec{
     1.0 / r0_vec.x,
     1.0 / r0_vec.y,
@@ -903,6 +910,7 @@ template <int flags> inline void colvar::selfcoordnum::selfcoordnum_sequential_l
 {
   size_t const n = group1->size();
   bool *pairlist_elem = pairlist.get();
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
 
   for (size_t i = 0; i < n - 1; i++) {
 

--- a/src/colvarcomp_coordnums.cpp
+++ b/src/colvarcomp_coordnums.cpp
@@ -87,6 +87,9 @@ public:
       }
     }
     auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+    if (!cvc->is_enabled(f_cvc_pbc_minimum_image)) {
+      boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+    }
     // NOTE: We pass boundary_conditions as a function argument from CPU, so this is not necessary
     // for the time being, but it may be useful if the boundary_conditions is GPU-resident.
     // error_code |= checkGPUError(cudaStreamWaitEvent(
@@ -123,6 +126,9 @@ public:
                              COLVARS_BUG_ERROR);
     }
     auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+    if (!cvc->is_enabled(f_cvc_pbc_minimum_image)) {
+      boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+    }
     int error_code = COLVARS_OK;
     auto group = cvc->b_group1_center_only ? cvc->group2 : cvc->group1;
     auto group_com = cvc->b_group1_center_only ? cvc->group1 : cvc->group2;
@@ -163,6 +169,9 @@ public:
                              COLVARS_BUG_ERROR);
     }
     auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+    if (!cvc->is_enabled(f_cvc_pbc_minimum_image)) {
+      boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+    }
     int error_code = COLVARS_OK;
     // NOTE: We pass boundary_conditions as a function argument from CPU, so this is not necessary
     // for the time being, but it may be useful if the boundary_conditions is GPU-resident.
@@ -203,6 +212,9 @@ public:
         cvc->group1->size(), cvc->b_enable_pairlist, gpu_warp_size, cvc->get_stream());
     }
     auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+    if (!cvc->is_enabled(f_cvc_pbc_minimum_image)) {
+      boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+    }
     error_code |= checkGPUError(cudaStreamWaitEvent(
       cvc->get_stream(), cvmodule->proxy->get_event(colvarproxy_gpu::event_type::update_lattice)));
     error_code |= checkGPUError(cudaStreamWaitEvent(
@@ -587,6 +599,9 @@ void inline colvar::coordnum::main_loop()
   cvm::atom_pos const group2_com = group2->center_of_mass();
   cvm::rvector group1_com_grad, group2_com_grad;
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
 
   bool *pairlist_elem = pairlist.get();
 
@@ -830,6 +845,9 @@ void colvar::h_bond::calc_value()
 {
   constexpr int flags = coordnum::ef_null;
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   cvm::rvector G1, G2;
   const cvm::atom_pos A1{atom_groups[0]->pos_x(0),
                          atom_groups[0]->pos_y(0),
@@ -872,6 +890,9 @@ void colvar::h_bond::calc_gradients()
 {
   int constexpr flags = coordnum::ef_gradients;
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   const cvm::rvector inv_r0_vec{
     1.0 / r0_vec.x,
     1.0 / r0_vec.y,
@@ -911,6 +932,9 @@ template <int flags> inline void colvar::selfcoordnum::selfcoordnum_sequential_l
   size_t const n = group1->size();
   bool *pairlist_elem = pairlist.get();
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
 
   for (size_t i = 0; i < n - 1; i++) {
 

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -52,6 +52,7 @@ int colvar::distance::init(std::string const &conf)
 
 void colvar::distance::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   dist_v = boundary_conditions.position_distance(group1->center_of_mass(), group2->center_of_mass());
   x.real_value = dist_v.norm();
 }
@@ -94,6 +95,7 @@ colvar::distance_vec::distance_vec()
 
 void colvar::distance_vec::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   x.rvector_value =
       boundary_conditions.position_distance(group1->center_of_mass(), group2->center_of_mass());
 }
@@ -118,12 +120,14 @@ void colvar::distance_vec::apply_force(colvarvalue const &force)
 
 cvm::real colvar::distance_vec::dist2(colvarvalue const &x1, colvarvalue const &x2) const
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   return (boundary_conditions.position_distance(x1.rvector_value, x2.rvector_value)).norm2();
 }
 
 
 colvarvalue colvar::distance_vec::dist2_lgrad(colvarvalue const &x1, colvarvalue const &x2) const
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   return 2.0 * boundary_conditions.position_distance(x2.rvector_value, x1.rvector_value);
 }
 
@@ -185,6 +189,7 @@ void colvar::distance_z::calc_value()
 {
   cvm::rvector const M = main->center_of_mass();
   cvm::rvector const R1 = ref1->center_of_mass();
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   if (fixed_axis) {
     dist_v = boundary_conditions.position_distance(R1, M);
   } else {
@@ -249,6 +254,7 @@ colvar::distance_xy::distance_xy()
 
 void colvar::distance_xy::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   dist_v = boundary_conditions.position_distance(ref1->center_of_mass(), main->center_of_mass());
   if (!fixed_axis) {
     v12 = boundary_conditions.position_distance(ref1->center_of_mass(), ref2->center_of_mass());
@@ -275,6 +281,7 @@ void colvar::distance_xy::calc_gradients()
     ref1->set_weighted_gradient(-1.0 * x_inv * dist_v_ortho);
     main->set_weighted_gradient(       x_inv * dist_v_ortho);
   } else {
+    auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
     v13 = boundary_conditions.position_distance(ref1->center_of_mass(), main->center_of_mass());
     A = (dist_v * axis) / axis_norm;
 
@@ -316,6 +323,7 @@ colvar::distance_dir::distance_dir()
 
 void colvar::distance_dir::calc_value()
 {
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   dist_v =
       boundary_conditions.position_distance(group1->center_of_mass(), group2->center_of_mass());
   x.rvector_value = dist_v.unit();
@@ -437,6 +445,7 @@ void colvar::distance_inv::calc_value()
     group1->grad_z(i) += g1.z; \
   }                            \
 } while (0);
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   x.real_value = 0.0;
   CALL_KERNEL();
 
@@ -511,6 +520,7 @@ void colvar::distance_pairs::calc_value()
     group1->grad_z(i1) += g1.z;*/                                    \
   }                                                                \
 } while (0);
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   CALL_KERNEL();
 #undef CALL_KERNEL
 }
@@ -546,6 +556,7 @@ void colvar::distance_pairs::apply_force(colvarvalue const &force)
     group1_force_obj.add_atom_force(i1, f1);                            \
   }                                                                     \
 } while (0);
+  auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
   CALL_KERNEL();
 #undef CALL_KERNEL
 }

--- a/src/colvarcomp_distances.cpp
+++ b/src/colvarcomp_distances.cpp
@@ -53,6 +53,9 @@ int colvar::distance::init(std::string const &conf)
 void colvar::distance::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   dist_v = boundary_conditions.position_distance(group1->center_of_mass(), group2->center_of_mass());
   x.real_value = dist_v.norm();
 }
@@ -96,6 +99,9 @@ colvar::distance_vec::distance_vec()
 void colvar::distance_vec::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   x.rvector_value =
       boundary_conditions.position_distance(group1->center_of_mass(), group2->center_of_mass());
 }
@@ -121,6 +127,9 @@ void colvar::distance_vec::apply_force(colvarvalue const &force)
 cvm::real colvar::distance_vec::dist2(colvarvalue const &x1, colvarvalue const &x2) const
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   return (boundary_conditions.position_distance(x1.rvector_value, x2.rvector_value)).norm2();
 }
 
@@ -128,6 +137,9 @@ cvm::real colvar::distance_vec::dist2(colvarvalue const &x1, colvarvalue const &
 colvarvalue colvar::distance_vec::dist2_lgrad(colvarvalue const &x1, colvarvalue const &x2) const
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   return 2.0 * boundary_conditions.position_distance(x2.rvector_value, x1.rvector_value);
 }
 
@@ -190,6 +202,9 @@ void colvar::distance_z::calc_value()
   cvm::rvector const M = main->center_of_mass();
   cvm::rvector const R1 = ref1->center_of_mass();
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   if (fixed_axis) {
     dist_v = boundary_conditions.position_distance(R1, M);
   } else {
@@ -255,6 +270,9 @@ colvar::distance_xy::distance_xy()
 void colvar::distance_xy::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   dist_v = boundary_conditions.position_distance(ref1->center_of_mass(), main->center_of_mass());
   if (!fixed_axis) {
     v12 = boundary_conditions.position_distance(ref1->center_of_mass(), ref2->center_of_mass());
@@ -282,6 +300,9 @@ void colvar::distance_xy::calc_gradients()
     main->set_weighted_gradient(       x_inv * dist_v_ortho);
   } else {
     auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+    if (!is_enabled(f_cvc_pbc_minimum_image)) {
+      boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+    }
     v13 = boundary_conditions.position_distance(ref1->center_of_mass(), main->center_of_mass());
     A = (dist_v * axis) / axis_norm;
 
@@ -324,6 +345,9 @@ colvar::distance_dir::distance_dir()
 void colvar::distance_dir::calc_value()
 {
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   dist_v =
       boundary_conditions.position_distance(group1->center_of_mass(), group2->center_of_mass());
   x.rvector_value = dist_v.unit();
@@ -446,6 +470,9 @@ void colvar::distance_inv::calc_value()
   }                            \
 } while (0);
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   x.real_value = 0.0;
   CALL_KERNEL();
 
@@ -521,6 +548,9 @@ void colvar::distance_pairs::calc_value()
   }                                                                \
 } while (0);
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   CALL_KERNEL();
 #undef CALL_KERNEL
 }
@@ -557,6 +587,9 @@ void colvar::distance_pairs::apply_force(colvarvalue const &force)
   }                                                                     \
 } while (0);
   auto boundary_conditions = cvmodule->proxy->get_system_boundaries();
+  if (!is_enabled(f_cvc_pbc_minimum_image)) {
+    boundary_conditions.set_type(colvarmodule::system_boundary_conditions::types::non_periodic);
+  }
   CALL_KERNEL();
 #undef CALL_KERNEL
 }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -874,6 +874,24 @@ void colvarmodule::unregister_named_atom_group(atom_group *ag) {
   }
 }
 
+void colvarmodule::register_atom_group_from_cvc(atom_group *ag) {
+  std::lock_guard<std::mutex> lock(registered_atom_groups_mutex);
+  registered_atom_groups[ag].fetch_add(1, std::memory_order_relaxed);
+}
+
+void colvarmodule::unregister_atom_group_from_cvc(atom_group* ag) {
+  std::lock_guard<std::mutex> lock(registered_atom_groups_mutex);
+  auto it = registered_atom_groups.find(ag);
+  if (it != registered_atom_groups.end()) {
+    const int old_count = it->second.fetch_sub(1);
+    if (old_count == 1) {
+      registered_atom_groups.erase(it);
+    }
+  } else {
+    return;
+  }
+}
+
 int colvarmodule::change_configuration(std::string const &bias_name,
                                        std::string const &conf)
 {
@@ -935,7 +953,62 @@ int colvarmodule::calc()
              this->to_str(this->step_absolute())+"\n");
   }
 
+  const bool use_gpu = proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::gpu;
+  increase_depth();
+  // Read atom groups
+  if (use_gpu) {
+#if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
+    for (auto it = registered_atom_groups.begin(); it != registered_atom_groups.end(); ++it) {
+      auto parent_cvcs = it->first->get_parents();
+      bool use_cpu_buffers = false;
+      for (auto c = parent_cvcs.begin(); c != parent_cvcs.end(); ++c) {
+        if ((*c)->get_object_type() == colvardeps::object_t::colvarcomp) {
+          auto cvc = dynamic_cast<colvar::cvc*>(*c);
+          use_cpu_buffers |= cvc->is_enabled(colvardeps::f_cvc_require_cpu_buffers);
+        }
+      }
+      if (use_cpu_buffers) {
+        it->first->reset_atoms_data();
+      }
+      error_code |= it->first->get_gpu_atom_group()->read_data_gpu(it->first);
+      error_code |= it->first->get_gpu_atom_group()->after_read_data_sync(it->first, use_cpu_buffers);
+    }
+#endif
+  } else {
+    // TODO: Maybe we can calculate the atom groups in parallel in case of SMP
+    for (auto it = registered_atom_groups.begin(); it != registered_atom_groups.end(); ++it) {
+      it->first->reset_atoms_data();
+      it->first->read_positions();
+      it->first->calc_required_properties();
+    }
+  }
+  error_code |= proxy->update_system_boundaries();
+  decrease_depth();
   error_code |= calc_colvars();
+  increase_depth();
+  // Calculate atom group fit gradients
+  if (use_gpu) {
+#if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
+    for (auto it = registered_atom_groups.begin(); it != registered_atom_groups.end(); ++it) {
+      if (it->first->is_enabled(colvardeps::f_ag_fit_gradients)) {
+        error_code |= (it->first)->get_gpu_atom_group()->calc_fit_gradients_gpu(it->first);
+      }
+    }
+#endif
+  } else {
+    for (auto it = registered_atom_groups.begin(); it != registered_atom_groups.end(); ++it) {
+      if (it->first->is_enabled(colvardeps::f_ag_fit_gradients)) {
+        it->first->calc_fit_gradients();
+      }
+    }
+  }
+  // Debug gradients
+  for (auto cvi = variables_active()->begin(); cvi != variables_active()->end(); cvi++) {
+    if ((*cvi)->is_enabled(colvardeps::f_cv_active)) {
+      error_code |= (*cvi)->debug_cvc_gradients();
+    }
+  }
+  decrease_depth();
   error_code |= calc_biases();
   error_code |= update_colvar_forces();
 
@@ -1217,31 +1290,11 @@ int colvarmodule::update_colvar_forces()
   // force values (done in cvm::atom_group::apply_force and apply_colvar_force)
   // into host-pinned buffers. But before that, I still need to clear these
   // buffers of all atom groups that may have forces applied on.
-  // TODO: How can I avoid constructing forced_atom_groups every step?
-  std::vector<atom_group *> forced_atom_groups;
   if (proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::gpu) {
 #if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
-    for (cvi = variables_active()->begin(); cvi != variables_active()->end(); cvi++) {
-      if ((*cvi)->is_enabled(colvardeps::f_cv_apply_force)) {
-        auto& cvcs = (*cvi)->get_cvcs();
-        for (size_t i = 0; i < cvcs.size(); i++) {
-          if (!cvcs[i]->is_enabled()) continue;
-          std::vector<atom_group *>& ags = (cvcs[i])->atom_groups;
-          for (auto ag = ags.begin(); ag != ags.end(); ++ag) {
-            if ((*ag)->size() > 0) {
-              forced_atom_groups.push_back(*ag);
-            }
-          }
-        }
-      }
-    }
-    // Since atom groups can be shared, I have to sort and deduplicate the array.
-    std::sort(forced_atom_groups.begin(), forced_atom_groups.end());
-    auto last = std::unique(forced_atom_groups.begin(), forced_atom_groups.end());
-    forced_atom_groups.erase(last, forced_atom_groups.end());
     // Clear the host-pinned buffers
-    for (auto ag = forced_atom_groups.begin(); ag != forced_atom_groups.end(); ++ag) {
-      error_code |= (*ag)->get_gpu_atom_group()->begin_apply_force_gpu();
+    for (auto ag = registered_atom_groups.begin(); ag != registered_atom_groups.end(); ++ag) {
+      error_code |= ag->first->get_gpu_atom_group()->begin_apply_force_gpu();
     }
 #endif
   }
@@ -1261,8 +1314,8 @@ int colvarmodule::update_colvar_forces()
     // own stream, the CUDA kernel/Graph for adding forces are always pushed after the
     // CUDA graph for fit gradients. As a result, we don't need to synchronize the
     // fit gradients event.
-    for (auto ag = forced_atom_groups.begin(); ag != forced_atom_groups.end(); ++ag) {
-      error_code |= (*ag)->get_gpu_atom_group()->add_force_to_proxy_gpu((*ag));
+    for (auto ag = registered_atom_groups.begin(); ag != registered_atom_groups.end(); ++ag) {
+      error_code |= ag->first->get_gpu_atom_group()->add_force_to_proxy_gpu(ag->first);
     }
 #endif
   }

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -446,7 +446,7 @@ int colvarmodule::parse_global_params(std::string const &conf)
         this->error("GPU parallelism is not implemented.\n");
         return COLVARS_INPUT_ERROR;
       } else {
-        this->log("EXPERIMENTAL GPU parallelism will be used. GPU information:\n");
+        this->log("EXPERIMENTAL GPU parallelism will be used.\n");
       }
     } else {
       proxy->set_smp_mode(colvarproxy_smp::smp_mode_t::none);
@@ -492,7 +492,7 @@ int colvarmodule::parse_global_params(std::string const &conf)
         break;
       }
       case colvarproxy_smp::smp_mode_t::gpu: {
-        this->log("EXPERIMENTAL GPU parallelism will be used. GPU information:\n");
+        this->log("EXPERIMENTAL GPU parallelism will be used.\n");
         break;
       }
       case colvarproxy_smp::smp_mode_t::none: {

--- a/src/colvarmodule.cpp
+++ b/src/colvarmodule.cpp
@@ -955,6 +955,21 @@ int colvarmodule::calc()
 
   const bool use_gpu = proxy->get_smp_mode() == colvarproxy_smp::smp_mode_t::gpu;
   increase_depth();
+  // TODO: This is a hack which does not fix the underlying design issue of Colvars.
+  // If two CVCs use the same atom group, clearly they cannot compute total forces
+  // at the same time because both of them would call read_total_forces() from the
+  // same atom group. The atom gradients are also problematic, since they could
+  // be (i) cleared after reset_atoms_data(), (ii) modified from the two CVCs
+  // at the same time if the atom group is shared. This hack only sacrifices SMP
+  // to solve (i). It is better to re-design the overall Colvars hierarchy to
+  // solve (ii). See also https://github.com/Colvars/colvars/discussions/655.
+  if (proxy->total_forces_valid()) {
+    for (auto cvi = variables_active()->begin(); cvi != variables_active()->end(); cvi++) {
+      if (!(*cvi)->is_enabled(colvardeps::f_cv_total_force_current_step)) {
+        error_code |= (*cvi)->calc_cvc_total_force(0, (*cvi)->num_cvcs());
+      }
+    }
+  }
   // Read atom groups
   if (use_gpu) {
 #if defined (COLVARS_CUDA) || defined (COLVARS_HIP)
@@ -1006,6 +1021,9 @@ int colvarmodule::calc()
   for (auto cvi = variables_active()->begin(); cvi != variables_active()->end(); cvi++) {
     if ((*cvi)->is_enabled(colvardeps::f_cv_active)) {
       error_code |= (*cvi)->debug_cvc_gradients();
+    }
+    if ((*cvi)->is_enabled(colvardeps::f_cv_total_force_current_step)) {
+      error_code |= (*cvi)->calc_cvc_total_force(0, (*cvi)->num_cvcs());
     }
   }
   decrease_depth();

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -14,6 +14,8 @@
 #include <unordered_map>
 #include <memory>
 #include <cstdio>
+#include <atomic>
+#include <mutex>
 
 #include "colvars_version.h"
 
@@ -334,10 +336,17 @@ private:
   /// Array of named atom groups
   std::vector<atom_group *> named_atom_groups;
 
+  /// Array of all registered atom groups from CVCs
+  std::unordered_map<atom_group *, std::atomic<int>> registered_atom_groups;
+  std::mutex registered_atom_groups_mutex;
+
 public:
 
   void register_named_atom_group(atom_group *ag);
   void unregister_named_atom_group(atom_group *ag);
+
+  void register_atom_group_from_cvc(atom_group *ag);
+  void unregister_atom_group_from_cvc(atom_group *ag);
 
   /// Array of collective variables
   std::vector<colvar *> *variables();

--- a/src/colvarproxy_system.h
+++ b/src/colvarproxy_system.h
@@ -93,9 +93,12 @@ public:
   virtual cvm::rvector position_distance(cvm::atom_pos const &pos1,
                                          cvm::atom_pos const &pos2) const;
   /// Get the current system boundary conditions
-  virtual cvm::system_boundary_conditions get_system_boundaries() {
+  const cvm::system_boundary_conditions& get_system_boundaries() const {
     return boundaries_;
   }
+
+  /// Routine to update the system boundaries implemented by proxy
+  virtual int update_system_boundaries() { return COLVARS_OK; }
 
   /// \brief Tell the proxy whether total forces are needed (they may not
   /// always be available)

--- a/src/colvars_system.h
+++ b/src/colvars_system.h
@@ -60,7 +60,7 @@ public:
   inline COLVARS_HOST_DEVICE void set_boundaries(bool periodic_x_in, bool periodic_y_in,
                                                 bool periodic_z_in, cvm::rvector const &A,
                                                 cvm::rvector const &B, cvm::rvector const &C);
-protected:
+public:
 
   /// Type of boundary conditions in the current computation
   types type_ = types::non_periodic;
@@ -167,12 +167,13 @@ cvm::rvector cvm::system_boundary_conditions::position_distance(cvm::atom_pos co
     return diff;
   }
 
-  if (type() == types::unsupported) {
-#if !(defined(__HIP_DEVICE_COMPILE__)) && !(defined(__CUDA_ARCH__))
-    cvm::error_static("Error: unsupported boundary conditions.\n", COLVARS_INPUT_ERROR);
-#endif
-    return diff;
-  }
+
+//   if (type() == types::unsupported) {
+// #if !(defined(__HIP_DEVICE_COMPILE__)) && !(defined(__CUDA_ARCH__))
+//     cvm::error_static("Error: unsupported boundary conditions.\n", COLVARS_INPUT_ERROR);
+// #endif
+//     return diff;
+//   }
 
   cvm::real const x_shift = ::floor(reciprocal_cell_x * diff + 0.5);
   cvm::real const y_shift = ::floor(reciprocal_cell_y * diff + 0.5);


### PR DESCRIPTION
This PR implements the idea discussed in https://github.com/Colvars/colvars/pull/938#discussion_r3625807200, and also refactors the update of lattice (boundary condition) so that `boundaries_` is updated only once in the GPU code path. This PR also lays the foundation of reusing atom groups.

**This PR depends on https://github.com/Colvars/colvars/pull/940**. Sadly I still haven't figured out how to make a stacked PR...