### PR TITLE
Optimize the switching function of coordnum on GPU

### DIFF
--- a/src/colvarcomp_coordnums.h
+++ b/src/colvarcomp_coordnums.h
@@ -199,7 +199,11 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
   if constexpr ((static_en > 0) && (static_ed > 0)) {
     if constexpr (static_ed_is_2en) {
       // xn = cvm::positive_integer_power<static_en / 2>(l2);
-      xn_1 = cvm::positive_integer_power<static_en / 2 - 1>(l2);
+      if constexpr (static_en == 2) {
+        xn_1 = 1.0;
+      } else {
+        xn_1 = cvm::positive_integer_power<static_en / 2 - 1>(l2);
+      }
       xn = xn_1 * l2;
       en2_r = (cvm::real)static_en / 2;
     } else {

--- a/src/colvarcomp_coordnums.h
+++ b/src/colvarcomp_coordnums.h
@@ -188,18 +188,26 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
   int en, int ed,
   cvm::real pairlist_tol)
 {
+  constexpr bool static_ed_is_2en = (static_en > 0) && (static_ed > 0) && (static_ed == 2 * static_en);
   if constexpr ((static_en > 0) && (static_ed > 0)) {
     // Assume en and ed are even integers, and avoid sqrt in the following
     static_assert(std::integral_constant<int, static_en>::value % 2 == 0, "static_en must be an even positive integer.");
     static_assert(std::integral_constant<int, static_ed>::value % 2 == 0, "static_ed must be an even positive integer.");
   }
   // Assume en and ed are even integers, and avoid sqrt in the following
-  cvm::real xn, xd, en2_r, ed2_r;
+  cvm::real xn, xn_1, xd, en2_r, ed2_r;
   if constexpr ((static_en > 0) && (static_ed > 0)) {
-    xn = cvm::positive_integer_power<static_en / 2>(l2);
-    xd = cvm::positive_integer_power<static_ed / 2>(l2);
-    en2_r = (cvm::real)static_en / 2;
-    ed2_r = (cvm::real)static_ed / 2;
+    if constexpr (static_ed_is_2en) {
+      // xn = cvm::positive_integer_power<static_en / 2>(l2);
+      xn_1 = cvm::positive_integer_power<static_en / 2 - 1>(l2);
+      xn = xn_1 * l2;
+      en2_r = (cvm::real)static_en / 2;
+    } else {
+      xn = cvm::positive_integer_power<static_en / 2>(l2);
+      xd = cvm::positive_integer_power<static_ed / 2>(l2);
+      en2_r = (cvm::real)static_en / 2;
+      ed2_r = (cvm::real)static_ed / 2;
+    }
   } else {
     int const en2 = en/2;
     int const ed2 = ed/2;
@@ -213,14 +221,18 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
   cvm::real const h = l2 - 1.0;
   cvm::real func_no_pairlist;
 
-  if (std::abs(h) < eps_l2) {
-    // Order-2 Taylor expansion: c0 + c1*h + c2*h^2
-    cvm::real const c0 = en2_r / ed2_r;
-    cvm::real const c1 = (en2_r * (en2_r - ed2_r)) / (2.0 * ed2_r);
-    cvm::real const c2 = (en2_r * (en2_r - ed2_r) * (2.0 * en2_r - ed2_r - 3.0)) / (12.0 * ed2_r);
-    func_no_pairlist = c0 + h * (c1 + h * c2);
+  if constexpr (static_ed_is_2en) {
+    func_no_pairlist = 1.0 / (1.0 + xn);
   } else {
-    func_no_pairlist = (1.0 - xn) / (1.0 - xd);
+    if (std::abs(h) < eps_l2) {
+      // Order-2 Taylor expansion: c0 + c1*h + c2*h^2
+      cvm::real const c0 = en2_r / ed2_r;
+      cvm::real const c1 = (en2_r * (en2_r - ed2_r)) / (2.0 * ed2_r);
+      cvm::real const c2 = (en2_r * (en2_r - ed2_r) * (2.0 * en2_r - ed2_r - 3.0)) / (12.0 * ed2_r);
+      func_no_pairlist = c0 + h * (c1 + h * c2);
+    } else {
+      func_no_pairlist = (1.0 - xn) / (1.0 - xd);
+    }
   }
 
   cvm::real func, inv_one_pairlist_tol;
@@ -237,18 +249,23 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
     return 0;
 
   if (flags & ef_gradients) {
-    // Logarithmic derivative: 1st-order Taylor expansion around l2 = 1
-    cvm::real log_deriv;
-    if (std::abs(h) < eps_l2) {
-      cvm::real const g0 = 0.5 * (en2_r - ed2_r);
-      cvm::real const g1 = ((en2_r - ed2_r) * (en2_r + ed2_r - 6.0)) / 12.0;
-      log_deriv = g0 + h * g1;
+    if constexpr (static_ed_is_2en) {
+      const cvm::real deriv = -func_no_pairlist * func_no_pairlist * en2_r * xn_1;
+      dFdl2 = (flags & ef_use_pairlist) ? inv_one_pairlist_tol * deriv : deriv;
     } else {
-      log_deriv = (ed2_r * xd / ((1.0 - xd) * l2)) - (en2_r * xn / ((1.0 - xn) * l2));
+      // Logarithmic derivative: 1st-order Taylor expansion around l2 = 1
+      cvm::real log_deriv;
+      if (std::abs(h) < eps_l2) {
+        cvm::real const g0 = 0.5 * (en2_r - ed2_r);
+        cvm::real const g1 = ((en2_r - ed2_r) * (en2_r + ed2_r - 6.0)) / 12.0;
+        log_deriv = g0 + h * g1;
+      } else {
+        log_deriv = (ed2_r * xd / ((1.0 - xd) * l2)) - (en2_r * xn / ((1.0 - xn) * l2));
+      }
+      dFdl2 = (flags & ef_use_pairlist) ?
+        func_no_pairlist * inv_one_pairlist_tol * log_deriv :
+        func * log_deriv;
     }
-    dFdl2 = (flags & ef_use_pairlist) ?
-      func_no_pairlist * inv_one_pairlist_tol * log_deriv :
-      func * log_deriv;
   }
 
   return func;

--- a/src/colvarcomp_coordnums.h
+++ b/src/colvarcomp_coordnums.h
@@ -191,8 +191,8 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
   constexpr bool static_ed_is_2en = (static_en > 0) && (static_ed > 0) && (static_ed == 2 * static_en);
   if constexpr ((static_en > 0) && (static_ed > 0)) {
     // Assume en and ed are even integers, and avoid sqrt in the following
-    static_assert(std::integral_constant<int, static_en>::value % 2 == 0, "static_en must be an even positive integer.");
-    static_assert(std::integral_constant<int, static_ed>::value % 2 == 0, "static_ed must be an even positive integer.");
+    static_assert(static_en % 2 == 0, "static_en must be an even positive integer.");
+    static_assert(static_ed % 2 == 0, "static_ed must be an even positive integer.");
   }
   // Assume en and ed are even integers, and avoid sqrt in the following
   cvm::real xn, xn_1, xd, en2_r, ed2_r;

--- a/src/colvarcomp_coordnums.h
+++ b/src/colvarcomp_coordnums.h
@@ -49,13 +49,13 @@ public:
   /// @param en Numerator exponent
   /// @param ed Denominator exponent
   /// @param pairlist_tol Pairlist tolerance
-  template <int flags>
+  template <int flags, int static_en = 0, int static_ed = 0>
   inline COLVARS_HOST_DEVICE static cvm::real switching_function(
     cvm::real const &l2, cvm::real &dFdl2, int en, int ed,
     cvm::real pairlist_tol);
 
   /// Main kernel for the coordination number
-  template <int flags>
+  template <int flags, int static_en = 0, int static_ed = 0>
   inline COLVARS_HOST_DEVICE static cvm::real compute_pair_coordnum(
     cvm::rvector const &inv_r0_vec,
     cvm::rvector const &inv_r0sq_vec, int en, int ed,
@@ -182,22 +182,35 @@ protected:
 };
 
 
-template <int flags>
+template <int flags, int static_en, int static_ed>
 inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
   cvm::real const &l2, cvm::real &dFdl2,
   int en, int ed,
   cvm::real pairlist_tol)
 {
+  if constexpr ((static_en > 0) && (static_ed > 0)) {
+    // Assume en and ed are even integers, and avoid sqrt in the following
+    static_assert(std::integral_constant<int, static_en>::value % 2 == 0, "static_en must be an even positive integer.");
+    static_assert(std::integral_constant<int, static_ed>::value % 2 == 0, "static_ed must be an even positive integer.");
+  }
   // Assume en and ed are even integers, and avoid sqrt in the following
-  int const en2 = en/2;
-  int const ed2 = ed/2;
+  cvm::real xn, xd, en2_r, ed2_r;
+  if constexpr ((static_en > 0) && (static_ed > 0)) {
+    xn = cvm::positive_integer_power<static_en / 2>(l2);
+    xd = cvm::positive_integer_power<static_ed / 2>(l2);
+    en2_r = (cvm::real)static_en / 2;
+    ed2_r = (cvm::real)static_ed / 2;
+  } else {
+    int const en2 = en/2;
+    int const ed2 = ed/2;
+    xn = cvm::integer_power(l2, en2);
+    xd = cvm::integer_power(l2, ed2);
+    en2_r = (cvm::real) en2;
+    ed2_r = (cvm::real) ed2;
+  }
 
-  cvm::real const xn = cvm::integer_power(l2, en2);
-  cvm::real const xd = cvm::integer_power(l2, ed2);
   cvm::real const eps_l2 = 1.0e-7;
   cvm::real const h = l2 - 1.0;
-  cvm::real const en2_r = (cvm::real) en2;
-  cvm::real const ed2_r = (cvm::real) ed2;
   cvm::real func_no_pairlist;
 
   if (std::abs(h) < eps_l2) {
@@ -242,7 +255,7 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::switching_function(
 }
 
 
-template<int flags>
+template<int flags, int static_en, int static_ed>
 inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::compute_pair_coordnum(
   cvm::rvector const &inv_r0_vec,
   cvm::rvector const &inv_r0sq_vec,
@@ -280,7 +293,7 @@ inline COLVARS_HOST_DEVICE cvm::real colvar::coordnum::compute_pair_coordnum(
   }
 
   cvm::real dFdl2 = 0.0;
-  cvm::real F = switching_function<flags>(l2, dFdl2, en, ed, pairlist_tol);
+  cvm::real F = switching_function<flags, static_en, static_ed>(l2, dFdl2, en, ed, pairlist_tol);
 
   if ((flags & ef_gradients) && (F > 0.0)) {
     cvm::rvector const dl2dx((2.0 * inv_r0sq_vec.x) * diff.x,

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -114,6 +114,18 @@ public:
     return (n > 0) ? yy : 1.0/yy;
   }
 
+  template <int n>
+  static COLVARS_HOST_DEVICE inline real
+  positive_integer_power(real const& x) {
+    static_assert(n > 0, "n must be greater than zero in positive_integer_power.");
+    real y = 1.0;
+    #pragma unroll
+    for (int i = 0; i < n; ++i) {
+      y *= x;
+    }
+    return y;
+  }
+
   /// Reimplemented to work around MS compiler issues
   static inline real pow(real const &x, real const &y)
   {

--- a/src/colvarmodule.h
+++ b/src/colvarmodule.h
@@ -119,7 +119,6 @@ public:
   positive_integer_power(real const& x) {
     static_assert(n > 0, "n must be greater than zero in positive_integer_power.");
     real y = 1.0;
-    #pragma unroll
     for (int i = 0; i < n; ++i) {
       y *= x;
     }

--- a/src/cuda/colvarcomp_coordnums_kernel.cu
+++ b/src/cuda/colvarcomp_coordnums_kernel.cu
@@ -14,6 +14,13 @@
 
 #if defined(COLVARS_CUDA) || defined (COLVARS_HIP)
 namespace colvars_gpu {
+
+namespace{
+constexpr uint64_t join(const uint32_t hi, const uint32_t lo) {
+    return ((uint64_t)hi << 32) | lo;
+}
+}
+
 template <int static_en, int static_ed, int blockSize, int tileSize, int flags>
 __global__ void computeCoordinationNumberTwoGroupsCUDAKernel1(
   const cvm::real* __restrict pos1x,
@@ -256,38 +263,61 @@ int calc_value_coordnum_two_groups(
   };
   const unsigned int numBlocks = (numAtoms1 + default_block_size - 1) / default_block_size;
   void* kernel = nullptr;
+  // Encode en and ed in a single integer
+  const uint64_t ened = join(en, ed);
 #if defined (COLVARS_CUDA)
-#define CASE(N) case N: { switch (gpu_warp_size) { \
-    case 32: {kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1< \
-      0, 0, default_block_size, 32, N>; break;} \
-    default: return cvmodule->error("Unimplemented warp size: " + cvm::to_str(gpu_warp_size));} \
+#define CASE(N, ENED) case N: { switch (gpu_warp_size) {                                                                           \
+    case 32: {                                                                                                                     \
+      switch (ENED) {                                                                                                              \
+        case join(4, 8):  kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<4,  8, default_block_size, 32, N>;  break; \
+        case join(6, 12): kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<6, 12, default_block_size, 32, N>;  break; \
+        default:          kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<0,  0, default_block_size, 32, N>;  break; \
+      }                                                                                                                            \
+      break; }                                                                                                                     \
+    default: return cvmodule->error("Unimplemented warp size: " + cvm::to_str(gpu_warp_size), COLVARS_BUG_ERROR);}                 \
   } break
 #elif defined (COLVARS_HIP)
-#define CASE(N) case N: { switch (gpu_warp_size) { \
-    case 32: {kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1< \
-      0, 0, default_block_size, 32, N>; break;} \
-    case 64: {kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1< \
-      0, 0, default_block_size, 64, N>; break;} \
-    default: return cvmodule->error("Unimplemented warp size: " + cvm::to_str(gpu_warp_size));} \
+#define CASE(N, ENED) case N: { switch (gpu_warp_size) {                                                                            \
+    case 32: {                                                                                                                      \
+      switch (ENED) {                                                                                                               \
+        case join(4, 8):  kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<4,  8, default_block_size, 32, N>;  break;  \
+        case join(6, 12): kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<6, 12, default_block_size, 32, N>;  break;  \
+        default:          kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<0,  0, default_block_size, 32, N>;  break;  \
+      }                                                                                                                             \
+      break; }                                                                                                                      \
+    case 64: {                                                                                                                      \
+      switch (ENED) {                                                                                                               \
+        case join(4, 8):  kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<4,  8, default_block_size, 64, N>;  break;  \
+        case join(6, 12): kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<6, 12, default_block_size, 64, N>;  break;  \
+        default:          kernel = (void*)computeCoordinationNumberTwoGroupsCUDAKernel1<0,  0, default_block_size, 64, N>;  break;  \
+      }                                                                                                                             \
+      break; }                                                                                                                      \
+    default: return cvmodule->error("Unimplemented warp size: " + cvm::to_str(gpu_warp_size), COLVARS_BUG_ERROR);}                  \
   } break
 #endif
   switch (flags) {
     CASE(colvar::coordnum::ef_gradients +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_gradients +
          colvar::coordnum::ef_use_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_gradients +
          colvar::coordnum::ef_use_pairlist +
          colvar::coordnum::ef_rebuild_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
 
-    CASE(colvar::coordnum::ef_null);
+    CASE(colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_use_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_use_pairlist +
          colvar::coordnum::ef_rebuild_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     default: {
       return cvmodule->error("Unimplemented flags in calc_value_coordnum_two_groups: " +
         cvm::to_str(flags) + "\n");
@@ -968,41 +998,63 @@ int calc_value_coordnum_self_group(
     &d_tlPairListSelf, &d_tlPairList, &d_tbcount,
     &d_coordnum_tmp, &h_coordnum_out
   };
+  // Encode en and ed in a single integer
+  const uint64_t ened = join(en, ed);
   // NOTE: For CUDA, we only support 32 as a warp size, but for HIP,
   // there could be two different warp sizes (32 and 64).
 #if defined (COLVARS_CUDA)
-#define CASE(N) case N: { \
-  switch (gpu_warp_size) { \
-    case 32: kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0, 0, default_block_size, 32, N>; break;\
-    default: return cvmodule->error("Unsupported warp size in calc_value_coordnum_self_group: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);\
-  } \
+#define CASE(N, ENED) case N: { switch (gpu_warp_size) {                                                                          \
+    case 32: {                                                                                                                    \
+      switch (ENED) {                                                                                                             \
+        case join(4, 8):  kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<4,  8, default_block_size, 32, N>; break; \
+        case join(6, 12): kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<6, 12, default_block_size, 32, N>; break; \
+        default:          kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0,  0, default_block_size, 32, N>; break; \
+      }                                                                                                                           \
+      break; }                                                                                                                    \
+    default: return cvmodule->error("Unsupported warp size in: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);}        \
   } break
 #elif defined (COLVARS_HIP)
-#define CASE(N) case N: { \
-  switch (gpu_warp_size) { \
-    case 32: kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0, 0, default_block_size, 32, N>; break;\
-    case 64: kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0, 0, default_block_size, 64, N>; break;\
-    default: return cvmodule->error("Unsupported warp size in calc_value_coordnum_self_group: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);\
-  } \
+#define CASE(N, ENED) case N: { switch (gpu_warp_size) {                                                                          \
+    case 32: {                                                                                                                    \
+      switch (ENED) {                                                                                                             \
+        case join(4, 8):  kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<4,  8, default_block_size, 32, N>; break; \
+        case join(6, 12): kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<6, 12, default_block_size, 32, N>; break; \
+        default:          kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0,  0, default_block_size, 32, N>; break; \
+      }                                                                                                                           \
+      break; }                                                                                                                    \
+    case 64: {                                                                                                                    \
+      switch (ENED) {                                                                                                             \
+        case join(4, 8):  kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<4,  8, default_block_size, 64, N>; break; \
+        case join(6, 12): kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<6, 12, default_block_size, 64, N>; break; \
+        default:          kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0,  0, default_block_size, 64, N>; break; \
+      }                                                                                                                           \
+      break; }                                                                                                                    \
+    default: return cvmodule->error("Unsupported warp size in: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);}        \
   } break
 #endif
   switch (flags) {
     CASE(colvar::coordnum::ef_gradients +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_gradients +
          colvar::coordnum::ef_use_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_gradients +
          colvar::coordnum::ef_use_pairlist +
          colvar::coordnum::ef_rebuild_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
 
-    CASE(colvar::coordnum::ef_null);
+    CASE(colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_use_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     CASE(colvar::coordnum::ef_use_pairlist +
          colvar::coordnum::ef_rebuild_pairlist +
-         colvar::coordnum::ef_null);
+         colvar::coordnum::ef_null,
+         ened);
     default: {
       return cvmodule->error("Unimplemented flags in calc_value_coordnum_self_group: " +
         cvm::to_str(flags) + "\n");

--- a/src/cuda/colvarcomp_coordnums_kernel.cu
+++ b/src/cuda/colvarcomp_coordnums_kernel.cu
@@ -14,7 +14,7 @@
 
 #if defined(COLVARS_CUDA) || defined (COLVARS_HIP)
 namespace colvars_gpu {
-template <int N, int M, int blockSize, int tileSize, int flags>
+template <int static_en, int static_ed, int blockSize, int tileSize, int flags>
 __global__ void computeCoordinationNumberTwoGroupsCUDAKernel1(
   const cvm::real* __restrict pos1x,
   const cvm::real* __restrict pos1y,
@@ -123,7 +123,7 @@ __global__ void computeCoordinationNumberTwoGroupsCUDAKernel1(
           }
           cvm::real partial = 0;
           if (pairlist_elem) {
-            partial = colvar::coordnum::compute_pair_coordnum<flags>(
+            partial = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
               inv_r0_vec, inv_r0sq_vec, en, ed,
               x1, y1, z1, x2, y2, z2,
               iGrad.x, iGrad.y, iGrad.z,
@@ -300,7 +300,7 @@ int calc_value_coordnum_two_groups(
   return error_code;
 }
 
-template <int N, int M, int blockSize, int flags>
+template <int static_en, int static_ed, int blockSize, int flags>
 __global__ void computeCoordinationNumberGroupToCenterKernel(
   const cvm::real* __restrict posx,
   const cvm::real* __restrict posy,
@@ -356,7 +356,7 @@ __global__ void computeCoordinationNumberGroupToCenterKernel(
     const cvm::real y1 = posy[i];
     const cvm::real z1 = posz[i];
     if constexpr (!use_pairlist) {
-      ei += colvar::coordnum::compute_pair_coordnum<flags>(
+      ei += colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
         inv_r0_vec, inv_r0sq_vec, en, ed,
         x1, y1, z1, x2, y2, z2,
         grad_x, grad_y, grad_z,
@@ -368,7 +368,7 @@ __global__ void computeCoordinationNumberGroupToCenterKernel(
       if constexpr (!rebuild_pairlist) {
         const bool within = pairlist[i];
         if (within) {
-          ei += colvar::coordnum::compute_pair_coordnum<flags>(
+          ei += colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
             inv_r0_vec, inv_r0sq_vec, en, ed,
             x1, y1, z1, x2, y2, z2,
             grad_x, grad_y, grad_z,
@@ -378,7 +378,7 @@ __global__ void computeCoordinationNumberGroupToCenterKernel(
             pairlist_tol, pairlist_tol_l2_max, bc);
         }
       } else {
-        const auto f = colvar::coordnum::compute_pair_coordnum<flags>(
+        const auto f = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
           inv_r0_vec, inv_r0sq_vec, en, ed,
           x1, y1, z1, x2, y2, z2,
           grad_x, grad_y, grad_z,
@@ -506,7 +506,7 @@ int calc_value_coordnum_group_to_com(
   return error_code;
 }
 
-template <int N, int M, int flags>
+template <int static_en, int static_ed, int flags>
 __global__ void computeCoordinationNumberGroupTwoCOMsKernel(
   const cvm::rvector* __restrict com1,
   const cvm::rvector* __restrict com2,
@@ -549,7 +549,7 @@ __global__ void computeCoordinationNumberGroupTwoCOMsKernel(
       com2_grad_z = 0;
     }
     if constexpr (!use_pairlist) {
-      (*h_coordnum_out) = colvar::coordnum::compute_pair_coordnum<flags>(
+      (*h_coordnum_out) = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
         inv_r0_vec, inv_r0sq_vec, en, ed,
         x1, y1, z1, x2, y2, z2,
         com1_grad_x, com1_grad_y, com1_grad_z,
@@ -559,7 +559,7 @@ __global__ void computeCoordinationNumberGroupTwoCOMsKernel(
       if constexpr (!rebuild_pairlist) {
         const bool within = pairlist[i];
         if (within) {
-          (*h_coordnum_out) = colvar::coordnum::compute_pair_coordnum<flags>(
+          (*h_coordnum_out) = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
             inv_r0_vec, inv_r0sq_vec, en, ed,
             x1, y1, z1, x2, y2, z2,
             com1_grad_x, com1_grad_y, com1_grad_z,
@@ -569,7 +569,7 @@ __global__ void computeCoordinationNumberGroupTwoCOMsKernel(
           (*h_coordnum_out) = 0;
         }
       } else {
-        const auto f = colvar::coordnum::compute_pair_coordnum<flags>(
+        const auto f = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
             inv_r0_vec, inv_r0sq_vec, en, ed,
             x1, y1, z1, x2, y2, z2,
             com1_grad_x, com1_grad_y, com1_grad_z,
@@ -650,7 +650,7 @@ int calc_value_coordnum_com_to_com(
   return error_code;
 }
 
-template <int N, int M, int blockSize, int tileSize, int flags>
+template <int static_en, int static_ed, int blockSize, int tileSize, int flags>
 __global__ void computeCoordinationNumberSelfGroupCUDAKernel1(
   const cvm::real* __restrict pos1x,
   const cvm::real* __restrict pos1y,
@@ -731,7 +731,7 @@ __global__ void computeCoordinationNumberSelfGroupCUDAKernel1(
         }
         cvm::real partial = 0;
         if (pairlist_elem) {
-          partial = colvar::coordnum::compute_pair_coordnum<flags>(
+          partial = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
             inv_r0_vec, inv_r0sq_vec, en, ed,
             x1, y1, z1, x2, y2, z2,
             iGrad.x, iGrad.y, iGrad.z,
@@ -764,7 +764,7 @@ __global__ void computeCoordinationNumberSelfGroupCUDAKernel1(
           }
           cvm::real partial = 0;
           if (pairlist_elem) {
-            partial = colvar::coordnum::compute_pair_coordnum<flags>(
+            partial = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
               inv_r0_vec, inv_r0sq_vec, en, ed,
               x1, y1, z1, x2, y2, z2,
               iGrad.x, iGrad.y, iGrad.z,
@@ -841,7 +841,7 @@ __global__ void computeCoordinationNumberSelfGroupCUDAKernel1(
           }
           cvm::real partial = 0;
           if (pairlist_elem) {
-            partial = colvar::coordnum::compute_pair_coordnum<flags>(
+            partial = colvar::coordnum::compute_pair_coordnum<flags, static_en, static_ed>(
               inv_r0_vec, inv_r0sq_vec, en, ed,
               x1, y1, z1, x2, y2, z2,
               iGrad.x, iGrad.y, iGrad.z,

--- a/src/cuda/colvarcomp_coordnums_kernel.cu
+++ b/src/cuda/colvarcomp_coordnums_kernel.cu
@@ -1011,7 +1011,7 @@ int calc_value_coordnum_self_group(
         default:          kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0,  0, default_block_size, 32, N>; break; \
       }                                                                                                                           \
       break; }                                                                                                                    \
-    default: return cvmodule->error("Unsupported warp size in: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);}        \
+    default: return cvmodule->error("Unsupported warp size in calc_value_coordnum_self_group: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);}        \
   } break
 #elif defined (COLVARS_HIP)
 #define CASE(N, ENED) case N: { switch (gpu_warp_size) {                                                                          \
@@ -1029,7 +1029,7 @@ int calc_value_coordnum_self_group(
         default:          kernel = (void*)computeCoordinationNumberSelfGroupCUDAKernel1<0,  0, default_block_size, 64, N>; break; \
       }                                                                                                                           \
       break; }                                                                                                                    \
-    default: return cvmodule->error("Unsupported warp size in: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);}        \
+    default: return cvmodule->error("Unsupported warp size in calc_value_coordnum_self_group: " + cvm::to_str(gpu_warp_size) + "\n", COLVARS_BUG_ERROR);}        \
   } break
 #endif
   switch (flags) {


### PR DESCRIPTION
**This PR partially supersedes https://github.com/Colvars/colvars/pull/926 and depends on https://github.com/Colvars/colvars/pull/955.**

This PR changes the template arguments of `colvar::coordnum::switching_function` and `colvar::coordnum::compute_pair_coordnum` to accept additional `static_en` and `static_ed` as static template parameters for `en` and `ed`. If any of `static_en` and `static_ed` is zero, then the dynamic `en` and `ed` would be used. This PR also instantiates commonly used `(en, ed)` for the GPU kernels. **This PR does not include any CPU optimizations (unlike https://github.com/Colvars/colvars/pull/926).**